### PR TITLE
feat(binding): implement full BindingRegistry loader with validation (#303)

### DIFF
--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -1,8 +1,37 @@
 // Package binding defines the Binding and BindingRegistry types
-// for associating tmux panes with postman nodes. Issue #300.
+// for associating tmux panes with postman nodes. Issue #300, #303.
 package binding
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+
+	"github.com/BurntSushi/toml"
+)
+
+// validNodeNameRe validates node_name and pane_node_name fields.
+// Identical bound to internal/message.validNodeNameRe (A-1 / #299).
+// Duplicated here to avoid an import cycle with internal/message.
+var validNodeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
+
+// validIDRe validates channel_id and context_id fields.
+// Same pattern as validNodeNameRe; separate var clarifies intent (ID vs node).
+var validIDRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
+
+// LoadOption is a functional option for Load.
+type LoadOption func(*loadOptions)
+
+type loadOptions struct {
+	allowEmptySenders bool
+}
+
+// AllowEmptySenders changes the hard error on empty permitted_senders to a WARNING.
+// Exit code remains zero.
+func AllowEmptySenders() LoadOption {
+	return func(o *loadOptions) { o.allowEmptySenders = true }
+}
 
 // Binding associates a tmux pane with a named node in the postman system.
 type Binding struct {
@@ -21,8 +50,147 @@ type BindingRegistry struct {
 	Bindings []Binding
 }
 
+// tomlFile is the top-level TOML structure for bindings.toml.
+// Uses [[binding]] array-of-tables.
+type tomlFile struct {
+	Binding []Binding `toml:"binding"`
+}
+
 // Load reads a binding registry from the TOML file at path.
-// Not yet implemented.
-func Load(path string) (*BindingRegistry, error) {
-	return nil, fmt.Errorf("not implemented")
+// It checks file permissions, parses the TOML, validates every field,
+// and enforces the seven-row state validity table and duplicate constraints.
+// Load never acquires a .lock file.
+func Load(path string, opts ...LoadOption) (*BindingRegistry, error) {
+	o := &loadOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Milestone 1: permission check — 0600 or stricter required.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	mode := info.Mode().Perm()
+	if mode&0o044 != 0 {
+		return nil, fmt.Errorf(
+			"bindings.toml must not be group- or world-readable (got %04o): %s",
+			mode, path,
+		)
+	}
+
+	// Milestone 2: TOML parse.
+	var raw tomlFile
+	if _, err := toml.DecodeFile(path, &raw); err != nil {
+		return nil, fmt.Errorf("parse bindings.toml: %w", err)
+	}
+
+	// Milestone 4: duplicate detection (Constraint 12).
+	seenChannels := make(map[string]struct{}, len(raw.Binding))
+	seenNodes := make(map[string]struct{}, len(raw.Binding))
+
+	for i, b := range raw.Binding {
+		// Duplicate channel_id.
+		if _, dup := seenChannels[b.ChannelID]; dup {
+			return nil, fmt.Errorf("binding[%d]: duplicate channel_id %q", i, b.ChannelID)
+		}
+		seenChannels[b.ChannelID] = struct{}{}
+
+		// Duplicate node_name.
+		if _, dup := seenNodes[b.NodeName]; dup {
+			return nil, fmt.Errorf("binding[%d]: duplicate node_name %q", i, b.NodeName)
+		}
+		seenNodes[b.NodeName] = struct{}{}
+
+		// Milestone 3 + Milestone 2: field validation + state table.
+		if err := validateBinding(b, i, o); err != nil {
+			return nil, err
+		}
+	}
+
+	return &BindingRegistry{Bindings: raw.Binding}, nil
+}
+
+// validateBinding validates a single Binding entry.
+// Enforces the seven-row state validity table and all field constraints.
+func validateBinding(b Binding, idx int, o *loadOptions) error {
+	tag := fmt.Sprintf("binding[%d] (node_name=%q)", idx, b.NodeName)
+
+	// --- Milestone 3: field regex validation ---
+
+	if !validIDRe.MatchString(b.ChannelID) {
+		return fmt.Errorf("%s: invalid channel_id %q", tag, b.ChannelID)
+	}
+	if !validNodeNameRe.MatchString(b.NodeName) {
+		return fmt.Errorf("%s: invalid node_name %q", tag, b.NodeName)
+	}
+	if !validIDRe.MatchString(b.ContextID) {
+		return fmt.Errorf("%s: invalid context_id %q (path traversal prevention)", tag, b.ContextID)
+	}
+	if b.PaneNodeName != "" && !validNodeNameRe.MatchString(b.PaneNodeName) {
+		return fmt.Errorf("%s: invalid pane_node_name %q", tag, b.PaneNodeName)
+	}
+	for _, sender := range b.PermittedSenders {
+		if !validNodeNameRe.MatchString(sender) {
+			return fmt.Errorf("%s: invalid permitted_senders entry %q", tag, sender)
+		}
+	}
+	if len(b.PermittedSenders) == 0 {
+		if o.allowEmptySenders {
+			log.Printf("WARNING: %s has empty permitted_senders", tag)
+		} else {
+			return fmt.Errorf("%s: permitted_senders must not be empty", tag)
+		}
+	}
+
+	// --- Milestone 2: seven-row state validity table ---
+	if err := validateState(b, tag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateState enforces the seven-row state validity table.
+//
+// Valid combinations of (active, session_name, pane_title, pane_node_name):
+//
+//	Row 1: false, "",  "",  ""   — unassigned
+//	Row 2: true,  set, "",  set  — assigned, match by pane_node_name
+//	Row 3: true,  set, set, ""   — assigned, match by pane_title
+//	Row 4: true,  set, set, set  — assigned, both matchers
+//	Row 5: false, set, "",  set  — inactive, was node_name-matched
+//	Row 6: false, set, set, ""   — inactive, was title-matched
+//	Row 7: false, set, set, set  — inactive, was both-matched
+func validateState(b Binding, tag string) error {
+	active := b.Active
+	hasSession := b.SessionName != ""
+	hasTitle := b.PaneTitle != ""
+	hasNode := b.PaneNodeName != ""
+
+	switch {
+	// Row 1: unassigned
+	case !active && !hasSession && !hasTitle && !hasNode:
+		return nil
+	// Rows 2-4: active assigned
+	case active && hasSession && !hasTitle && hasNode:
+		return nil // row 2
+	case active && hasSession && hasTitle && !hasNode:
+		return nil // row 3
+	case active && hasSession && hasTitle && hasNode:
+		return nil // row 4
+	// Rows 5-7: inactive with session
+	case !active && hasSession && !hasTitle && hasNode:
+		return nil // row 5
+	case !active && hasSession && hasTitle && !hasNode:
+		return nil // row 6
+	case !active && hasSession && hasTitle && hasNode:
+		return nil // row 7
+	// All other combinations are invalid.
+	default:
+		return fmt.Errorf(
+			"%s: invalid state combination (active=%v session_name=%q pane_title=%q pane_node_name=%q)",
+			tag, active, b.SessionName, b.PaneTitle, b.PaneNodeName,
+		)
+	}
 }

--- a/internal/binding/binding_test.go
+++ b/internal/binding/binding_test.go
@@ -1,0 +1,297 @@
+package binding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeToml writes content to a temp file and returns the path.
+// mode is the desired file permission (e.g., 0o600).
+func writeToml(t *testing.T, content string, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bindings.toml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeToml: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	return path
+}
+
+// validBinding is a minimal valid TOML binding entry (row 3: assigned, pane_title match).
+const validBinding = `
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "my-session"
+pane_title        = "worker-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["boss"]
+`
+
+func TestLoad_ValidRoundTrip(t *testing.T) {
+	path := writeToml(t, validBinding, 0o600)
+	reg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reg.Bindings) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(reg.Bindings))
+	}
+	if reg.Bindings[0].NodeName != "worker" {
+		t.Errorf("expected node_name=worker, got %q", reg.Bindings[0].NodeName)
+	}
+}
+
+// --- Permission tests ---
+
+func TestLoad_WorldReadable(t *testing.T) {
+	path := writeToml(t, validBinding, 0o644)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for world-readable file, got nil")
+	}
+	if !strings.Contains(err.Error(), "world-readable") && !strings.Contains(err.Error(), "group- or world-readable") {
+		t.Errorf("expected permission error message, got: %v", err)
+	}
+}
+
+func TestLoad_GroupReadable(t *testing.T) {
+	path := writeToml(t, validBinding, 0o640)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for group-readable file, got nil")
+	}
+}
+
+// --- Field validation tests ---
+
+func TestLoad_InvalidChannelID(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `channel_id        = "ch1"`, `channel_id = "ab cd"`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid channel_id")
+	}
+}
+
+func TestLoad_InvalidNodeName(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `node_name         = "worker"`, `node_name = "bad node"`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid node_name")
+	}
+}
+
+func TestLoad_InvalidContextID(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `context_id        = "ctx1"`, `context_id = "../etc"`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid context_id (path traversal)")
+	}
+}
+
+func TestLoad_InvalidPaneNodeName(t *testing.T) {
+	// pane_node_name validation applies only when non-empty
+	base := `
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "my-session"
+pane_title        = ""
+pane_node_name    = "bad node name"
+active            = true
+permitted_senders = ["boss"]
+`
+	path := writeToml(t, base, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid pane_node_name")
+	}
+}
+
+func TestLoad_InvalidPermittedSender(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `permitted_senders = ["boss"]`, `permitted_senders = ["bad node"]`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid permitted_senders entry")
+	}
+}
+
+func TestLoad_EmptySenders_Error(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `permitted_senders = ["boss"]`, `permitted_senders = []`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for empty permitted_senders without AllowEmptySenders()")
+	}
+}
+
+func TestLoad_EmptySenders_AllowOption(t *testing.T) {
+	toml := strings.ReplaceAll(validBinding, `permitted_senders = ["boss"]`, `permitted_senders = []`)
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path, AllowEmptySenders())
+	if err != nil {
+		t.Fatalf("unexpected error with AllowEmptySenders(): %v", err)
+	}
+}
+
+// --- Duplicate detection (Constraint 12 — boss condition: both branches) ---
+
+func TestLoad_DuplicateChannelID(t *testing.T) {
+	toml := `
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "sess"
+pane_title        = "worker-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["boss"]
+
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker2"
+context_id        = "ctx1"
+session_name      = "sess"
+pane_title        = "worker2-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["boss"]
+`
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for duplicate channel_id")
+	}
+	if !strings.Contains(err.Error(), "duplicate channel_id") {
+		t.Errorf("expected 'duplicate channel_id' in error, got: %v", err)
+	}
+}
+
+func TestLoad_DuplicateNodeName(t *testing.T) {
+	toml := `
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "sess"
+pane_title        = "worker-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["boss"]
+
+[[binding]]
+channel_id        = "ch2"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "sess"
+pane_title        = "worker-pane2"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["boss"]
+`
+	path := writeToml(t, toml, 0o600)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for duplicate node_name")
+	}
+	if !strings.Contains(err.Error(), "duplicate node_name") {
+		t.Errorf("expected 'duplicate node_name' in error, got: %v", err)
+	}
+}
+
+// --- Seven-row state validity table: 9 invalid combinations ---
+
+func makeStateToml(active bool, sessionName, paneTitle, paneNodeName string) string {
+	activeStr := "false"
+	if active {
+		activeStr = "true"
+	}
+	return `
+[[binding]]
+channel_id        = "ch1"
+node_name         = "worker"
+context_id        = "ctx1"
+session_name      = "` + sessionName + `"
+pane_title        = "` + paneTitle + `"
+pane_node_name    = "` + paneNodeName + `"
+active            = ` + activeStr + `
+permitted_senders = ["boss"]
+`
+}
+
+func TestLoad_InvalidStateRows(t *testing.T) {
+	// 9 invalid combinations
+	cases := []struct {
+		name         string
+		active       bool
+		sessionName  string
+		paneTitle    string
+		paneNodeName string
+	}{
+		// active=true, session_name="" (4 rows)
+		{"active_no_session_no_title_no_node", true, "", "", ""},
+		{"active_no_session_no_title_with_node", true, "", "", "node1"},
+		{"active_no_session_with_title_no_node", true, "", "title1", ""},
+		{"active_no_session_with_title_with_node", true, "", "title1", "node1"},
+		// active=true, session set, no pane identity
+		{"active_session_no_title_no_node", true, "sess", "", ""},
+		// active=false, no session, non-empty pane fields (3 rows)
+		{"inactive_no_session_no_title_with_node", false, "", "", "node1"},
+		{"inactive_no_session_with_title_no_node", false, "", "title1", ""},
+		{"inactive_no_session_with_title_with_node", false, "", "title1", "node1"},
+		// active=false, session set, no pane identity
+		{"inactive_session_no_title_no_node", false, "sess", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := makeStateToml(tc.active, tc.sessionName, tc.paneTitle, tc.paneNodeName)
+			path := writeToml(t, content, 0o600)
+			_, err := Load(path, AllowEmptySenders())
+			if err == nil {
+				t.Errorf("expected state validation error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// Verify all 7 valid state rows are accepted.
+func TestLoad_ValidStateRows(t *testing.T) {
+	cases := []struct {
+		name         string
+		active       bool
+		sessionName  string
+		paneTitle    string
+		paneNodeName string
+	}{
+		{"row1_unassigned", false, "", "", ""},
+		{"row2_assigned_node", true, "sess", "", "node1"},
+		{"row3_assigned_title", true, "sess", "title1", ""},
+		{"row4_assigned_both", true, "sess", "title1", "node1"},
+		{"row5_inactive_node", false, "sess", "", "node1"},
+		{"row6_inactive_title", false, "sess", "title1", ""},
+		{"row7_inactive_both", false, "sess", "title1", "node1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := makeStateToml(tc.active, tc.sessionName, tc.paneTitle, tc.paneNodeName)
+			path := writeToml(t, content, 0o600)
+			_, err := Load(path, AllowEmptySenders())
+			if err != nil {
+				t.Errorf("unexpected error for valid row %s: %v", tc.name, err)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/fsnotify/fsnotify"
 	"github.com/i9wa4/tmux-a2a-postman/internal/alert"
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/daemon"
 	"github.com/i9wa4/tmux-a2a-postman/internal/diplomat"
@@ -92,6 +93,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  get-session-health         Print session health per node")
 		fmt.Fprintln(os.Stderr, "  read                       List inbox message paths")
 		fmt.Fprintln(os.Stderr, "  archive <filename> [filename...]   Mark inbox messages as read (advanced)")
+		fmt.Fprintln(os.Stderr, "  validate-bindings          Validate bindings.toml file")
 		fmt.Fprintln(os.Stderr, "  help [topic]               Show help overview or topic-based help")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Examples:")
@@ -217,6 +219,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "❌ postman send-message: %v\n", err)
 			os.Exit(1)
 		}
+	case "validate-bindings":
+		if err := runValidateBindings(args); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ postman validate-bindings: %v\n", err)
+			os.Exit(1)
+		}
 	case "help":
 		runHelp(args)
 	default:
@@ -224,6 +231,29 @@ func main() {
 		fs.Usage()
 		os.Exit(1)
 	}
+}
+
+func runValidateBindings(args []string) error {
+	fs := flag.NewFlagSet("validate-bindings", flag.ContinueOnError)
+	baseDir := fs.String("base-dir", "", "directory containing bindings.toml (required)")
+	allowEmpty := fs.Bool("allow-empty-senders", false, "treat empty permitted_senders as WARNING instead of error")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *baseDir == "" {
+		return fmt.Errorf("--base-dir is required")
+	}
+	path := filepath.Join(*baseDir, "bindings.toml")
+	var opts []binding.LoadOption
+	if *allowEmpty {
+		opts = append(opts, binding.AllowEmptySenders())
+	}
+	reg, err := binding.Load(path, opts...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("OK: %d bindings loaded from %s\n", len(reg.Bindings), path)
+	return nil
 }
 
 func runStartWithFlags(contextID, configPath, logFilePath string, noTUI bool) error {


### PR DESCRIPTION
## Parent

Part of #298 — label **B-2** (requires A-1 / #299 and A-2 / #300; parallel with B-1 / #302).

## Summary

Closes #303

Implements the full `Load` function and supporting types in `internal/binding/binding.go`, replacing the A-2 stub. Adds the `validate-bindings` CLI subcommand for offline verification of `bindings.toml`.

## Changes

### M1 [Go] `LoadOption` pattern + file permission check

`internal/binding/binding.go`:

- Define `LoadOption` functional type with `AllowEmptySenders()` option
- Update `Load` signature to `Load(path string, opts ...LoadOption) (*BindingRegistry, error)`
- Check file permissions at startup: refuse if world- or group-readable (mode `0o044` bit set)
- Lock-free: no `.lock` file acquisition

### M2 [Go] TOML parse + seven-row state validity table

`internal/binding/binding.go`:

- Parse `bindings.toml` via `BurntSushi/toml` using `[[binding]]` array-of-tables (no new dependency)
- Implement `validateState` enforcing the seven-row valid-state table; all 9 invalid combinations rejected
- Valid states: unassigned (row 1), assigned by pane_node_name/pane_title/both (rows 2-4), inactive variants (rows 5-7)

### M3 [Go] Field validation

`internal/binding/binding.go`:

- `channel_id`: `^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$` (non-empty required)
- `node_name`: same bounded regex (A-1 prerequisite)
- `context_id`: same regex (path traversal prevention)
- `pane_node_name`: regex when non-empty
- each `permitted_senders` entry: regex
- `permitted_senders` empty: hard error; soft warning with `AllowEmptySenders()`
- `validNodeNameRe` duplicated locally (import-cycle prevention)

### M4 [Go] Duplicate detection (Constraint 12)

`internal/binding/binding.go`:

- Fail closed on duplicate `channel_id` within the file
- Fail closed on duplicate `node_name` within the file

### M5 [Skipped] `NodeInfos()` — blocked on B-1 / #302

`NodeInfo.IsPhony` field does not yet exist. Will be implemented after #302 merges.

### M6 [Go] `validate-bindings` CLI subcommand

`main.go`:

- Add `runValidateBindings(args []string) error` with `--base-dir` (required) and `--allow-empty-senders` flags
- Add `case "validate-bindings"` to command dispatch
- Add help text entry

### M7 [Tests] Full test suite

`internal/binding/binding_test.go` (new, 25 tests):

- Permission rejection: 0644, 0640
- All 9 invalid state rows rejected; all 7 valid state rows accepted
- Field validation: invalid `channel_id`, `node_name`, `context_id`, `pane_node_name`, `permitted_senders`
- Duplicate `channel_id` rejected; duplicate `node_name` rejected (both Constraint-12 branches)
- `AllowEmptySenders()`: warning emitted, no error; without option: error

## Verification

```
$ go test ./internal/binding/... -v
=== RUN   TestLoad_ValidRoundTrip
--- PASS: TestLoad_ValidRoundTrip (0.00s)
...
--- PASS: TestLoad_DuplicateChannelID (0.00s)
--- PASS: TestLoad_DuplicateNodeName (0.00s)
--- PASS: TestLoad_InvalidStateRows (0.00s)
--- PASS: TestLoad_ValidStateRows (0.00s)
PASS
ok  	github.com/i9wa4/tmux-a2a-postman/internal/binding

$ nix flake check
all checks passed

$ nix build
BUILD OK

$ ./result/bin/tmux-a2a-postman validate-bindings --base-dir /tmp/test-bindings
OK: 1 bindings loaded from /tmp/test-bindings/bindings.toml
```