### PR TITLE
feat(deploy): implement Phase 1 phony deployment direct binding (#308)

### DIFF
--- a/docs/design/bindings-toml-schema.md
+++ b/docs/design/bindings-toml-schema.md
@@ -1,0 +1,93 @@
+# bindings.toml Schema
+
+Reference for the `bindings.toml` file used by the phony-node binding registry
+(Issue #303 / Issue #308). Loaded by `internal/binding.Load()`.
+
+## Security
+
+The file MUST be mode `0600` (owner read/write only). `binding.Load()` rejects
+files with group- or world-readable bits set (`mode & 0o044 != 0`).
+
+## File Location
+
+Conventional path: `$XDG_CONFIG_HOME/tmux-a2a-postman/bindings.toml`
+(or wherever the operator chooses; path is passed to `Load()` directly).
+
+## TOML Structure
+
+The file uses TOML array-of-tables with the key `[[binding]]`. Each entry
+represents one external channel / phony node association.
+
+### Fields
+
+| Field              | Type     | Required | Constraints                                      |
+| ------------------ | -------- | -------- | ------------------------------------------------ |
+| `channel_id`       | string   | yes      | `^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`; unique       |
+| `node_name`        | string   | yes      | same pattern; unique; used for routing           |
+| `context_id`       | string   | yes      | same pattern; path traversal prevention          |
+| `session_name`     | string   | no       | free string; empty when unassigned               |
+| `pane_title`       | string   | no       | free string; empty when not used for matching    |
+| `pane_node_name`   | string   | no       | same pattern as `node_name` or empty             |
+| `active`           | bool     | yes      | `true` = messages delivered; `false` = dead-letter |
+| `permitted_senders`| []string | yes      | each entry matches `node_name` pattern; must not be empty |
+
+### Duplicate Constraints
+
+- `channel_id` must be unique across all entries.
+- `node_name` must be unique across all entries.
+
+## Valid State Combinations (7-Row Table)
+
+`binding.Load()` enforces the following state machine via `validateState()`.
+Any combination not listed is rejected with an error.
+
+| Row | active | session_name | pane_title | pane_node_name | Description                     |
+| --- | ------ | ------------ | ---------- | -------------- | ------------------------------- |
+| 1   | false  | (empty)      | (empty)    | (empty)        | Unassigned — registered, no pane yet |
+| 2   | true   | set          | (empty)    | set            | Active, match by pane_node_name |
+| 3   | true   | set          | set        | (empty)        | Active, match by pane_title     |
+| 4   | true   | set          | set        | set            | Active, both matchers           |
+| 5   | false  | set          | (empty)    | set            | Inactive, was node_name-matched |
+| 6   | false  | set          | set        | (empty)        | Inactive, was title-matched     |
+| 7   | false  | set          | set        | set            | Inactive, was both-matched      |
+
+Row 1 is the initial state after Phase A registration (§6.1 Phase A).
+Rows 2–4 are set by Phase B assignment (§6.1 Phase B).
+Rows 5–7 are set by teardown (§6.2).
+
+## Example
+
+```toml
+# bindings.toml — mode 0600 required
+# Managed by: tmux-a2a-postman bind register/assign/deactivate/rebind
+
+# Row 1: unassigned (Phase A complete, Phase B pending)
+[[binding]]
+channel_id        = "slack-general"
+node_name         = "slack-bot"
+context_id        = "session-20260101-120000-abcd"
+session_name      = ""
+pane_title        = ""
+pane_node_name    = ""
+active            = false
+permitted_senders = ["orchestrator", "worker"]
+
+# Row 3: active, matched by pane_title (Phase B complete)
+[[binding]]
+channel_id        = "gh-notifications"
+node_name         = "gh-monitor"
+context_id        = "session-20260101-120000-abcd"
+session_name      = "my-tmux-session"
+pane_title        = "gh-monitor-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["orchestrator"]
+```
+
+## Save() Limitation
+
+`binding.Save()` serialises the registry back to TOML using the
+`github.com/BurntSushi/toml` encoder. TOML comments in the original file are
+NOT preserved — the written file will contain only the structured data.
+Operators should treat comments as advisory and regenerate them from this
+schema document after any `Save()` call.

--- a/e2e/phony_test.go
+++ b/e2e/phony_test.go
@@ -1,0 +1,141 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
+	"github.com/i9wa4/tmux-a2a-postman/internal/message"
+)
+
+// writeBndToml writes a bindings.toml to tmpDir and returns its path.
+// mode is applied after writing (e.g. 0o600).
+func writeBndToml(t *testing.T, dir, content string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, "bindings.toml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeBndToml: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("writeBndToml chmod: %v", err)
+	}
+	return path
+}
+
+// activeBinding is a minimal bindings.toml with one active Row 3 entry.
+const activeBinding = `
+[[binding]]
+channel_id        = "ch-e2e"
+node_name         = "ext-worker"
+context_id        = "ctx-e2e"
+session_name      = "test-session"
+pane_title        = "ext-pane"
+pane_node_name    = ""
+active            = true
+permitted_senders = ["orchestrator"]
+`
+
+// TestPhonyDelivery_Success verifies that DeliverToPhonyNode writes a file
+// to the phony inbox when active=true and sender is permitted.
+// The dead-letter directory must NOT exist after a clean delivery.
+// Loads from a real bindings.toml file (not an in-memory registry) to add
+// value beyond the unit tests in internal/message.
+func TestPhonyDelivery_Success(t *testing.T) {
+	baseDir := t.TempDir()
+	cfgDir := t.TempDir()
+	bndPath := writeBndToml(t, cfgDir, activeBinding, 0o600)
+
+	reg, err := binding.Load(bndPath)
+	if err != nil {
+		t.Fatalf("binding.Load: %v", err)
+	}
+
+	msg := message.Message{Body: "hello from orchestrator"}
+	if err := message.DeliverToPhonyNode(baseDir, "ctx-e2e", "ext-worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("DeliverToPhonyNode: %v", err)
+	}
+
+	// Assert: inbox file was created.
+	inboxDir := filepath.Join(baseDir, "ctx-e2e", "phony", "ext-worker", "inbox")
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		t.Fatalf("reading inbox dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("inbox is empty after delivery")
+	}
+
+	// Assert: dead-letter dir does NOT exist (writePhonyDeadLetter only runs on failure).
+	dlDir := filepath.Join(baseDir, "ctx-e2e", "phony", "ext-worker", "dead-letter")
+	if _, err := os.Stat(dlDir); !os.IsNotExist(err) {
+		t.Errorf("dead-letter dir should not exist after clean delivery; got err=%v", err)
+	}
+}
+
+// inactiveBinding is an assigned but inactive (Row 6) entry.
+const inactiveBinding = `
+[[binding]]
+channel_id        = "ch-inactive"
+node_name         = "ext-worker"
+context_id        = "ctx-e2e"
+session_name      = "test-session"
+pane_title        = "ext-pane"
+pane_node_name    = ""
+active            = false
+permitted_senders = ["orchestrator"]
+`
+
+// TestPhonyDelivery_ChannelUnbound verifies that inactive bindings produce
+// a dead-letter file with reason channel_unbound.
+func TestPhonyDelivery_ChannelUnbound(t *testing.T) {
+	baseDir := t.TempDir()
+	cfgDir := t.TempDir()
+	bndPath := writeBndToml(t, cfgDir, inactiveBinding, 0o600)
+
+	reg, err := binding.Load(bndPath)
+	if err != nil {
+		t.Fatalf("binding.Load: %v", err)
+	}
+
+	msg := message.Message{Body: "should be dead-lettered"}
+	if err := message.DeliverToPhonyNode(baseDir, "ctx-e2e", "ext-worker", "orchestrator", reg, msg); err != nil {
+		t.Fatalf("DeliverToPhonyNode (channel_unbound): %v", err)
+	}
+
+	dlDir := filepath.Join(baseDir, "ctx-e2e", "phony", "ext-worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil {
+		t.Fatalf("reading dead-letter dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("dead-letter dir is empty; expected channel_unbound dead-letter file")
+	}
+}
+
+// TestPhonyDelivery_RoutingDenied verifies that an unpermitted sender produces
+// a dead-letter file with reason routing_denied.
+func TestPhonyDelivery_RoutingDenied(t *testing.T) {
+	baseDir := t.TempDir()
+	cfgDir := t.TempDir()
+	bndPath := writeBndToml(t, cfgDir, activeBinding, 0o600)
+
+	reg, err := binding.Load(bndPath)
+	if err != nil {
+		t.Fatalf("binding.Load: %v", err)
+	}
+
+	msg := message.Message{Body: "should be denied"}
+	if err := message.DeliverToPhonyNode(baseDir, "ctx-e2e", "ext-worker", "intruder", reg, msg); err != nil {
+		t.Fatalf("DeliverToPhonyNode (routing_denied): %v", err)
+	}
+
+	dlDir := filepath.Join(baseDir, "ctx-e2e", "phony", "ext-worker", "dead-letter")
+	entries, err := os.ReadDir(dlDir)
+	if err != nil {
+		t.Fatalf("reading dead-letter dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("dead-letter dir is empty; expected routing_denied dead-letter file")
+	}
+}

--- a/internal/bindcmd/bindcmd.go
+++ b/internal/bindcmd/bindcmd.go
@@ -1,0 +1,217 @@
+// Package bindcmd implements the `tmux-a2a-postman bind` subcommands.
+// Shell scripts in scripts/ are thin wrappers that delegate all bindings.toml
+// mutations here; no TOML parsing occurs in the shell scripts themselves.
+//
+// Subcommands:
+//   - register  §6.1 Phase A — append unassigned binding (Row 1)
+//   - assign    §6.1 Phase B — activate binding with session/pane fields (Rows 2-4)
+//   - deactivate §6.2        — set active=false (Rows 5-7)
+//   - rebind    §6.3         — full field update
+//
+// TODO(Phase 2): add runtime e2e verification tests for these subcommands.
+package bindcmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
+)
+
+// Run dispatches the bind subcommand from args.
+// args[0] is the subcommand name; remaining args are flags.
+func Run(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("bind: subcommand required (register|assign|deactivate|rebind)")
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "register":
+		return runRegister(rest)
+	case "assign":
+		return runAssign(rest)
+	case "deactivate":
+		return runDeactivate(rest)
+	case "rebind":
+		return runRebind(rest)
+	default:
+		return fmt.Errorf("bind: unknown subcommand %q (register|assign|deactivate|rebind)", sub)
+	}
+}
+
+// runRegister appends an unassigned binding (Row 1: active=false, no session).
+func runRegister(args []string) error {
+	fs := flag.NewFlagSet("bind register", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	path := fs.String("file", "", "path to bindings.toml (required)")
+	channelID := fs.String("channel-id", "", "channel ID (required)")
+	nodeName := fs.String("node-name", "", "node name (required)")
+	contextID := fs.String("context-id", "", "context ID (required)")
+	senders := fs.String("permitted-senders", "", "comma-separated permitted senders (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *path == "" || *channelID == "" || *nodeName == "" || *contextID == "" || *senders == "" {
+		fs.Usage()
+		return fmt.Errorf("bind register: --file, --channel-id, --node-name, --context-id, --permitted-senders are required")
+	}
+	reg, err := loadOrEmpty(*path)
+	if err != nil {
+		return err
+	}
+	b := binding.Binding{
+		ChannelID:        *channelID,
+		NodeName:         *nodeName,
+		ContextID:        *contextID,
+		Active:           false,
+		PermittedSenders: splitSenders(*senders),
+	}
+	reg.Bindings = append(reg.Bindings, b)
+	return reg.Save(*path)
+}
+
+// runAssign activates a binding and sets session/pane fields (Rows 2-4).
+func runAssign(args []string) error {
+	fs := flag.NewFlagSet("bind assign", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	path := fs.String("file", "", "path to bindings.toml (required)")
+	nodeName := fs.String("node-name", "", "node name to assign (required)")
+	sessionName := fs.String("session-name", "", "tmux session name (required)")
+	paneTitle := fs.String("pane-title", "", "pane title for matching")
+	paneNodeName := fs.String("pane-node-name", "", "pane node name for matching")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *path == "" || *nodeName == "" || *sessionName == "" {
+		fs.Usage()
+		return fmt.Errorf("bind assign: --file, --node-name, --session-name are required")
+	}
+	if *paneTitle == "" && *paneNodeName == "" {
+		return fmt.Errorf("bind assign: at least one of --pane-title or --pane-node-name is required")
+	}
+	reg, err := loadOrEmpty(*path)
+	if err != nil {
+		return err
+	}
+	for i := range reg.Bindings {
+		if reg.Bindings[i].NodeName == *nodeName {
+			reg.Bindings[i].Active = true
+			reg.Bindings[i].SessionName = *sessionName
+			reg.Bindings[i].PaneTitle = *paneTitle
+			reg.Bindings[i].PaneNodeName = *paneNodeName
+			return reg.Save(*path)
+		}
+	}
+	return fmt.Errorf("bind assign: node_name %q not found in %s", *nodeName, *path)
+}
+
+// runDeactivate sets active=false for the named node (Rows 5-7).
+func runDeactivate(args []string) error {
+	fs := flag.NewFlagSet("bind deactivate", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	path := fs.String("file", "", "path to bindings.toml (required)")
+	nodeName := fs.String("node-name", "", "node name to deactivate (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *path == "" || *nodeName == "" {
+		fs.Usage()
+		return fmt.Errorf("bind deactivate: --file and --node-name are required")
+	}
+	reg, err := loadOrEmpty(*path)
+	if err != nil {
+		return err
+	}
+	for i := range reg.Bindings {
+		if reg.Bindings[i].NodeName == *nodeName {
+			reg.Bindings[i].Active = false
+			return reg.Save(*path)
+		}
+	}
+	return fmt.Errorf("bind deactivate: node_name %q not found in %s", *nodeName, *path)
+}
+
+// runRebind performs a full field update on an existing binding (§6.3).
+func runRebind(args []string) error {
+	fs := flag.NewFlagSet("bind rebind", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	path := fs.String("file", "", "path to bindings.toml (required)")
+	nodeName := fs.String("node-name", "", "node name to rebind (required)")
+	sessionName := fs.String("session-name", "", "new session name")
+	paneTitle := fs.String("pane-title", "", "new pane title")
+	paneNodeName := fs.String("pane-node-name", "", "new pane node name")
+	active := fs.Bool("active", true, "active state")
+	senders := fs.String("permitted-senders", "", "comma-separated permitted senders (replaces existing)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *path == "" || *nodeName == "" {
+		fs.Usage()
+		return fmt.Errorf("bind rebind: --file and --node-name are required")
+	}
+	reg, err := loadOrEmpty(*path)
+	if err != nil {
+		return err
+	}
+	for i := range reg.Bindings {
+		if reg.Bindings[i].NodeName == *nodeName {
+			reg.Bindings[i].SessionName = *sessionName
+			reg.Bindings[i].PaneTitle = *paneTitle
+			reg.Bindings[i].PaneNodeName = *paneNodeName
+			reg.Bindings[i].Active = *active
+			if *senders != "" {
+				reg.Bindings[i].PermittedSenders = splitSenders(*senders)
+			}
+			return reg.Save(*path)
+		}
+	}
+	return fmt.Errorf("bind rebind: node_name %q not found in %s", *nodeName, *path)
+}
+
+// loadOrEmpty loads the registry from path, or returns an empty registry if
+// the file does not exist (allows register on a fresh bindings.toml).
+func loadOrEmpty(path string) (*binding.BindingRegistry, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return &binding.BindingRegistry{}, nil
+	}
+	return binding.Load(path, binding.AllowEmptySenders())
+}
+
+// splitSenders splits a comma-separated sender list, trimming whitespace.
+func splitSenders(s string) []string {
+	var out []string
+	for _, part := range splitComma(s) {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// splitComma splits s by comma and trims spaces from each element.
+func splitComma(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			part := trim(s[start:i])
+			out = append(out, part)
+			start = i + 1
+		}
+	}
+	return out
+}
+
+// trim removes leading and trailing spaces.
+func trim(s string) string {
+	start, end := 0, len(s)
+	for start < end && s[start] == ' ' {
+		start++
+	}
+	for end > start && s[end-1] == ' ' {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -3,6 +3,7 @@
 package binding
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -74,6 +75,29 @@ func (r *BindingRegistry) FindByNodeName(name string) *Binding {
 // Uses [[binding]] array-of-tables.
 type tomlFile struct {
 	Binding []Binding `toml:"binding"`
+}
+
+// Save writes the registry back to the TOML file at path using an atomic
+// rename (write to path+".tmp", then os.Rename) to avoid partial writes.
+// File mode is set to 0600 (owner read/write only).
+//
+// NOTE: TOML comments in the original file are NOT preserved — the TOML
+// encoder serialises only structured data. See docs/design/bindings-toml-schema.md.
+func (r *BindingRegistry) Save(path string) error {
+	f := tomlFile{Binding: r.Bindings}
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(f); err != nil {
+		return fmt.Errorf("encoding bindings.toml: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("writing bindings.toml.tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming bindings.toml.tmp -> bindings.toml: %w", err)
+	}
+	return nil
 }
 
 // Load reads a binding registry from the TOML file at path.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,43 @@
+// Package plugin defines the Plugin interface for external-channel sidecars.
+// Phase 1 (Issue #308): supervisory observation only — no autonomous action.
+// The sidecar passively polls the phony inbox and records; Send/Ack are stubs.
+//
+// TODO(Phase 2): implement runtime e2e verification and real sidecar dispatch.
+package plugin
+
+// PluginEnvelope is the cross-boundary message type passed between the
+// postman core and external-channel sidecar plugins.
+// NOTE: intentionally NOT named Message to avoid collision with
+// internal/message.Message — see Issue #308 Decision Log.
+type PluginEnvelope struct {
+	// ID is the message identifier, used for idempotent Ack calls.
+	ID string
+	// Body is the raw message payload.
+	Body string
+}
+
+// Plugin is the interface that all external-channel sidecar plugins must
+// implement. Phase 1 requires only the interface stub; the implementation
+// is a no-op (supervisory observation only).
+type Plugin interface {
+	// Poll returns any pending envelopes from the external channel.
+	Poll() ([]PluginEnvelope, error)
+	// Ack acknowledges delivery of the envelope with the given ID.
+	Ack(id string) error
+	// Send delivers an envelope to the external channel.
+	Send(env PluginEnvelope) error
+}
+
+// NoOpPlugin is the Phase 1 stub implementation of Plugin.
+// It performs no I/O; all methods succeed silently.
+// Replace with a real implementation in Phase 2.
+type NoOpPlugin struct{}
+
+// Poll returns an empty slice and no error.
+func (NoOpPlugin) Poll() ([]PluginEnvelope, error) { return nil, nil }
+
+// Ack accepts any id and succeeds silently.
+func (NoOpPlugin) Ack(_ string) error { return nil }
+
+// Send accepts any envelope and succeeds silently.
+func (NoOpPlugin) Send(_ PluginEnvelope) error { return nil }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,43 @@
+package plugin
+
+import "testing"
+
+func TestPluginEnvelope_Fields(t *testing.T) {
+	env := PluginEnvelope{ID: "msg-01", Body: "hello"}
+	if env.ID != "msg-01" {
+		t.Errorf("ID: got %q, want %q", env.ID, "msg-01")
+	}
+	if env.Body != "hello" {
+		t.Errorf("Body: got %q, want %q", env.Body, "hello")
+	}
+}
+
+func TestNoOpPlugin_ImplementsPlugin(t *testing.T) {
+	var _ Plugin = NoOpPlugin{}
+}
+
+func TestNoOpPlugin_Poll(t *testing.T) {
+	p := NoOpPlugin{}
+	envs, err := p.Poll()
+	if err != nil {
+		t.Fatalf("Poll returned error: %v", err)
+	}
+	if len(envs) != 0 {
+		t.Errorf("Poll returned %d envelopes, want 0", len(envs))
+	}
+}
+
+func TestNoOpPlugin_Ack(t *testing.T) {
+	p := NoOpPlugin{}
+	if err := p.Ack("any-id"); err != nil {
+		t.Fatalf("Ack returned error: %v", err)
+	}
+}
+
+func TestNoOpPlugin_Send(t *testing.T) {
+	p := NoOpPlugin{}
+	env := PluginEnvelope{ID: "x", Body: "payload"}
+	if err := p.Send(env); err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/fsnotify/fsnotify"
 	"github.com/i9wa4/tmux-a2a-postman/internal/alert"
+	"github.com/i9wa4/tmux-a2a-postman/internal/bindcmd"
 	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/daemon"
@@ -222,6 +223,11 @@ func main() {
 	case "send-message":
 		if err := runSendMessage(args); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ postman send-message: %v\n", err)
+			os.Exit(1)
+		}
+	case "bind":
+		if err := bindcmd.Run(args); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ postman bind: %v\n", err)
 			os.Exit(1)
 		}
 	case "help":

--- a/scripts/bind-phase-a
+++ b/scripts/bind-phase-a
@@ -1,0 +1,28 @@
+#!/bin/sh
+# bind-phase-a — §6.1 Phase A: register an unassigned phony-node binding.
+# Creates a Row 1 entry (active=false, no session) in bindings.toml.
+#
+# Usage:
+#   BINDINGS_FILE=<path> \
+#   CHANNEL_ID=<id> \
+#   NODE_NAME=<name> \
+#   CONTEXT_ID=<ctx> \
+#   PERMITTED_SENDERS=<sender1,sender2> \
+#   bind-phase-a
+#
+# All variables are required. BINDINGS_FILE is created if it does not exist.
+
+set -eu
+
+: "${BINDINGS_FILE:?BINDINGS_FILE is required}"
+: "${CHANNEL_ID:?CHANNEL_ID is required}"
+: "${NODE_NAME:?NODE_NAME is required}"
+: "${CONTEXT_ID:?CONTEXT_ID is required}"
+: "${PERMITTED_SENDERS:?PERMITTED_SENDERS is required}"
+
+exec tmux-a2a-postman bind register \
+  --file "$BINDINGS_FILE" \
+  --channel-id "$CHANNEL_ID" \
+  --node-name "$NODE_NAME" \
+  --context-id "$CONTEXT_ID" \
+  --permitted-senders "$PERMITTED_SENDERS"

--- a/scripts/bind-phase-b
+++ b/scripts/bind-phase-b
@@ -1,0 +1,30 @@
+#!/bin/sh
+# bind-phase-b — §6.1 Phase B: assign a registered binding to a session pane.
+# Transitions an existing Row 1 entry to Rows 2-4 (active=true + session/pane).
+#
+# Usage:
+#   BINDINGS_FILE=<path> \
+#   NODE_NAME=<name> \
+#   SESSION_NAME=<session> \
+#   PANE_TITLE=<title>      (set if matching by pane title)
+#   PANE_NODE_NAME=<node>   (set if matching by pane node name)
+#   bind-phase-b
+#
+# BINDINGS_FILE, NODE_NAME, SESSION_NAME are required.
+# At least one of PANE_TITLE or PANE_NODE_NAME must be non-empty.
+
+set -eu
+
+: "${BINDINGS_FILE:?BINDINGS_FILE is required}"
+: "${NODE_NAME:?NODE_NAME is required}"
+: "${SESSION_NAME:?SESSION_NAME is required}"
+
+PANE_TITLE="${PANE_TITLE:-}"
+PANE_NODE_NAME="${PANE_NODE_NAME:-}"
+
+exec tmux-a2a-postman bind assign \
+  --file "$BINDINGS_FILE" \
+  --node-name "$NODE_NAME" \
+  --session-name "$SESSION_NAME" \
+  --pane-title "$PANE_TITLE" \
+  --pane-node-name "$PANE_NODE_NAME"

--- a/scripts/bind-rebind
+++ b/scripts/bind-rebind
@@ -1,0 +1,37 @@
+#!/bin/sh
+# bind-rebind — §6.3: full re-bind of an existing entry.
+# Updates session_name, pane_title, pane_node_name, active, and
+# permitted_senders on an existing binding.
+#
+# Usage:
+#   BINDINGS_FILE=<path> \
+#   NODE_NAME=<name> \
+#   SESSION_NAME=<session> \
+#   PANE_TITLE=<title> \
+#   PANE_NODE_NAME=<node> \
+#   ACTIVE=true|false \
+#   PERMITTED_SENDERS=<sender1,sender2> \
+#   bind-rebind
+#
+# BINDINGS_FILE, NODE_NAME are required.
+# Omitted optional vars default to empty string / true.
+
+set -eu
+
+: "${BINDINGS_FILE:?BINDINGS_FILE is required}"
+: "${NODE_NAME:?NODE_NAME is required}"
+
+SESSION_NAME="${SESSION_NAME:-}"
+PANE_TITLE="${PANE_TITLE:-}"
+PANE_NODE_NAME="${PANE_NODE_NAME:-}"
+ACTIVE="${ACTIVE:-true}"
+PERMITTED_SENDERS="${PERMITTED_SENDERS:-}"
+
+exec tmux-a2a-postman bind rebind \
+  --file "$BINDINGS_FILE" \
+  --node-name "$NODE_NAME" \
+  --session-name "$SESSION_NAME" \
+  --pane-title "$PANE_TITLE" \
+  --pane-node-name "$PANE_NODE_NAME" \
+  --active="$ACTIVE" \
+  --permitted-senders "$PERMITTED_SENDERS"

--- a/scripts/bind-teardown
+++ b/scripts/bind-teardown
@@ -1,0 +1,15 @@
+#!/bin/sh
+# bind-teardown — §6.2: deactivate a binding (set active=false).
+# Transitions Rows 2-4 to Rows 5-7; messages are dead-lettered after this.
+#
+# Usage:
+#   BINDINGS_FILE=<path> NODE_NAME=<name> bind-teardown
+
+set -eu
+
+: "${BINDINGS_FILE:?BINDINGS_FILE is required}"
+: "${NODE_NAME:?NODE_NAME is required}"
+
+exec tmux-a2a-postman bind deactivate \
+  --file "$BINDINGS_FILE" \
+  --node-name "$NODE_NAME"

--- a/scripts/launchd/com.example.tmux-a2a-sidecar.plist
+++ b/scripts/launchd/com.example.tmux-a2a-sidecar.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.example.tmux-a2a-sidecar.plist — launchd user agent template.
+     Phase 1 (Issue #308): supervisory observation only; no autonomous action.
+
+     Install:
+       cp com.example.tmux-a2a-sidecar.plist ~/Library/LaunchAgents/
+       launchctl load ~/Library/LaunchAgents/com.example.tmux-a2a-sidecar.plist
+
+     Replace NODE_NAME with the node_name from bindings.toml.
+     Replace /usr/local/bin/tmux-a2a-sidecar with the actual sidecar binary path.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.example.tmux-a2a-sidecar</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/tmux-a2a-sidecar</string>
+    <string>--node-name</string>
+    <string>NODE_NAME</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>XDG_CONFIG_HOME</key>
+    <string>/Users/USER/.config</string>
+    <key>XDG_STATE_HOME</key>
+    <string>/Users/USER/.local/state</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/USER/.local/state/tmux-a2a-postman/sidecar-NODE_NAME.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/USER/.local/state/tmux-a2a-postman/sidecar-NODE_NAME.log</string>
+</dict>
+</plist>

--- a/scripts/systemd/tmux-a2a-sidecar@.service
+++ b/scripts/systemd/tmux-a2a-sidecar@.service
@@ -1,0 +1,25 @@
+# tmux-a2a-sidecar@.service — systemd user unit template for a phony-node sidecar.
+# Phase 1 (Issue #308): supervisory observation only; no autonomous action.
+#
+# Install:
+#   cp tmux-a2a-sidecar@.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now tmux-a2a-sidecar@<node-name>.service
+#
+# The instance name (%i) is the node_name from bindings.toml.
+# The sidecar binary must be on PATH or set ExecStart to an absolute path.
+
+[Unit]
+Description=tmux-a2a sidecar for phony node %i
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/tmux-a2a-sidecar --node-name %i
+Restart=on-failure
+RestartSec=5s
+Environment=XDG_CONFIG_HOME=%h/.config
+Environment=XDG_STATE_HOME=%h/.local/state
+
+[Install]
+WantedBy=default.target

--- a/scripts/verify-sidecar
+++ b/scripts/verify-sidecar
@@ -1,0 +1,24 @@
+#!/bin/sh
+# verify-sidecar — check that the named sidecar process is running.
+# Uses pgrep -x for exact-name match (POSIX-compatible; works on Linux + macOS).
+#
+# Usage: SIDECAR_NAME=<binary-name> verify-sidecar
+#        verify-sidecar <binary-name>
+#
+# Exits 0 if running, 1 if not found, 2 if argument missing.
+
+set -eu
+
+name="${1:-${SIDECAR_NAME:-}}"
+if [ -z "$name" ]; then
+  echo "usage: verify-sidecar <sidecar-name>" >&2
+  exit 2
+fi
+
+if pgrep -x "$name" > /dev/null 2>&1; then
+  echo "sidecar '$name' is running"
+  exit 0
+else
+  echo "sidecar '$name' is NOT running" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Parent

Part of #298 — label **E-1** (requires A-1 through D-1 and A-3; all merged).

## Summary

Closes #308

Implements all E-1 deliverables: one external channel per session, supervisor
passively observes and records phony inbox traffic. No autonomous sidecar action
in Phase 1.

## Changes

### [Go] `internal/plugin/plugin.go` + `internal/plugin/plugin_test.go`

- New package `internal/plugin` with `Plugin` interface (`Poll`/`Ack`/`Send`)
- `PluginEnvelope` cross-boundary type (not `Message` — avoids collision with `internal/message.Message`)
- `NoOpPlugin` stub for Phase 1 supervisory-only mode; TODO comment flags Phase 2 debt
- Unit tests: construction, interface satisfaction, all three stub methods

### [Go] `internal/binding/binding.go`

- Add `Save()` to `BindingRegistry`: atomic write via temp-file rename; mode 0600
- NOTE comment: TOML comments not preserved on `Save()` (encoder limitation)

### [Go] `internal/bindcmd/bindcmd.go`

- New package implementing `tmux-a2a-postman bind` subcommands:
  `register` (§6.1 Phase A), `assign` (§6.1 Phase B), `deactivate` (§6.2),
  `rebind` (§6.3)
- Delegates all TOML mutations to `internal/binding`; no text manipulation
- `loadOrEmpty` helper: returns empty registry when `bindings.toml` absent
  (supports `register` on a fresh install)

### [Go] `main.go`

- Wire `case "bind":` dispatch to `bindcmd.Run()`

### [Docs] `docs/design/bindings-toml-schema.md`

- 7-row state validity table (mirrors `binding.validateState`)
- Field reference: types, constraints, duplicate rules
- Security note: mode 0600 required; `binding.Load()` rejects group/world-readable files
- `Save()` comment-loss limitation documented

### [Scripts] `scripts/` — binding lifecycle (§6.1–§6.3)

- `bind-phase-a`: §6.1 Phase A — register unassigned channel (Row 1)
- `bind-phase-b`: §6.1 Phase B — assign channel to session pane (Rows 2–4)
- `bind-teardown`: §6.2 — set `active=false` (Rows 5–7)
- `bind-rebind`: §6.3 — full field update
- All scripts: POSIX sh (`#!/bin/sh`), thin wrappers delegating to `tmux-a2a-postman bind`

### [Scripts] `scripts/` — process supervision (§7)

- `scripts/systemd/tmux-a2a-sidecar@.service`: Linux user unit template (`%i` = node name)
- `scripts/launchd/com.example.tmux-a2a-sidecar.plist`: macOS launchd agent template
- `scripts/verify-sidecar`: startup verification via `pgrep -x`

### [Tests] `e2e/phony_test.go`

- `TestPhonyDelivery_Success`: loads real `bindings.toml`, delivers message, asserts inbox
  file created and dead-letter dir does NOT exist (`os.IsNotExist`)
- `TestPhonyDelivery_ChannelUnbound`: inactive binding produces dead-letter file
- `TestPhonyDelivery_RoutingDenied`: unpermitted sender produces dead-letter file

## Design Notes

- Shell scripts contain zero TOML logic; all mutations go through
  `tmux-a2a-postman bind` → `internal/bindcmd` → `internal/binding.Save()`
  to avoid fragile sed-based text manipulation and leverage the existing
  7-row state validator
- `binding.Save()` uses `os.Rename()` for atomicity: partial writes cannot
  corrupt `bindings.toml`
- `bind subcommands` are verified at compilation level in Phase 1;
  runtime e2e for the `bind` CLI itself is deferred to Phase 2

## Phase 2 Follow-up

- `bind rebind --active` default (currently `true`): reconsider semantics
  when rebind is used during teardown
- Add `OriginalAt` timestamp field to `PluginEnvelope` for ordering guarantees
- Runtime e2e for `bind register/assign/deactivate/rebind` subcommands

## Verification

```
$ nix flake check
all checks passed

$ nix build
exit 0

commit: 2f5e054
14 files changed, 775 insertions(+)
```