### PR TITLE
feat: durable auto-PING discovery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Public knobs for this model live in `postman.toml`:
 
 - `ui_node`
 - `reminder_interval_messages`
+- `auto_ping_delay_seconds`
 - `inbox_unread_threshold`
 - `journal_health_cutover_enabled`
 - `journal_compatibility_cutover_enabled`
@@ -257,6 +258,9 @@ Advanced dampening and rendering-shaping fields remain documented in
 `docs/design/notification.md` and `docs/guides/alert-config.md`.
 The embedded defaults in `internal/config/postman.default.toml` currently route
 alerts to `messenger`.
+`auto_ping_delay_seconds` controls how long a newly discovered or confirmed
+replacement-pane node waits before its first daemon auto-PING is delivered.
+`0` keeps auto-PING immediate.
 
 ### 4.6. Priority Order (highest to lowest)
 

--- a/docs/design/notification.md
+++ b/docs/design/notification.md
@@ -458,6 +458,11 @@ discovered nodes in the target session. `ui_node` still controls alert
 delivery, but it no longer narrows the manual PING pass, even when the
 operator explicitly sets a non-empty `ui_node` in TOML or Markdown.
 
+Discovery-time and confirmed replacement-pane auto-PING now use durable
+pending state. `auto_ping_delay_seconds` sets the `not_before_at` deadline for
+that first send attempt; after the deadline, queue-full or ownership-blocked
+outcomes keep the same pending debt until a later eligible pass succeeds.
+
 Liveness is confirmed via two independent paths:
 
 1. **PING reply**: when a node archives the PING (moves it from inbox to

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -73,6 +73,7 @@ func runSchema(stdout io.Writer, args []string) error {
 				"edges":                                 {Type: "array", Description: "Bidirectional routing edges between named nodes"},
 				"ui_node":                               {Type: "string", Description: "Human-facing node that receives daemon alerts and user_input waits"},
 				"reminder_interval_messages":            {Type: "integer", Description: "Reminder cadence after archived reads (0 = disabled)"},
+				"auto_ping_delay_seconds":               {Type: "number", Description: "Delay before the first auto-PING for newly discovered or replacement-pane nodes (0 = immediate)"},
 				"inbox_unread_threshold":                {Type: "integer", Description: "Unread-summary threshold for ui_node alerts (0 = disabled)"},
 				"read_context_mode":                     {Type: "string", Description: "Bare-pop read-time context mode: none or pieces"},
 				"read_context_pieces":                   {Type: "array", Description: "Ordered built-in read-time context pieces rendered on bare interactive pop"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	RetentionPeriodDays       int     `toml:"retention_period_days"`        // Inactive runtime cleanup threshold in days; 0 = disabled
 	MinDeliveryGapSeconds     float64 `toml:"min_delivery_gap_seconds"`     // Duplicate delivery rate limit; 0 = disabled
 	StartupDrainWindowSeconds float64 `toml:"startup_drain_window_seconds"` // Session-enabled bypass window after daemon start; 0 = disabled (#217)
+	AutoPingDelaySeconds      float64 `toml:"auto_ping_delay_seconds"`      // Delay from discovery/replacement to first auto-PING; 0 = immediate
 
 	// Pane capture settings (hybrid idle detection)
 	PaneCaptureEnabled         *bool   `toml:"pane_capture_enabled"` // nil = use default (true) (#219)
@@ -549,6 +550,8 @@ func localPostmanExplicitZero(cfg *Config, field string) bool {
 		return cfg.MinDeliveryGapSeconds == 0
 	case "startup_drain_window_seconds":
 		return cfg.StartupDrainWindowSeconds == 0
+	case "auto_ping_delay_seconds":
+		return cfg.AutoPingDelaySeconds == 0
 	case "pane_capture_max_panes":
 		return cfg.PaneCaptureMaxPanes == 0
 	case "inbox_unread_threshold":
@@ -614,6 +617,8 @@ func applyProjectLocalExplicitZero(base, override *Config) {
 			base.MinDeliveryGapSeconds = 0
 		case "startup_drain_window_seconds":
 			base.StartupDrainWindowSeconds = 0
+		case "auto_ping_delay_seconds":
+			base.AutoPingDelaySeconds = 0
 		case "pane_capture_max_panes":
 			base.PaneCaptureMaxPanes = 0
 		case "inbox_unread_threshold":
@@ -816,6 +821,9 @@ func mergeConfig(base, override *Config) {
 	}
 	if override.StartupDrainWindowSeconds != 0 {
 		base.StartupDrainWindowSeconds = override.StartupDrainWindowSeconds
+	}
+	if override.AutoPingDelaySeconds != 0 {
+		base.AutoPingDelaySeconds = override.AutoPingDelaySeconds
 	}
 	if override.PaneCaptureIntervalSeconds != 0 {
 		base.PaneCaptureIntervalSeconds = override.PaneCaptureIntervalSeconds

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -64,6 +64,7 @@ enter_retry_max = 2                # Max C-m retries on unchanged pane capture (
 startup_delay_seconds = 10.0       # Initial startup delay
 reminder_interval_messages = 20    # Send reminder after N messages (0 = disabled)
 inbox_unread_threshold = 3         # Alert ui_node when inbox has N+ unread messages (0 = disabled)
+auto_ping_delay_seconds = 0        # Delay before first auto-PING for newly discovered/replaced nodes (0 = immediate)
 message_ttl_seconds = 600              # Stale post/ drain TTL in seconds (0 = disabled)
 retention_period_days = 90            # Inactive runtime cleanup threshold in days (0 = disabled)
 min_delivery_gap_seconds = 1.0         # Duplicate delivery rate limit in seconds (0 = disabled)

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -169,25 +169,8 @@ func (TmuxHandAdapter) DeliverSystemMessage(target Target, delivery SystemMessag
 	}
 
 	if count, countErr := countInboxMessages(recipientInbox); countErr == nil && count >= delivery.QueueCap {
-		deadLetterDir := filepath.Join(target.SessionDir, "dead-letter")
-		if err := os.MkdirAll(deadLetterDir, 0o700); err != nil {
-			return SystemMessageResult{}, fmt.Errorf("creating dead-letter dir: %w", err)
-		}
-		dst := deadLetterDst(target.SessionDir, delivery.Filename, delivery.QueueFullSuffix)
-		if err := writeDeadLetterFile(dst, []byte(delivery.Content)); err != nil {
-			return SystemMessageResult{}, fmt.Errorf("writing queue-full dead-letter: %w", err)
-		}
-		recordCompatibilityMailboxPayload(target.SessionDir, target.SessionName, "compatibility_mailbox_dead_lettered", journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
-			MessageID: delivery.Filename,
-			From:      delivery.Sender,
-			To:        target.ActorID,
-			ThreadID:  delivery.ThreadID,
-			Path:      shadowRelativePath(target.SessionDir, dst),
-			Content:   delivery.Content,
-		})
-		syncCompatibilityMailbox(target.SessionDir)
-		log.Printf("postman: inbox queue full for %s (cap=%d, current=%d): dead-lettering %s\n", target.ActorID, delivery.QueueCap, count, delivery.Filename)
-		return SystemMessageResult{}, nil
+		log.Printf("postman: inbox queue full for %s (cap=%d, current=%d): leaving %s undelivered for retry\n", target.ActorID, delivery.QueueCap, count, delivery.Filename)
+		return SystemMessageResult{Delivered: false}, nil
 	}
 
 	dst := filepath.Join(recipientInbox, delivery.Filename)

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -157,6 +158,54 @@ func TestTmuxHandAdapterDeliverSystemMessageWritesInbox(t *testing.T) {
 	}
 	if string(body) != "system delivery" {
 		t.Fatalf("inbox body = %q, want %q", string(body), "system delivery")
+	}
+}
+
+func TestTmuxHandAdapterDeliverSystemMessageQueueFullStaysUndeliveredWithoutDeadLetter(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	target := Target{
+		ActorID:     "worker",
+		RunID:       "review-session:worker",
+		SessionName: "review-session",
+		SessionDir:  sessionDir,
+		Hand:        HandAttachment{Kind: HandKindTmux, Address: "%9"},
+	}
+
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(inboxDir) error = %v", err)
+	}
+	for i := range 20 {
+		name := filepath.Join(inboxDir, fmt.Sprintf("20260414-1155%02d-r1111-from-postman-to-worker.md", i))
+		if err := os.WriteFile(name, []byte("queued"), 0o600); err != nil {
+			t.Fatalf("WriteFile(queued %d) error = %v", i, err)
+		}
+	}
+
+	result, err := (TmuxHandAdapter{}).DeliverSystemMessage(target, SystemMessageDelivery{
+		Filename:        "20260414-120000-r1234-from-postman-to-worker.md",
+		Sender:          "postman",
+		Content:         "system delivery",
+		QueueCap:        20,
+		QueueFullSuffix: "-dl-queue-full",
+	})
+	if err != nil {
+		t.Fatalf("DeliverSystemMessage() error = %v", err)
+	}
+	if result.Delivered {
+		t.Fatal("DeliverSystemMessage() delivered = true, want false when inbox is full")
+	}
+
+	deadEntries, err := os.ReadDir(filepath.Join(sessionDir, "dead-letter"))
+	if err != nil {
+		t.Fatalf("ReadDir(dead-letter) error = %v", err)
+	}
+	if len(deadEntries) != 0 {
+		t.Fatalf("dead-letter entries = %d, want 0 for retryable queue-full system delivery", len(deadEntries))
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1600,9 +1600,11 @@ func startHeartbeatTrigger(ctx context.Context, sharedNodes *atomic.Pointer[map[
 // checkPaneRestarts detects pane restarts and sends PING (Issue #98).
 // Detects restart by comparing current paneStates with previous paneStates.
 // Issue #118: Added sessionDir for alert messaging.
-func (ds *DaemonState) checkPaneRestarts(paneStates map[string]uinode.PaneInfo, paneToNode map[string]string, nodes map[string]discovery.NodeInfo, cfg *config.Config, events chan<- tui.DaemonEvent, contextID, sessionDir string, adjacency map[string][]string, idleTracker *idle.IdleTracker) {
+func (ds *DaemonState) checkPaneRestarts(paneStates map[string]uinode.PaneInfo, paneToNode map[string]string, nodes map[string]discovery.NodeInfo, cfg *config.Config, events chan<- tui.DaemonEvent, contextID, sessionDir string, adjacency map[string][]string, idleTracker *idle.IdleTracker) []string {
 	ds.prevPaneStatesMu.Lock()
 	defer ds.prevPaneStatesMu.Unlock()
+
+	var restartedNodeKeys []string
 
 	for currentPaneID, currentInfo := range paneStates {
 		nodeKey, exists := paneToNode[currentPaneID]
@@ -1636,8 +1638,13 @@ func (ds *DaemonState) checkPaneRestarts(paneStates map[string]uinode.PaneInfo, 
 		}
 
 		if oldPaneID != "" {
+			if _, oldStillLive := paneStates[oldPaneID]; oldStillLive {
+				continue
+			}
+
 			// Restart detected: node had oldPaneID, now has currentPaneID
 			log.Printf("postman: pane restart detected for %s (old: %s, new: %s)\n", nodeKey, oldPaneID, currentPaneID)
+			restartedNodeKeys = append(restartedNodeKeys, nodeKey)
 
 			// Send TUI event
 			events <- tui.DaemonEvent{
@@ -1700,6 +1707,8 @@ func (ds *DaemonState) checkPaneRestarts(paneStates map[string]uinode.PaneInfo, 
 	for paneID, nodeKey := range paneToNode {
 		ds.prevPaneToNode[paneID] = nodeKey
 	}
+
+	return restartedNodeKeys
 }
 
 // checkPaneDisappearance detects disappeared panes and marks corresponding nodes as inactive.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
+	"github.com/i9wa4/tmux-a2a-postman/internal/uinode"
 )
 
 // TestWarnAlertConfig verifies the degraded startup branches of warnAlertConfig.
@@ -227,6 +228,40 @@ func TestShouldSendAlert_ZeroCooldown(t *testing.T) {
 	// Zero cooldown: always return true regardless of timestamp
 	if !ds.ShouldSendAlert(alertKey, 0) {
 		t.Error("expected true with zero cooldown")
+	}
+}
+
+func TestCheckPaneRestarts_IgnoresWinnerSwapWhileOldPaneStillLive(t *testing.T) {
+	ds := NewDaemonState(0, "ctx-main")
+	ds.prevPaneStates = map[string]uinode.PaneInfo{
+		"%10": {},
+	}
+	ds.prevPaneToNode = map[string]string{
+		"%10": "review:worker",
+	}
+
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  t.TempDir(),
+		},
+	}
+	paneStates := map[string]uinode.PaneInfo{
+		"%10": {},
+		"%11": {},
+	}
+	paneToNode := map[string]string{
+		"%11": "review:worker",
+	}
+	events := make(chan tui.DaemonEvent, 1)
+
+	restarted := ds.checkPaneRestarts(paneStates, paneToNode, nodes, &config.Config{}, events, "ctx-main", nodes["review:worker"].SessionDir, map[string][]string{}, idle.NewIdleTracker())
+	if len(restarted) != 0 {
+		t.Fatalf("checkPaneRestarts() = %#v, want no restart when old pane is still live", restarted)
+	}
+	if len(events) != 0 {
+		t.Fatalf("pane_restart event emitted for live winner swap: %#v", <-events)
 	}
 }
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -257,6 +257,8 @@ func (rt *daemonRuntime) bootstrap(ctx context.Context) {
 	if err := resumeCompatibilityMailboxProjections(rt.sessionDir, rt.nodes); err != nil {
 		log.Printf("postman: WARNING: %v\n", err)
 	}
+	autoEnableSessions := config.BoolVal(rt.cfg.AutoEnableNewSessions, false)
+	rt.dispatchPendingAutoPings(rt.nodes, autoEnableSessions, time.Now())
 }
 
 func (rt *daemonRuntime) handleContextDone() {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
+	"github.com/i9wa4/tmux-a2a-postman/internal/ping"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/reminder"
 	"github.com/i9wa4/tmux-a2a-postman/internal/session"
@@ -341,9 +342,11 @@ func (rt *daemonRuntime) handlePostWatcherEvent(eventPath string, op fsnotify.Op
 	freshNodes, _, err := rt.discoverNodes()
 	if err == nil {
 		rt.claimNewPanes(freshNodes)
-		rt.detectNewNodes(freshNodes, false)
+		newNodes := rt.detectNewNodes(freshNodes)
+		rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", time.Now())
 		rt.nodes = freshNodes
 		rt.storeSharedNodes()
+		rt.dispatchPendingAutoPings(freshNodes, config.BoolVal(rt.cfg.AutoEnableNewSessions, false), time.Now())
 
 		allSessions, _ := discovery.DiscoverAllSessions()
 		if allSessions == nil {
@@ -672,7 +675,8 @@ func (rt *daemonRuntime) handleScanTick() {
 	}
 
 	autoEnableSessions := config.BoolVal(rt.cfg.AutoEnableNewSessions, false)
-	rt.detectNewNodes(freshNodes, autoEnableSessions)
+	newNodes := rt.detectNewNodes(freshNodes)
+	rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", time.Now())
 	rt.nodes = freshNodes
 	rt.storeSharedNodes()
 	rt.alertDeliverySignalState = syncAlertDeliveryStatus(rt.alertDeliverySignalState, rt.cfg, rt.nodes, rt.events)
@@ -771,10 +775,13 @@ func (rt *daemonRuntime) handleScanTick() {
 			}
 
 			rt.daemonState.checkPaneDisappearance(paneStates, rt.daemonState.prevPaneToNode, rt.nodes, rt.events)
-			rt.daemonState.checkPaneRestarts(paneStates, paneToNode, rt.nodes, rt.cfg, rt.events, rt.contextID, rt.sessionDir, rt.adjacency, rt.idleTracker)
+			restartedNodes := rt.daemonState.checkPaneRestarts(paneStates, paneToNode, rt.nodes, rt.cfg, rt.events, rt.contextID, rt.sessionDir, rt.adjacency, rt.idleTracker)
+			rt.recordPendingAutoPings(restartedNodes, rt.nodes, "pane_restart", time.Now())
 			rt.prevPaneStatesJSON = currentJSONStr
 		}
 	}
+
+	rt.dispatchPendingAutoPings(freshNodes, autoEnableSessions, time.Now())
 
 	droppedNodeMap := rt.idleTracker.GetCurrentlyDroppedNodes(nodeConfigs)
 	nodeStates := rt.idleTracker.GetNodeStates()
@@ -957,17 +964,27 @@ func (rt *daemonRuntime) ensureNodeWatchDirs(nodeName string, nodeInfo discovery
 	}
 }
 
-func (rt *daemonRuntime) detectNewNodes(freshNodes map[string]discovery.NodeInfo, autoEnableSession bool) {
-	for nodeName, nodeInfo := range freshNodes {
+func (rt *daemonRuntime) detectNewNodes(freshNodes map[string]discovery.NodeInfo) []string {
+	nodeNames := make([]string, 0, len(freshNodes))
+	for nodeName := range freshNodes {
+		nodeNames = append(nodeNames, nodeName)
+	}
+	sort.Strings(nodeNames)
+
+	newNodes := make([]string, 0, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		nodeInfo := freshNodes[nodeName]
 		if rt.knownNodes[nodeName] {
 			continue
 		}
 		rt.knownNodes[nodeName] = true
-		if autoEnableSession {
-			rt.daemonState.AutoEnableSessionIfNew(nodeInfo.SessionName)
+		if nodeInfo.IsPhony {
+			continue
 		}
 		rt.ensureNodeWatchDirs(nodeName, nodeInfo)
+		newNodes = append(newNodes, nodeName)
 	}
+	return newNodes
 }
 
 func (rt *daemonRuntime) pruneClaimedPanes(freshNodes map[string]discovery.NodeInfo) {
@@ -999,4 +1016,183 @@ func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo)
 		}
 		rt.claimedPanes[nodeInfo.PaneID] = true
 	}
+}
+
+func (rt *daemonRuntime) recordPendingAutoPings(nodeKeys []string, freshNodes map[string]discovery.NodeInfo, reason string, now time.Time) {
+	if len(nodeKeys) == 0 {
+		return
+	}
+
+	sortedNodeKeys := append([]string{}, nodeKeys...)
+	sort.Strings(sortedNodeKeys)
+	for _, nodeKey := range sortedNodeKeys {
+		nodeInfo, ok := freshNodes[nodeKey]
+		if !ok {
+			continue
+		}
+		rt.recordPendingAutoPing(nodeKey, nodeInfo, reason, now)
+	}
+}
+
+func (rt *daemonRuntime) recordPendingAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, reason string, now time.Time) {
+	if nodeInfo.IsPhony || nodeInfo.SessionDir == "" || nodeInfo.SessionName == "" {
+		return
+	}
+
+	delaySeconds := 0.0
+	if rt.cfg != nil {
+		delaySeconds = rt.cfg.AutoPingDelaySeconds
+	}
+
+	triggeredAt := now
+	notBeforeAt := now.Add(time.Duration(delaySeconds * float64(time.Second)))
+	if state, ok, err := projection.ProjectAutoPingState(nodeInfo.SessionDir); err != nil {
+		log.Printf("postman: WARNING: auto-PING replay failed for %s: %v\n", nodeKey, err)
+	} else if ok {
+		if existing, exists := state.Nodes[nodeKey]; exists && existing.Pending {
+			if existing.DelaySeconds >= 0 {
+				delaySeconds = existing.DelaySeconds
+			}
+			if parsed, err := time.Parse(time.RFC3339Nano, existing.TriggeredAt); err == nil {
+				triggeredAt = parsed
+			}
+			if parsed, err := time.Parse(time.RFC3339Nano, existing.NotBeforeAt); err == nil {
+				notBeforeAt = parsed
+			}
+			if reason == "" {
+				reason = existing.Reason
+			}
+		}
+	}
+	if reason == "" {
+		reason = "discovered"
+	}
+
+	payload := projection.AutoPingEventPayload{
+		NodeKey:      nodeKey,
+		SessionName:  nodeInfo.SessionName,
+		NodeName:     ping.ExtractSimpleName(nodeKey),
+		PaneID:       nodeInfo.PaneID,
+		Reason:       reason,
+		TriggeredAt:  triggeredAt.Format(time.RFC3339Nano),
+		DelaySeconds: delaySeconds,
+		NotBeforeAt:  notBeforeAt.Format(time.RFC3339Nano),
+	}
+	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
+		log.Printf("postman: WARNING: auto-PING pending append failed for %s: %v\n", nodeKey, err)
+	}
+}
+
+func (rt *daemonRuntime) recordDeliveredAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, now time.Time) {
+	payload := projection.AutoPingEventPayload{
+		NodeKey:      nodeKey,
+		SessionName:  nodeInfo.SessionName,
+		NodeName:     ping.ExtractSimpleName(nodeKey),
+		PaneID:       nodeInfo.PaneID,
+		Reason:       pending.Reason,
+		TriggeredAt:  pending.TriggeredAt,
+		DelaySeconds: pending.DelaySeconds,
+		NotBeforeAt:  pending.NotBeforeAt,
+		DeliveredAt:  now.Format(time.RFC3339Nano),
+	}
+	if payload.Reason == "" {
+		payload.Reason = "discovered"
+	}
+	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
+		log.Printf("postman: WARNING: auto-PING delivered append failed for %s: %v\n", nodeKey, err)
+	}
+}
+
+func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discovery.NodeInfo, autoEnableSessions bool, now time.Time) {
+	if len(freshNodes) == 0 || rt.daemonState == nil {
+		return
+	}
+
+	projectedBySession := make(map[string]projection.AutoPingState)
+	for _, sessionDir := range runtimeSessionDirs(rt.sessionDir, freshNodes) {
+		state, ok, err := projection.ProjectAutoPingState(sessionDir)
+		if err != nil {
+			log.Printf("postman: WARNING: auto-PING replay failed for %s: %v\n", sessionDir, err)
+			continue
+		}
+		if ok {
+			projectedBySession[sessionDir] = state
+		}
+	}
+
+	nodeKeys := make([]string, 0, len(freshNodes))
+	for nodeKey := range freshNodes {
+		nodeKeys = append(nodeKeys, nodeKey)
+	}
+	sort.Strings(nodeKeys)
+
+	activeNodes := activeRuntimePingNodeNames(freshNodes)
+	livenessMap := map[string]bool{}
+	if rt.idleTracker != nil {
+		livenessMap = rt.idleTracker.GetLivenessMap()
+	}
+
+	for _, nodeKey := range nodeKeys {
+		nodeInfo := freshNodes[nodeKey]
+		if nodeInfo.IsPhony {
+			continue
+		}
+
+		state, ok := projectedBySession[nodeInfo.SessionDir]
+		if !ok {
+			continue
+		}
+		pending, exists := state.Nodes[nodeKey]
+		if !exists || !pending.Pending {
+			continue
+		}
+		if pending.NotBeforeAt != "" {
+			dueAt, err := time.Parse(time.RFC3339Nano, pending.NotBeforeAt)
+			if err == nil && now.Before(dueAt) {
+				continue
+			}
+		}
+		if owner := config.FindSessionOwner(rt.baseDir, nodeInfo.SessionName, rt.contextID); owner != "" {
+			continue
+		}
+
+		enabled := rt.daemonState.GetConfiguredSessionEnabled(nodeInfo.SessionName)
+		if !enabled && autoEnableSessions {
+			rt.daemonState.AutoEnableSessionIfNew(nodeInfo.SessionName)
+			enabled = rt.daemonState.GetConfiguredSessionEnabled(nodeInfo.SessionName)
+		}
+		if !enabled {
+			continue
+		}
+
+		tmpl := ""
+		if rt.cfg != nil {
+			tmpl = rt.cfg.DaemonMessageTemplate
+		}
+		result, err := ping.SendPingToNodeWithResult(nodeInfo, rt.contextID, nodeKey, tmpl, rt.cfg, activeNodes, livenessMap, rt.adjacency, freshNodes)
+		if err != nil {
+			log.Printf("postman: WARNING: auto-PING send failed for %s: %v\n", nodeKey, err)
+			continue
+		}
+		if !result.Delivered {
+			continue
+		}
+
+		rt.recordDeliveredAutoPing(nodeKey, nodeInfo, pending, now)
+	}
+}
+
+func activeRuntimePingNodeNames(nodes map[string]discovery.NodeInfo) []string {
+	activeNodes := make([]string, 0, len(nodes))
+	seen := make(map[string]bool)
+	for nodeName := range nodes {
+		simpleName := ping.ExtractSimpleName(nodeName)
+		if seen[simpleName] {
+			continue
+		}
+		seen[simpleName] = true
+		activeNodes = append(activeNodes, simpleName)
+	}
+	sort.Strings(activeNodes)
+	return activeNodes
 }

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -345,6 +346,81 @@ func TestDispatchPendingAutoPings_DeliversDuePendingPingAndClearsDebt(t *testing
 	}
 	if state.Nodes["review:worker"].Pending {
 		t.Fatal("pending auto-PING debt was not cleared after confirmed delivery")
+	}
+}
+
+func TestDispatchPendingAutoPings_QueueFullLeavesPendingWithoutDeadLetter(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.April, 26, 22, 2, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%61",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	recipientInbox := filepath.Join(sessionDir, "inbox", "worker")
+	if err := os.MkdirAll(recipientInbox, 0o700); err != nil {
+		t.Fatalf("MkdirAll recipient inbox: %v", err)
+	}
+	for i := range 20 {
+		name := filepath.Join(recipientInbox, fmt.Sprintf("20260426-2202%02d-rabcd-from-postman-to-worker.md", i))
+		if err := os.WriteFile(name, []byte("queued"), 0o600); err != nil {
+			t.Fatalf("WriteFile queued fixture %d: %v", i, err)
+		}
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg: &config.Config{
+			DaemonMessageTemplate: "PING {node} in {context_id}",
+			TmuxTimeout:           1.0,
+		},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		nodes: map[string]discovery.NodeInfo{
+			"review:worker": {
+				PaneID:      "%61",
+				SessionName: "review",
+				SessionDir:  sessionDir,
+			},
+		},
+	}
+	rt.daemonState.SetSessionEnabled("review", true)
+
+	rt.dispatchPendingAutoPings(rt.nodes, false, now)
+
+	deadEntries, err := os.ReadDir(filepath.Join(sessionDir, "dead-letter"))
+	if err != nil {
+		t.Fatalf("ReadDir dead-letter: %v", err)
+	}
+	if len(deadEntries) != 0 {
+		t.Fatalf("dead-letter entries = %d, want 0 for retryable queue-full auto-PING", len(deadEntries))
+	}
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if !state.Nodes["review:worker"].Pending {
+		t.Fatal("pending auto-PING debt was cleared even though delivery was blocked by a full inbox")
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -346,6 +347,73 @@ func TestDispatchPendingAutoPings_DeliversDuePendingPingAndClearsDebt(t *testing
 	}
 	if state.Nodes["review:worker"].Pending {
 		t.Fatal("pending auto-PING debt was not cleared after confirmed delivery")
+	}
+}
+
+func TestBootstrap_ReconcilesDuePendingAutoPingDebtAfterHydration(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.April, 27, 2, 50, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%63",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:     baseDir,
+		sessionDir:  sessionDir,
+		contextID:   "ctx-self",
+		selfSession: "review",
+		cfg: &config.Config{
+			DaemonMessageTemplate: "PING {node} in {context_id}",
+			TmuxTimeout:           1.0,
+		},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		events:      make(chan tui.DaemonEvent, 8),
+		nodes: map[string]discovery.NodeInfo{
+			"review:worker": {
+				PaneID:      "%63",
+				SessionName: "review",
+				SessionDir:  sessionDir,
+			},
+		},
+	}
+	rt.daemonState.SetSessionEnabled("review", true)
+
+	rt.bootstrap(context.Background())
+
+	entries, err := os.ReadDir(filepath.Join(sessionDir, "inbox", "worker"))
+	if err != nil {
+		t.Fatalf("ReadDir inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox entries after bootstrap = %d, want 1", len(entries))
+	}
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if state.Nodes["review:worker"].Pending {
+		t.Fatal("pending auto-PING debt was not cleared during bootstrap reconciliation")
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
 )
 
@@ -156,11 +158,20 @@ func TestPostEventGuard_DedupesByPathUntilFinished(t *testing.T) {
 	}
 }
 
-func TestDetectNewNodes_HonorsAutoEnableFlag(t *testing.T) {
+func TestDetectNewNodes_ReturnsOnlyNewRealNodesWithoutAutoEnable(t *testing.T) {
 	freshNodes := map[string]discovery.NodeInfo{
+		"self:known": {
+			SessionName: "self",
+			SessionDir:  t.TempDir(),
+		},
 		"foreign:worker": {
 			SessionName: "foreign",
 			SessionDir:  t.TempDir(),
+		},
+		"phony:helper": {
+			SessionName: "phony",
+			SessionDir:  t.TempDir(),
+			IsPhony:     true,
 		},
 	}
 	watcher, err := fsnotify.NewWatcher()
@@ -169,36 +180,22 @@ func TestDetectNewNodes_HonorsAutoEnableFlag(t *testing.T) {
 	}
 	defer func() { _ = watcher.Close() }()
 
-	rtDisabled := &daemonRuntime{
+	rt := &daemonRuntime{
 		cfg:         config.DefaultConfig(),
 		watcher:     watcher,
-		knownNodes:  make(map[string]bool),
+		knownNodes:  map[string]bool{"self:known": true},
 		watchedDirs: make(map[string]bool),
 		daemonState: NewDaemonState(0, "ctx-disabled"),
 		events:      make(chan tui.DaemonEvent, 1),
 	}
-	rtDisabled.detectNewNodes(freshNodes, false)
-	if rtDisabled.daemonState.GetConfiguredSessionEnabled("foreign") {
-		t.Fatal("detectNewNodes() auto-enabled a foreign session even though auto-enable was disabled")
-	}
+	newNodes := rt.detectNewNodes(freshNodes)
+	sort.Strings(newNodes)
 
-	watcherEnabled, err := fsnotify.NewWatcher()
-	if err != nil {
-		t.Fatalf("NewWatcher(enabled): %v", err)
+	if got, want := newNodes, []string{"foreign:worker"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("detectNewNodes() = %#v, want %#v", got, want)
 	}
-	defer func() { _ = watcherEnabled.Close() }()
-
-	rtEnabled := &daemonRuntime{
-		cfg:         config.DefaultConfig(),
-		watcher:     watcherEnabled,
-		knownNodes:  make(map[string]bool),
-		watchedDirs: make(map[string]bool),
-		daemonState: NewDaemonState(0, "ctx-enabled"),
-		events:      make(chan tui.DaemonEvent, 1),
-	}
-	rtEnabled.detectNewNodes(freshNodes, true)
-	if !rtEnabled.daemonState.GetConfiguredSessionEnabled("foreign") {
-		t.Fatal("detectNewNodes() did not auto-enable a foreign session when the auto-enable flag was true")
+	if rt.daemonState.GetConfiguredSessionEnabled("foreign") {
+		t.Fatal("detectNewNodes() auto-enabled a foreign session even though dispatch should own that decision")
 	}
 }
 
@@ -212,11 +209,252 @@ func TestHandleScanTick_SourceContractUsesAutoEnableNewSessionsConfig(t *testing
 	if !strings.Contains(source, "autoEnableSessions := config.BoolVal(rt.cfg.AutoEnableNewSessions, false)") {
 		t.Fatal("runtime.handleScanTick no longer derives session auto-enable from cfg.AutoEnableNewSessions")
 	}
-	if !strings.Contains(source, "rt.detectNewNodes(freshNodes, autoEnableSessions)") {
-		t.Fatal("runtime.handleScanTick no longer passes the config-backed auto-enable decision into detectNewNodes")
+	if !strings.Contains(source, "newNodes := rt.detectNewNodes(freshNodes)") {
+		t.Fatal("runtime.handleScanTick no longer collects newly discovered node keys from detectNewNodes")
 	}
-	if strings.Contains(source, "rt.detectNewNodes(freshNodes, true)") {
-		t.Fatal("runtime.handleScanTick still hardcodes foreign-session auto-enable")
+	if !strings.Contains(source, "rt.dispatchPendingAutoPings(freshNodes, autoEnableSessions") {
+		t.Fatal("runtime.handleScanTick no longer passes the config-backed auto-enable decision into dispatchPendingAutoPings")
+	}
+	if strings.Contains(source, "rt.detectNewNodes(freshNodes, autoEnableSessions)") {
+		t.Fatal("runtime.handleScanTick still pushes auto-enable side effects into detectNewNodes")
+	}
+}
+
+func TestDispatchPendingAutoPings_ForeignOwnedSessionStaysPendingAndDisabled(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "foreign")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+	installShadowJournalManager(sessionDir, "ctx-self", "foreign", time.Now())
+	t.Cleanup(journal.ClearProcessManager)
+
+	writeRuntimeLivePID(t, baseDir, "ctx-owner", "daemon")
+	if err := os.MkdirAll(filepath.Join(baseDir, "ctx-owner", "foreign"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(ctx-owner/foreign): %v", err)
+	}
+	installRuntimeSessionOwnerTmux(t, map[string]string{
+		"foreign": "ctx-owner:43210",
+	})
+
+	now := time.Date(2026, time.April, 26, 21, 55, 0, 0, time.UTC)
+	if err := journal.RecordProcessEvent(sessionDir, "foreign", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "foreign:worker",
+		SessionName:  "foreign",
+		NodeName:     "worker",
+		PaneID:       "%51",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:     baseDir,
+		contextID:   "ctx-self",
+		cfg:         &config.Config{DaemonMessageTemplate: "PING {node} in {context_id}"},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		nodes: map[string]discovery.NodeInfo{
+			"foreign:worker": {
+				PaneID:      "%51",
+				SessionName: "foreign",
+				SessionDir:  sessionDir,
+			},
+		},
+	}
+
+	rt.dispatchPendingAutoPings(rt.nodes, true, now)
+
+	if rt.daemonState.GetConfiguredSessionEnabled("foreign") {
+		t.Fatal("dispatchPendingAutoPings() auto-enabled a foreign-owned session")
+	}
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if !state.Nodes["foreign:worker"].Pending {
+		t.Fatal("pending auto-PING was cleared even though the session is foreign-owned")
+	}
+}
+
+func TestDispatchPendingAutoPings_DeliversDuePendingPingAndClearsDebt(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.April, 26, 22, 0, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%61",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg: &config.Config{
+			DaemonMessageTemplate: "PING {node} in {context_id}",
+			TmuxTimeout:           1.0,
+		},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		nodes: map[string]discovery.NodeInfo{
+			"review:worker": {
+				PaneID:      "%61",
+				SessionName: "review",
+				SessionDir:  sessionDir,
+			},
+		},
+	}
+	rt.daemonState.SetSessionEnabled("review", true)
+
+	rt.dispatchPendingAutoPings(rt.nodes, false, now)
+
+	entries, err := os.ReadDir(filepath.Join(sessionDir, "inbox", "worker"))
+	if err != nil {
+		t.Fatalf("ReadDir inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox entries = %d, want 1", len(entries))
+	}
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if state.Nodes["review:worker"].Pending {
+		t.Fatal("pending auto-PING debt was not cleared after confirmed delivery")
+	}
+}
+
+func TestDispatchPendingAutoPings_RespectsNotBeforeAt(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.April, 26, 22, 5, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%62",
+		Reason:       "discovered",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 30,
+		NotBeforeAt:  now.Add(30 * time.Second).Format(time.RFC3339Nano),
+	}, now); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg: &config.Config{
+			DaemonMessageTemplate: "PING {node} in {context_id}",
+			TmuxTimeout:           1.0,
+		},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		nodes: map[string]discovery.NodeInfo{
+			"review:worker": {
+				PaneID:      "%62",
+				SessionName: "review",
+				SessionDir:  sessionDir,
+			},
+		},
+	}
+	rt.daemonState.SetSessionEnabled("review", true)
+
+	rt.dispatchPendingAutoPings(rt.nodes, false, now)
+
+	inboxEntries, err := os.ReadDir(filepath.Join(sessionDir, "inbox"))
+	if err != nil {
+		t.Fatalf("ReadDir inbox root: %v", err)
+	}
+	if len(inboxEntries) != 0 {
+		t.Fatalf("inbox root entries = %d, want 0 before not_before_at", len(inboxEntries))
+	}
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if !state.Nodes["review:worker"].Pending {
+		t.Fatal("future pending auto-PING was cleared before not_before_at")
+	}
+}
+
+func installRuntimeSessionOwnerTmux(t *testing.T, owners map[string]string) {
+	t.Helper()
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	var builder strings.Builder
+	builder.WriteString("#!/bin/sh\n")
+	builder.WriteString("if [ \"$1 $2\" = \"show-options -gqv\" ]; then\n")
+	builder.WriteString("  case \"$3\" in\n")
+	keys := make([]string, 0, len(owners))
+	for key := range owners {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		builder.WriteString("    @a2a_session_on_" + key + ")\n")
+		builder.WriteString("      printf '%s\\n' '" + owners[key] + "'\n")
+		builder.WriteString("      exit 0\n")
+		builder.WriteString("      ;;\n")
+	}
+	builder.WriteString("    *)\n")
+	builder.WriteString("      exit 0\n")
+	builder.WriteString("      ;;\n")
+	builder.WriteString("  esac\n")
+	builder.WriteString("fi\n")
+	builder.WriteString("exit 1\n")
+
+	if err := os.WriteFile(scriptPath, []byte(builder.String()), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func writeRuntimeLivePID(t *testing.T, baseDir, contextName, sessionName string) {
+	t.Helper()
+
+	dir := filepath.Join(baseDir, contextName, sessionName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pid dir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "postman.pid"), []byte("1"), 0o600); err != nil {
+		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 }
 

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -919,16 +919,26 @@ func sendDeliveryNotification(target controlplane.Target, cfg *config.Config, ad
 }
 
 func DeliverSystemMessageDirect(filename string, nodeInfo discovery.NodeInfo, recipient, sender, contextID, content string, cfg *config.Config, adjacency map[string][]string, knownNodes map[string]discovery.NodeInfo, livenessMap map[string]bool) error {
-	return DeliverSystemMessageDirectToTarget(filename, controlplane.TargetForNode(recipient, nodeInfo), sender, contextID, content, cfg, adjacency, knownNodes, livenessMap)
+	_, err := DeliverSystemMessageDirectResult(filename, nodeInfo, recipient, sender, contextID, content, cfg, adjacency, knownNodes, livenessMap)
+	return err
+}
+
+func DeliverSystemMessageDirectResult(filename string, nodeInfo discovery.NodeInfo, recipient, sender, contextID, content string, cfg *config.Config, adjacency map[string][]string, knownNodes map[string]discovery.NodeInfo, livenessMap map[string]bool) (controlplane.SystemMessageResult, error) {
+	return DeliverSystemMessageDirectResultToTarget(filename, controlplane.TargetForNode(recipient, nodeInfo), sender, contextID, content, cfg, adjacency, knownNodes, livenessMap)
 }
 
 func DeliverSystemMessageDirectToTarget(filename string, target controlplane.Target, sender, contextID, content string, cfg *config.Config, adjacency map[string][]string, knownNodes map[string]discovery.NodeInfo, livenessMap map[string]bool) error {
+	_, err := DeliverSystemMessageDirectResultToTarget(filename, target, sender, contextID, content, cfg, adjacency, knownNodes, livenessMap)
+	return err
+}
+
+func DeliverSystemMessageDirectResultToTarget(filename string, target controlplane.Target, sender, contextID, content string, cfg *config.Config, adjacency map[string][]string, knownNodes map[string]discovery.NodeInfo, livenessMap map[string]bool) (controlplane.SystemMessageResult, error) {
 	if err := nodeaddr.Validate(target.ActorID); err != nil {
-		return fmt.Errorf("invalid recipient address: %w", err)
+		return controlplane.SystemMessageResult{}, fmt.Errorf("invalid recipient address: %w", err)
 	}
 	adapter, err := controlplane.DefaultHandAdapter(target)
 	if err != nil {
-		return fmt.Errorf("selecting hand adapter: %w", err)
+		return controlplane.SystemMessageResult{}, fmt.Errorf("selecting hand adapter: %w", err)
 	}
 	result, err := adapter.DeliverSystemMessage(target, controlplane.SystemMessageDelivery{
 		Filename:        filename,
@@ -939,16 +949,16 @@ func DeliverSystemMessageDirectToTarget(filename string, target controlplane.Tar
 		QueueFullSuffix: dlSuffixQueueFull,
 	})
 	if err != nil {
-		return err
+		return controlplane.SystemMessageResult{}, err
 	}
 	if !result.Delivered {
-		return nil
+		return result, nil
 	}
 
 	notificationPath := target.PostPath(filename)
 	sendDeliveryNotification(target, cfg, adjacency, knownNodes, contextID, target.ActorID, sender, target.SessionName, notificationPath, livenessMap)
 	log.Printf("📬 postman: delivered %s -> %s\n", filename, target.ActorID)
-	return nil
+	return result, nil
 }
 
 // countInboxMessages returns the number of .md files in an inbox directory.

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -672,7 +672,7 @@ func TestMoveToDeadLetterRejectsSymlinkDestination(t *testing.T) {
 	}
 }
 
-func TestDeliverSystemMessageDirectRejectsSymlinkedDeadLetterDir(t *testing.T) {
+func TestDeliverSystemMessageDirectQueueFullSkipsDeadLetterDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionDir := filepath.Join(tmpDir, "test")
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
@@ -717,11 +717,8 @@ func TestDeliverSystemMessageDirectRejectsSymlinkedDeadLetterDir(t *testing.T) {
 		map[string]discovery.NodeInfo{},
 		map[string]bool{},
 	)
-	if err == nil {
-		t.Fatal("expected symlink rejection error, got nil")
-	}
-	if !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("expected symlink rejection error, got: %v", err)
+	if err != nil {
+		t.Fatalf("expected queue-full direct delivery to stay undelivered without touching dead-letter, got: %v", err)
 	}
 
 	escapedPath := filepath.Join(escapedDir, "20260201-040000-from-daemon-to-worker-dl-queue-full.md")

--- a/internal/ping/ping.go
+++ b/internal/ping/ping.go
@@ -26,6 +26,11 @@ func ExtractSimpleName(fullName string) string {
 // SendPingToNode sends a PING message to a specific node.
 // nodeName should be the full session-prefixed name (session:node).
 func SendPingToNode(nodeInfo discovery.NodeInfo, contextID, nodeName, tmpl string, cfg *config.Config, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo) error {
+	_, err := SendPingToNodeWithResult(nodeInfo, contextID, nodeName, tmpl, cfg, activeNodes, livenessMap, adjacency, nodes)
+	return err
+}
+
+func SendPingToNodeWithResult(nodeInfo discovery.NodeInfo, contextID, nodeName, tmpl string, cfg *config.Config, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo) (controlplane.SystemMessageResult, error) {
 	target := controlplane.TargetForNode(nodeName, nodeInfo)
 	simpleName := target.ActorID
 	sourceSessionName := target.SessionName
@@ -36,7 +41,7 @@ func SendPingToNode(nodeInfo discovery.NodeInfo, contextID, nodeName, tmpl strin
 	// Use simple name in filename (Issue #33: keep filenames simple)
 	filename, err := message.GenerateFilename(ts, "postman", simpleName, sourceSessionName)
 	if err != nil {
-		return fmt.Errorf("generating filename: %w", err)
+		return controlplane.SystemMessageResult{}, fmt.Errorf("generating filename: %w", err)
 	}
 	postPath := target.PostPath(filename)
 
@@ -51,5 +56,5 @@ func SendPingToNode(nodeInfo discovery.NodeInfo, contextID, nodeName, tmpl strin
 		"role_content": roleContent,
 	})
 
-	return message.DeliverSystemMessageDirectToTarget(filename, target, "postman", contextID, content, cfg, adjacency, nodes, livenessMap)
+	return message.DeliverSystemMessageDirectResultToTarget(filename, target, "postman", contextID, content, cfg, adjacency, nodes, livenessMap)
 }

--- a/internal/ping/ping_test.go
+++ b/internal/ping/ping_test.go
@@ -239,6 +239,61 @@ func TestSendPingToNode_DeliveryFlow(t *testing.T) {
 	}
 }
 
+func TestSendPingToNodeWithResult_QueueFullDoesNotCountAsDelivered(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "queue-full-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	nodeInfo := discovery.NodeInfo{
+		PaneID:      "%100",
+		SessionName: "queue-full-session",
+		SessionDir:  sessionDir,
+	}
+	cfg := &config.Config{
+		TmuxTimeout:           5.0,
+		DaemonMessageTemplate: "PING {node} in {context_id}",
+	}
+
+	recipientInbox := filepath.Join(sessionDir, "inbox", "worker")
+	if err := os.MkdirAll(recipientInbox, 0o700); err != nil {
+		t.Fatalf("MkdirAll recipient inbox: %v", err)
+	}
+	for i := range 20 {
+		name := filepath.Join(recipientInbox, fmt.Sprintf("20260426-2145%02d-rabcd-from-postman-to-worker.md", i))
+		if err := os.WriteFile(name, []byte("queued"), 0o600); err != nil {
+			t.Fatalf("WriteFile queued fixture %d: %v", i, err)
+		}
+	}
+
+	result, err := SendPingToNodeWithResult(
+		nodeInfo,
+		"test-ctx",
+		"queue-full-session:worker",
+		cfg.DaemonMessageTemplate,
+		cfg,
+		[]string{"worker"},
+		map[string]bool{},
+		map[string][]string{},
+		map[string]discovery.NodeInfo{},
+	)
+	if err != nil {
+		t.Fatalf("SendPingToNodeWithResult() error = %v", err)
+	}
+	if result.Delivered {
+		t.Fatal("SendPingToNodeWithResult() delivered = true, want false when inbox is full")
+	}
+
+	deadEntries, err := os.ReadDir(filepath.Join(sessionDir, "dead-letter"))
+	if err != nil {
+		t.Fatalf("ReadDir dead-letter: %v", err)
+	}
+	if len(deadEntries) != 1 {
+		t.Fatalf("dead-letter entries = %d, want 1", len(deadEntries))
+	}
+}
+
 func TestSendPingToNode_NotificationAttemptedOnDelivery(t *testing.T) {
 	tmpDir := t.TempDir()
 	argsFile := filepath.Join(tmpDir, "tmux-args.txt")

--- a/internal/ping/ping_test.go
+++ b/internal/ping/ping_test.go
@@ -239,7 +239,7 @@ func TestSendPingToNode_DeliveryFlow(t *testing.T) {
 	}
 }
 
-func TestSendPingToNodeWithResult_QueueFullDoesNotCountAsDelivered(t *testing.T) {
+func TestSendPingToNodeWithResult_QueueFullReturnsUndeliveredWithoutDeadLetter(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionDir := filepath.Join(tmpDir, "queue-full-session")
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
@@ -289,8 +289,8 @@ func TestSendPingToNodeWithResult_QueueFullDoesNotCountAsDelivered(t *testing.T)
 	if err != nil {
 		t.Fatalf("ReadDir dead-letter: %v", err)
 	}
-	if len(deadEntries) != 1 {
-		t.Fatalf("dead-letter entries = %d, want 1", len(deadEntries))
+	if len(deadEntries) != 0 {
+		t.Fatalf("dead-letter entries = %d, want 0 for retryable queue-full auto-PING", len(deadEntries))
 	}
 }
 

--- a/internal/projection/auto_ping_state.go
+++ b/internal/projection/auto_ping_state.go
@@ -1,0 +1,105 @@
+package projection
+
+import (
+	"encoding/json"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+)
+
+const (
+	AutoPingPendingEventType   = "auto_ping_pending"
+	AutoPingDeliveredEventType = "auto_ping_delivered"
+)
+
+type AutoPingEventPayload struct {
+	NodeKey      string  `json:"node_key"`
+	SessionName  string  `json:"session_name,omitempty"`
+	NodeName     string  `json:"node_name,omitempty"`
+	PaneID       string  `json:"pane_id,omitempty"`
+	Reason       string  `json:"reason,omitempty"`
+	TriggeredAt  string  `json:"triggered_at,omitempty"`
+	DelaySeconds float64 `json:"delay_seconds,omitempty"`
+	NotBeforeAt  string  `json:"not_before_at,omitempty"`
+	DeliveredAt  string  `json:"delivered_at,omitempty"`
+}
+
+type AutoPingNodeState struct {
+	NodeKey      string
+	SessionName  string
+	NodeName     string
+	PaneID       string
+	Reason       string
+	TriggeredAt  string
+	DelaySeconds float64
+	NotBeforeAt  string
+	DeliveredAt  string
+	Pending      bool
+}
+
+type AutoPingState struct {
+	Nodes map[string]AutoPingNodeState
+}
+
+func ProjectAutoPingState(sessionDir string) (AutoPingState, bool, error) {
+	state, ok := loadCurrentSessionState(sessionDir)
+	if !ok {
+		return AutoPingState{}, false, nil
+	}
+
+	events, err := journal.Replay(sessionDir)
+	if err != nil || len(events) == 0 {
+		return AutoPingState{}, false, nil
+	}
+
+	projected := AutoPingState{
+		Nodes: make(map[string]AutoPingNodeState),
+	}
+	sawLease := false
+	sawResolution := false
+
+	for _, event := range events {
+		if event.SessionKey != state.SessionKey || event.Generation != state.Generation {
+			continue
+		}
+
+		switch event.Type {
+		case "lease_acquired":
+			sawLease = true
+			continue
+		case "session_resolved":
+			sawResolution = true
+			continue
+		case AutoPingPendingEventType, AutoPingDeliveredEventType:
+		default:
+			continue
+		}
+
+		var payload AutoPingEventPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			return AutoPingState{}, false, nil
+		}
+		if payload.NodeKey == "" {
+			return AutoPingState{}, false, nil
+		}
+
+		nodeState := AutoPingNodeState{
+			NodeKey:      payload.NodeKey,
+			SessionName:  payload.SessionName,
+			NodeName:     payload.NodeName,
+			PaneID:       payload.PaneID,
+			Reason:       payload.Reason,
+			TriggeredAt:  payload.TriggeredAt,
+			DelaySeconds: payload.DelaySeconds,
+			NotBeforeAt:  payload.NotBeforeAt,
+			DeliveredAt:  payload.DeliveredAt,
+			Pending:      event.Type == AutoPingPendingEventType,
+		}
+		projected.Nodes[payload.NodeKey] = nodeState
+	}
+
+	if !sawLease || !sawResolution {
+		return AutoPingState{}, false, nil
+	}
+
+	return projected, true, nil
+}

--- a/internal/projection/auto_ping_state_test.go
+++ b/internal/projection/auto_ping_state_test.go
@@ -1,0 +1,162 @@
+package projection
+
+import (
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+)
+
+func TestProjectAutoPingState_FallsBackWhenHistoryIsMissing(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	got, ok, err := ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("ProjectAutoPingState() ok = true, want false with %#v", got)
+	}
+}
+
+func TestProjectAutoPingState_ReplaysCurrentGeneration(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.April, 26, 21, 45, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingPendingEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%12",
+		Reason:       "discovered",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 5,
+		NotBeforeAt:  now.Add(5 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("AppendEvent(pending worker): %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingPendingEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:critic",
+		SessionName:  "review",
+		NodeName:     "critic",
+		PaneID:       "%13",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(pending critic): %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:critic",
+		SessionName:  "review",
+		NodeName:     "critic",
+		PaneID:       "%13",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(3 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(delivered critic): %v", err)
+	}
+
+	got, ok, err := ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+
+	worker := got.Nodes["review:worker"]
+	if !worker.Pending {
+		t.Fatal("worker pending = false, want true")
+	}
+	if worker.PaneID != "%12" {
+		t.Fatalf("worker PaneID = %q, want %q", worker.PaneID, "%12")
+	}
+	if worker.NotBeforeAt != now.Add(5*time.Second).Format(time.RFC3339Nano) {
+		t.Fatalf("worker NotBeforeAt = %q, want %q", worker.NotBeforeAt, now.Add(5*time.Second).Format(time.RFC3339Nano))
+	}
+
+	critic := got.Nodes["review:critic"]
+	if critic.Pending {
+		t.Fatal("critic pending = true, want false after delivered event")
+	}
+	if critic.DeliveredAt != now.Add(3*time.Second).Format(time.RFC3339Nano) {
+		t.Fatalf("critic DeliveredAt = %q, want %q", critic.DeliveredAt, now.Add(3*time.Second).Format(time.RFC3339Nano))
+	}
+}
+
+func TestProjectAutoPingState_ReplaysAcrossLeaseResume(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.April, 26, 21, 50, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter(first) error = %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingPendingEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%20",
+		Reason:       "discovered",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 3,
+		NotBeforeAt:  now.Add(3 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("AppendEvent(first pending): %v", err)
+	}
+
+	resumedWriter, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 202, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("OpenShadowWriter(second) error = %v", err)
+	}
+	if _, err := resumedWriter.AppendEvent(AutoPingPendingEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%21",
+		Reason:       "pane_restart",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 3,
+		NotBeforeAt:  now.Add(3 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(second pending): %v", err)
+	}
+	if _, err := resumedWriter.AppendEvent(AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%21",
+		Reason:       "pane_restart",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 3,
+		NotBeforeAt:  now.Add(3 * time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(4 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(4*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(delivered): %v", err)
+	}
+
+	got, ok, err := ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+
+	worker := got.Nodes["review:worker"]
+	if worker.Pending {
+		t.Fatal("worker pending = true, want false after replayed delivery")
+	}
+	if worker.PaneID != "%21" {
+		t.Fatalf("worker PaneID = %q, want %q", worker.PaneID, "%21")
+	}
+}


### PR DESCRIPTION
## Summary

- add journal-backed auto-PING pending and delivered replay for new-node and replacement-pane discovery
- make direct daemon PING delivery result-aware so queue-full stays retryable instead of counting as success
- add `auto_ping_delay_seconds`, update docs, and cover replay, ownership, delay, and collision behavior with tests

## Verification

- go test ./internal/projection ./internal/ping ./internal/daemon
- nix flake check
- nix build

Closes #391.
