### PR TITLE
chore(envelope): remove stale resolveNodeName follow-up (#148)

### DIFF
--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -18,9 +18,6 @@ import (
 //
 // tmpl is caller-provided: pass cfg.DaemonMessageTemplate for daemon PING
 // or cfg.NotificationTemplate for pane notification hints.
-//
-// NOTE: resolveNodeName is inlined here as accepted debt from #141.
-// Follow-up: consolidate into internal/discovery — see issue #148.
 func BuildEnvelope(
 	cfg *config.Config,
 	tmpl string,


### PR DESCRIPTION
## Summary

Related to #148.

- Remove the obsolete #148 debt note from `internal/envelope/envelope.go`.
- Keep behavior unchanged; the envelope builder already uses `discovery.ResolveNodeName`.

## Verification

- `go test ./internal/envelope`
- `nix fmt -- --fail-on-change`
- `nix flake check`
- `nix build`
- deprecated-reference scan over `README.md` and `skills/*/SKILL.md`
