### PR TITLE
fix: resolve version from Go build metadata

### DIFF
--- a/internal/cli/helptext/version.txt
+++ b/internal/cli/helptext/version.txt
@@ -9,4 +9,8 @@ Output:
   JSON
 
 Shape:
-  {"name":"tmux-a2a-postman","version":"dev","commit":"unknown"}
+  {"name":"tmux-a2a-postman","version":"vX.Y.Z","commit":"unknown"}
+
+Tagged module installs populate version from Go build info when release ldflags
+are not present. Commit is populated from release ldflags or VCS build info
+when available.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,70 @@
 package version
 
+import "runtime/debug"
+
+const (
+	defaultVersion = "dev"
+	defaultCommit  = "unknown"
+	develVersion   = "(devel)"
+)
+
 // Version is the current version of tmux-a2a-postman
 // Set via ldflags during build: -X github.com/i9wa4/tmux-a2a-postman/internal/version.Version=x.y.z
-var Version = "dev"
+var Version = defaultVersion
 
 // Commit is the git commit hash
 // Set via ldflags during build: -X github.com/i9wa4/tmux-a2a-postman/internal/version.Commit=abc123
-var Commit = "unknown"
+var Commit = defaultCommit
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	Version, Commit = resolveBuildInfo(Version, Commit, info)
+}
+
+func resolveBuildInfo(currentVersion, currentCommit string, info *debug.BuildInfo) (string, string) {
+	if info == nil {
+		return currentVersion, currentCommit
+	}
+
+	resolvedVersion := currentVersion
+	if currentVersion == defaultVersion {
+		if moduleVersion := buildInfoModuleVersion(info); moduleVersion != "" {
+			resolvedVersion = moduleVersion
+		}
+	}
+
+	resolvedCommit := currentCommit
+	if currentCommit == defaultCommit {
+		if revision := buildInfoVCSRevision(info); revision != "" {
+			resolvedCommit = shortRevision(revision)
+		}
+	}
+
+	return resolvedVersion, resolvedCommit
+}
+
+func buildInfoModuleVersion(info *debug.BuildInfo) string {
+	if info.Main.Version == "" || info.Main.Version == develVersion {
+		return ""
+	}
+	return info.Main.Version
+}
+
+func buildInfoVCSRevision(info *debug.BuildInfo) string {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return ""
+}
+
+func shortRevision(revision string) string {
+	if len(revision) <= 7 {
+		return revision
+	}
+	return revision[:7]
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,66 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveBuildInfo_UsesTaggedModuleVersionWhenLDFlagsAreDefault(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Path:    "github.com/i9wa4/tmux-a2a-postman",
+			Version: "v1.2.3",
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildInfo(defaultVersion, defaultCommit, info)
+	if gotVersion == defaultVersion {
+		t.Fatalf("version stayed at default %q; tagged module installs must report the module version", gotVersion)
+	}
+	if gotVersion != "v1.2.3" {
+		t.Fatalf("version = %q, want module version", gotVersion)
+	}
+	if gotCommit != defaultCommit {
+		t.Fatalf("commit = %q, want default commit when no VCS revision is embedded", gotCommit)
+	}
+}
+
+func TestResolveBuildInfo_UsesVCSRevisionWhenLDFlagsAreDefault(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Path:    "github.com/i9wa4/tmux-a2a-postman",
+			Version: develVersion,
+		},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildInfo(defaultVersion, defaultCommit, info)
+	if gotVersion != defaultVersion {
+		t.Fatalf("version = %q, want default version for devel module builds", gotVersion)
+	}
+	if gotCommit != "0123456" {
+		t.Fatalf("commit = %q, want short VCS revision", gotCommit)
+	}
+}
+
+func TestResolveBuildInfo_KeepsLDFlagValues(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Path:    "github.com/i9wa4/tmux-a2a-postman",
+			Version: "v1.2.3",
+		},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildInfo("v9.9.9", "fedcba9", info)
+	if gotVersion != "v9.9.9" {
+		t.Fatalf("version = %q, want ldflag version", gotVersion)
+	}
+	if gotCommit != "fedcba9" {
+		t.Fatalf("commit = %q, want ldflag commit", gotCommit)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve release versions from Go build metadata when ldflags keep default values.
- Preserve explicit ldflag-provided version and commit values.
- Add regression coverage for tagged module version and VCS revision fallback behavior.

## Changed Files
- internal/version/version.go
- internal/version/version_test.go
- internal/cli/helptext/version.txt

## Verification
- go test ./internal/version ./internal/cli
- go test ./...
- nix flake check
- nix build