### PR TITLE
fix(message): tighten validNodeNameRe to bounded form ^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$ (#299)

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -20,7 +20,8 @@ import (
 
 // validNodeNameRe validates from/to fields in message filenames (#174).
 // Allows alphanumeric characters and hyphens, must start with alphanumeric.
-var validNodeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+// Enforces a 64-char cap (1 required + 0-63 trailing) to match the binding registry loader (#299).
+var validNodeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
 
 // Dead-letter reason strings used in sender notifications and TUI events (Issue #161).
 const (

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -39,6 +39,14 @@ func TestParseMessageFilename(t *testing.T) {
 			wantFrom: "node-alpha",
 			wantTo:   "node-beta",
 		},
+		{
+			// 64-char from field: "a" + 63 "a" chars = 64 total (#299)
+			name:     "64-char node name (boundary accept)",
+			filename: "12345-from-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-to-b.md",
+			wantTS:   "12345",
+			wantFrom: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			wantTo:   "b",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +79,8 @@ func TestParseMessageFilename_Invalid(t *testing.T) {
 		{"empty from", "20260201-from--to-b.md"},
 		{"empty to", "20260201-from-a-to-.md"},
 		{"empty timestamp", "-from-a-to-b.md"},
+		// 65-char from field: "a" + 64 "a" chars = 65 total, exceeds 64-char cap (#299)
+		{"65-char node name (boundary reject)", "12345-from-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-to-b.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #299

`validNodeNameRe` in `internal/message/message.go` was unbounded (`^[a-zA-Z0-9][a-zA-Z0-9-]*$`). The binding registry loader (B-2) enforces a 64-character cap on `node_name` and `channel_id`. Without this fix, a 65-char node name that passes registry validation would silently dead-letter all routed messages at the delivery path's regex check. Both checks now enforce the same bound.

## Changes

### M1 [Go] `validNodeNameRe` — bounded form

`internal/message/message.go` line 24: change regex quantifier from `*` (unbounded) to `{0,63}` (max 63 trailing chars after the required leading alphanumeric), giving a 64-char total cap. Updated comment to reference #299 and the 64-char cap.

### M2 [Tests] Boundary test cases

`internal/message/message_test.go`:

- `TestParseMessageFilename/64-char_node_name_(boundary_accept)` — 64-char name accepted
- `TestParseMessageFilename_Invalid/65-char_node_name_(boundary_reject)` — 65-char name rejected

## Verification

```
$ grep -n 'validNodeNameRe' internal/message/message.go
24: var validNodeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)

$ go test ./internal/message/...
ok  	github.com/i9wa4/tmux-a2a-postman/internal/message

$ nix flake check
all checks passed

$ nix build
BUILD OK
```