### PR TITLE
feat(message): implement DeliverToPhonyNode handler (#305)

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -1,7 +1,9 @@
 package message
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
@@ -44,6 +47,11 @@ const (
 	dlSuffixForeignSession   = "-dl-foreign-session"
 )
 
+const (
+	phonyDeadLetterReasonRoutingDenied  = "routing_denied"
+	phonyDeadLetterReasonChannelUnbound = "channel_unbound"
+)
+
 // deadLetterDst builds the dead-letter destination path with reason suffix.
 // Transforms "msg.md" → "msg-dl-{reason}.md" in dead-letter/ directory.
 func deadLetterDst(sessionDir, filename, suffix string) string {
@@ -75,6 +83,15 @@ type MessageInfo struct {
 	To          string
 	SessionHash string // Optional 4-char hex hash extracted from filename (#198)
 	Filename    string // Original filename (set by ScanInboxMessages)
+}
+
+// Message carries the payload and metadata for phony-node delivery (#305).
+type Message struct {
+	Body           string
+	MessageID      string
+	SenderID       string
+	IdempotencyKey string
+	OriginalAt     time.Time
 }
 
 // SessionHash returns a 4-character hex hash of the tmux session name (#198).
@@ -596,6 +613,116 @@ func DrainStalePost(sessionDir string, ttlSeconds float64) int {
 		}
 	}
 	return count
+}
+
+// generatePhonyFilename produces a dead-letter/inbox filename from the current
+// time and 2 CSPRNG bytes. Format: YYYYMMDDTHHMMSS-<4hex>.json.
+// MUST NOT derive from channel_id, sender_id, node_name, or message body (#305).
+func generatePhonyFilename() (string, error) {
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	ts := time.Now().Format("20060102T150405")
+	return fmt.Sprintf("%s-%04x.json", ts, b), nil
+}
+
+// phonyDeadLetterRecord is the JSON schema v1 for phony-node dead-letters (#305).
+type phonyDeadLetterRecord struct {
+	SchemaVersion  int    `json:"schema_version"`
+	Reason         string `json:"reason"`
+	Direction      string `json:"direction"`
+	ChannelID      string `json:"channel_id"`
+	NodeName       string `json:"node_name"`
+	Body           string `json:"body"`
+	WrittenAt      string `json:"written_at"`
+	OriginalAt     string `json:"original_at"`
+	MessageID      string `json:"message_id"`
+	SenderID       string `json:"sender_id"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// writePhonyDeadLetter writes a JSON dead-letter record to the phony node's
+// dead-letter directory. File mode 0600, directory mode 0700 (#305).
+func writePhonyDeadLetter(baseDir, contextID, nodeName, channelID, reason string, msg Message) error {
+	dir := filepath.Join(baseDir, contextID, "phony", nodeName, "dead-letter")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating phony dead-letter dir: %w", err)
+	}
+	filename, err := generatePhonyFilename()
+	if err != nil {
+		return fmt.Errorf("generating phony dead-letter filename: %w", err)
+	}
+	rec := phonyDeadLetterRecord{
+		SchemaVersion:  1,
+		Reason:         reason,
+		Direction:      "inbound",
+		ChannelID:      channelID,
+		NodeName:       nodeName,
+		Body:           msg.Body,
+		WrittenAt:      time.Now().Format(time.RFC3339),
+		OriginalAt:     msg.OriginalAt.Format(time.RFC3339),
+		MessageID:      msg.MessageID,
+		SenderID:       msg.SenderID,
+		IdempotencyKey: msg.IdempotencyKey,
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshaling phony dead-letter: %w", err)
+	}
+	return os.WriteFile(filepath.Join(dir, filename), data, 0o600)
+}
+
+// DeliverToPhonyNode delivers an outbound message from a session pane to a phony
+// node inbox at <baseDir>/<contextID>/phony/<nodeName>/inbox/.
+// Routing rules (DEFAULT DENY):
+//   - Binding absent for nodeName: dead-letter routing_denied
+//   - Binding active=false: dead-letter channel_unbound
+//   - sender not in permitted_senders (including empty list): dead-letter routing_denied
+//
+// On success, msg.Body is written as a new file in the inbox directory.
+// Dead-letter filenames are generated from timestamp + CSPRNG; they MUST NOT
+// derive from channel_id, sender_id, node_name, or message body (#305).
+func DeliverToPhonyNode(baseDir, contextID, nodeName, sender string, registry *binding.BindingRegistry, msg Message) error {
+	// 1. Find binding by node name (DEFAULT DENY: absent = routing_denied)
+	var found *binding.Binding
+	for i := range registry.Bindings {
+		if registry.Bindings[i].NodeName == nodeName {
+			found = &registry.Bindings[i]
+			break
+		}
+	}
+	if found == nil {
+		return writePhonyDeadLetter(baseDir, contextID, nodeName, "", phonyDeadLetterReasonRoutingDenied, msg)
+	}
+
+	// 2. Active check (channel_unbound if inactive)
+	if !found.Active {
+		return writePhonyDeadLetter(baseDir, contextID, nodeName, found.ChannelID, phonyDeadLetterReasonChannelUnbound, msg)
+	}
+
+	// 3. permitted_senders check (DEFAULT DENY: empty list = deny all)
+	allowed := false
+	for _, s := range found.PermittedSenders {
+		if s == sender {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return writePhonyDeadLetter(baseDir, contextID, nodeName, found.ChannelID, phonyDeadLetterReasonRoutingDenied, msg)
+	}
+
+	// 4. Deliver to phony inbox
+	inboxDir := filepath.Join(baseDir, contextID, "phony", nodeName, "inbox")
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		return fmt.Errorf("creating phony inbox: %w", err)
+	}
+	filename, err := generatePhonyFilename()
+	if err != nil {
+		return fmt.Errorf("generating phony inbox filename: %w", err)
+	}
+	return os.WriteFile(filepath.Join(inboxDir, filename), []byte(msg.Body), 0o600)
 }
 
 // ScanInboxMessages scans the inbox directory and returns a list of MessageInfo.

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1,10 +1,13 @@
 package message
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
@@ -617,5 +620,179 @@ func TestDeliverMessage_ForeignSession(t *testing.T) {
 	deadPath := filepath.Join(senderDir, "dead-letter", "20260201-040000-from-postman-to-bob-dl-foreign-session.md")
 	if _, err := os.Stat(deadPath); err != nil {
 		t.Errorf("message not dead-lettered with dlSuffixForeignSession: %v", err)
+	}
+}
+
+// helper: build a minimal BindingRegistry with one active binding for nodeName.
+func makeRegistry(nodeName string, active bool, permittedSenders []string) *binding.BindingRegistry {
+	return &binding.BindingRegistry{
+		Bindings: []binding.Binding{
+			{
+				ChannelID:        "chan-01",
+				NodeName:         nodeName,
+				ContextID:        "ctx-01",
+				Active:           active,
+				PermittedSenders: permittedSenders,
+			},
+		},
+	}
+}
+
+func TestDeliverToPhonyNode_Success(t *testing.T) {
+	baseDir := t.TempDir()
+	reg := makeRegistry("worker", true, []string{"orchestrator"})
+	msg := Message{Body: "hello phony", MessageID: "msg-1", SenderID: "orchestrator"}
+
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("DeliverToPhonyNode failed: %v", err)
+	}
+
+	inboxDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "inbox")
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		t.Fatalf("inbox dir missing: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 inbox file, got %d", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(inboxDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("reading inbox file: %v", err)
+	}
+	if string(data) != msg.Body {
+		t.Errorf("inbox body: got %q, want %q", string(data), msg.Body)
+	}
+}
+
+func TestDeliverToPhonyNode_RoutingDenied(t *testing.T) {
+	baseDir := t.TempDir()
+	reg := makeRegistry("worker", true, []string{"orchestrator"})
+	msg := Message{Body: "unauthorized", SenderID: "intruder"}
+
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "intruder", reg, msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// dead-letter must exist
+	dlDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 dead-letter file, dir err=%v entries=%d", err, len(entries))
+	}
+	// inbox must be empty
+	inboxDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "inbox")
+	if _, err := os.Stat(inboxDir); !os.IsNotExist(err) {
+		t.Error("inbox should not exist when routing is denied")
+	}
+	// verify JSON reason
+	data, _ := os.ReadFile(filepath.Join(dlDir, entries[0].Name()))
+	var rec phonyDeadLetterRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal dead-letter: %v", err)
+	}
+	if rec.Reason != "routing_denied" {
+		t.Errorf("reason: got %q, want %q", rec.Reason, "routing_denied")
+	}
+	if rec.SchemaVersion != 1 {
+		t.Errorf("schema_version: got %d, want 1", rec.SchemaVersion)
+	}
+}
+
+func TestDeliverToPhonyNode_DefaultDeny_AbsentKey(t *testing.T) {
+	baseDir := t.TempDir()
+	// Registry has no binding for "worker"
+	reg := &binding.BindingRegistry{Bindings: []binding.Binding{}}
+	msg := Message{Body: "hello", SenderID: "orchestrator"}
+
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dlDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 dead-letter, got err=%v n=%d", err, len(entries))
+	}
+	data, _ := os.ReadFile(filepath.Join(dlDir, entries[0].Name()))
+	var rec phonyDeadLetterRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec.Reason != "routing_denied" {
+		t.Errorf("reason: got %q, want routing_denied", rec.Reason)
+	}
+}
+
+func TestDeliverToPhonyNode_DefaultDeny_EmptyList(t *testing.T) {
+	baseDir := t.TempDir()
+	reg := makeRegistry("worker", true, []string{}) // empty permitted_senders
+	msg := Message{Body: "hello", SenderID: "orchestrator"}
+
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dlDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 dead-letter, got err=%v n=%d", err, len(entries))
+	}
+	data, _ := os.ReadFile(filepath.Join(dlDir, entries[0].Name()))
+	var rec phonyDeadLetterRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec.Reason != "routing_denied" {
+		t.Errorf("reason: got %q, want routing_denied", rec.Reason)
+	}
+}
+
+func TestDeliverToPhonyNode_ChannelUnbound(t *testing.T) {
+	baseDir := t.TempDir()
+	reg := makeRegistry("worker", false, []string{"orchestrator"}) // active=false
+	msg := Message{Body: "hello", SenderID: "orchestrator"}
+
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dlDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 dead-letter, got err=%v n=%d", err, len(entries))
+	}
+	data, _ := os.ReadFile(filepath.Join(dlDir, entries[0].Name()))
+	var rec phonyDeadLetterRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec.Reason != "channel_unbound" {
+		t.Errorf("reason: got %q, want channel_unbound", rec.Reason)
+	}
+}
+
+func TestDeliverToPhonyNode_FilenameInvariant(t *testing.T) {
+	// sender_id with path traversal chars; filename must not contain those bytes
+	baseDir := t.TempDir()
+	reg := makeRegistry("worker", true, []string{"orchestrator"})
+	// Try to inject "/" and ".." via sender_id and channel_id (via body)
+	msg := Message{
+		Body:      "../../../etc/passwd",
+		MessageID: "msg/../traversal",
+		SenderID:  "orchestrator/../evil",
+	}
+	// routing will pass (sender param is "orchestrator")
+	if err := DeliverToPhonyNode(baseDir, "ctx-01", "worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inboxDir := filepath.Join(baseDir, "ctx-01", "phony", "worker", "inbox")
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 inbox file, err=%v n=%d", err, len(entries))
+	}
+	name := entries[0].Name()
+	if strings.Contains(name, "/") || strings.Contains(name, "..") || strings.Contains(name, "evil") || strings.Contains(name, "passwd") {
+		t.Errorf("filename contains unsafe bytes: %q", name)
 	}
 }


### PR DESCRIPTION
## Parent

Part of #298 — label **C-1** (requires B-2 / #303; parallel with C-2).

## Summary

Closes #305

Implements `DeliverToPhonyNode` in `internal/message/message.go` — the handler that delivers outbound messages from session panes to phony-node inboxes with DEFAULT DENY routing and structured JSON dead-lettering on permission failures.

## Changes

### M1 [Go] `Message` struct

`internal/message/message.go`:

- Define exported `Message` struct with `Body`, `MessageID`, `SenderID`, `IdempotencyKey`, `OriginalAt` fields
- Used as the payload carrier for phony-node delivery

### M2 [Go] `DeliverToPhonyNode` + helpers

`internal/message/message.go`:

- Add imports: `crypto/rand`, `encoding/json`, `internal/binding`
- Add dead-letter reason constants: `phonyDeadLetterReasonRoutingDenied`, `phonyDeadLetterReasonChannelUnbound`
- Add `generatePhonyFilename()`: CSPRNG-based filename (timestamp + 2 random bytes as 4hex); filename MUST NOT derive from channel_id, sender_id, node_name, or message body
- Add `phonyDeadLetterRecord` unexported struct: JSON schema v1, fields include schema_version, reason, direction, channel_id, node_name, body, written_at, original_at, message_id, sender_id, idempotency_key
- Add `writePhonyDeadLetter()`: writes JSON record to `<baseDir>/<contextID>/phony/<nodeName>/dead-letter/`; mode 0600/0700
- Add `DeliverToPhonyNode()`: routing check order — binding absent → routing_denied; active=false → channel_unbound; sender not in permitted_senders (including empty list) → routing_denied; on success writes msg.Body to `<baseDir>/<contextID>/phony/<nodeName>/inbox/`

### M3 [Tests] 6 new tests

`internal/message/message_test.go`:

- `TestDeliverToPhonyNode_Success`: happy path; inbox file exists, content == msg.Body
- `TestDeliverToPhonyNode_RoutingDenied`: unauthorized sender → dead-letter routing_denied; inbox absent
- `TestDeliverToPhonyNode_DefaultDeny_AbsentKey`: no binding for nodeName → dead-letter routing_denied
- `TestDeliverToPhonyNode_DefaultDeny_EmptyList`: empty permitted_senders → dead-letter routing_denied
- `TestDeliverToPhonyNode_ChannelUnbound`: active=false → dead-letter channel_unbound
- `TestDeliverToPhonyNode_FilenameInvariant`: path-traversal chars in msg fields do not appear in generated filename

## Verification

```
$ go test -count=1 ./internal/message/...
ok  	github.com/i9wa4/tmux-a2a-postman/internal/message	0.342s

$ nix flake check
all checks passed!

$ nix build
result/bin/tmux-a2a-postman  5.0 MB (commit 7f42e30)
```
