### PR TITLE
feat(reminder): add {template} variable to reminder context

### DIFF
--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -95,7 +95,16 @@ edges = []
 # reply_command = "tmux-a2a-postman create-draft --context-id {context_id} --to <recipient>"
 # ui_node = "messenger"            # TUI target node for watchdog alerts
 
-# Reminder message (sent periodically to nodes)
+# reminder_message:
+#   {node}      - Node name
+#   {count}     - Message count since last reminder
+#   {template}  - Node's role template (inline content, or "Role template: <path>" for
+#                 materialized nodes — agent must read the file for full content)
+#
+# NOTE: if reminder_message = "{template}" and a node has no template defined,
+#       {template} expands to "" and SendToPane is called with empty content (spurious Enter).
+#       Ensure all nodes have a template when using this pattern.
+#
 # reminder_message = ""
 
 # Common template (prepended to all node templates)

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -78,9 +78,27 @@ func (r *ReminderState) Increment(nodeName string, sessionName string, nodes map
 				}
 			}
 			if found && reminderMessage != "" {
+				// Resolve node's role template (mirrors notification.go BuildNotification)
+				// NOTE: reuses nodeConfig and hasNodeConfig declared at line 40
+				nodeTemplate := ""
+				if matPath, ok := cfg.MaterializedPaths[nodeName]; ok {
+					nodeTemplate = "Role template: " + matPath + "\n"
+				} else {
+					if hasNodeConfig {
+						nodeTemplate = nodeConfig.Template
+					}
+					if cfg.CommonTemplate != "" {
+						if nodeTemplate != "" {
+							nodeTemplate = cfg.CommonTemplate + "\n\n" + nodeTemplate
+						} else {
+							nodeTemplate = cfg.CommonTemplate
+						}
+					}
+				}
 				vars := map[string]string{
-					"node":  nodeName,
-					"count": strconv.Itoa(count),
+					"node":     nodeName,
+					"count":    strconv.Itoa(count),
+					"template": nodeTemplate,
 				}
 				timeout := time.Duration(cfg.TmuxTimeout * float64(time.Second))
 				content := template.ExpandTemplate(reminderMessage, vars, timeout)

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -1,11 +1,14 @@
 package reminder
 
 import (
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/template"
 )
 
 func TestNewReminderState(t *testing.T) {
@@ -218,6 +221,21 @@ func TestReminderPhaseTwoLookup(t *testing.T) {
 	state.mu.Unlock()
 	if count != 0 {
 		t.Errorf("Phase 2 lookup: after threshold, counter = %d, want 0", count)
+	}
+}
+
+func TestTemplateExpandTemplate(t *testing.T) {
+	vars := map[string]string{
+		"node":     "worker",
+		"count":    "5",
+		"template": "# WORKER ROLE",
+	}
+	msg := template.ExpandTemplate("{template} count:{count}", vars, 5*time.Second)
+	if strings.Contains(msg, "{template}") {
+		t.Errorf("expected {template} to be expanded, got: %s", msg)
+	}
+	if !strings.Contains(msg, "# WORKER ROLE") {
+		t.Errorf("expected template content in output, got: %s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `{template}` variable to reminder context in `Increment()` — mirrors `notification.go BuildNotification()` template resolution logic (MaterializedPaths → nodeConfig.Template → CommonTemplate cascade)
- Compact `notification_template` and `ping_template` to reduce message overhead (~55 lines → ~12 lines before content)
- Update `reminder_message` to `"{template}"` so each node receives its specific role template periodically

## Changes

### Daemon

- `internal/reminder/reminder.go`: Add `{template}` variable to `Increment()` vars map. Reuses `nodeConfig`/`hasNodeConfig` already declared at line 40 (no second map lookup).
- `internal/reminder/reminder_test.go`: Add `TestTemplateExpandTemplate` to verify `{template}` expansion.
- `internal/config/postman.default.toml`: Document `{template}` variable for `reminder_message`, including materialized-node path-reference caveat and empty-template spurious-Enter warning.

### User Config (not tracked by git)

- `~/.config/tmux-a2a-postman/postman.toml`:
  - `notification_template`: removed `{template}` header block; NEVER guardrail kept; mv path made unambiguous
  - `ping_template`: compressed reply; NEVER guardrail added; mv path made unambiguous
  - `reminder_message = "{template}"` (was `$(cat ~/.agents/AGENTS.md)`)
  - `reminder_interval_seconds` renamed to `reminder_interval_messages` (deprecated field)

## Test

```
ok  github.com/i9wa4/tmux-a2a-postman/internal/reminder  0.018s
```

Build: clean.

## Reviews

**Critic:** APPROVED — "Changes 3 and 4: APPROVED. All four issues from the previous review are addressed and verified against the actual files. The implementation is correct and consistent."

**Boss:** Daemon code reviewed and approved independently. Commit `6b1883b` verified: 3 files, +48/-3 lines.

**Guardian exception:** Guardian was non-responsive after multiple inbox delivery attempts and a manual content feed directly to the pane (~35 minutes total). User directed forward movement ("Move. Do not wait indefinitely."). Same behavioral gap documented in PR #142.
