### PR TITLE
Add startup readiness ping lock

### DIFF
--- a/docs/ping-events.md
+++ b/docs/ping-events.md
@@ -52,8 +52,9 @@ sends the normal pane notification when inbox delivery succeeds.
   command first activates that session for this daemon.
 - Source: user/operator.
 - Recipients: every discovered node in the selected tmux session.
-- Notes: not limited by startup `ui_node`. If the session is owned by another
-  daemon, the send is blocked.
+- Notes: not limited by startup `ui_node`. During the startup auto-PING delay,
+  the TUI disables `p` and shows a readiness countdown instead of dispatching a
+  manual PING. If the session is owned by another daemon, the send is blocked.
 
 ### 1.5. Compaction Recovery
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -61,6 +61,8 @@ type DaemonEvent struct {
 // DaemonEventMsg wraps DaemonEvent for tea.Msg interface.
 type DaemonEventMsg DaemonEvent
 
+type startupReadinessTickMsg time.Time
+
 // TUICommand represents a command from TUI to the daemon.
 // Issue #47: Added for manual PING functionality.
 type TUICommand struct {
@@ -96,6 +98,9 @@ type Model struct {
 	nodeCount     int
 	lastEvent     string
 	quitting      bool
+
+	startupPingReadyAt  time.Time
+	startupReadinessNow time.Time
 
 	// Config reference (for node state thresholds)
 	config *config.Config
@@ -144,6 +149,72 @@ func moveSelectedSession(sessions []SessionInfo, selected, delta int) int {
 	}
 
 	return candidate
+}
+
+func startupPingLockDuration(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.AutoPingDelaySeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.AutoPingDelaySeconds * float64(time.Second))
+}
+
+func ceilSeconds(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	seconds := d / time.Second
+	if d%time.Second != 0 {
+		seconds++
+	}
+	return seconds * time.Second
+}
+
+func (m Model) readinessNow() time.Time {
+	if !m.startupReadinessNow.IsZero() {
+		return m.startupReadinessNow
+	}
+	return time.Now()
+}
+
+func (m Model) startupPingLocked() bool {
+	if m.startupPingReadyAt.IsZero() {
+		return false
+	}
+	return m.readinessNow().Before(m.startupPingReadyAt)
+}
+
+func (m Model) startupPingRemaining() time.Duration {
+	if !m.startupPingLocked() {
+		return 0
+	}
+	return ceilSeconds(m.startupPingReadyAt.Sub(m.readinessNow()))
+}
+
+func formatStartupPingRemaining(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	return fmt.Sprintf("%.0fs", d.Seconds())
+}
+
+func (m Model) startupReadinessTickCmd() tea.Cmd {
+	if !m.startupPingLocked() {
+		return nil
+	}
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		return startupReadinessTickMsg(t)
+	})
+}
+
+func (m Model) startupReadinessNotice() string {
+	remaining := m.startupPingRemaining()
+	if remaining <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"startup readiness: PING locked for %s while startup auto-PING discovery opens",
+		formatStartupPingRemaining(remaining),
+	)
 }
 
 func (m *Model) refreshVisibleSessions() {
@@ -230,32 +301,40 @@ func (m *Model) updateNodeStatesFromActivity(nodeStatesRaw interface{}) {
 // Issue #45: Removed messageList and selectedMsg initialization
 // Issue #47: Added tuiCommands channel parameter
 func InitialModel(daemonEvents <-chan DaemonEvent, tuiCommands chan<- TUICommand, cfg *config.Config, ownContextID string) Model {
+	now := time.Now()
+	startupPingReadyAt := time.Time{}
+	if lockDuration := startupPingLockDuration(cfg); lockDuration > 0 {
+		startupPingReadyAt = now.Add(lockDuration)
+	}
+
 	return Model{
-		width:             80,              // Default width (Issue #35)
-		height:            24,              // Default height (Issue #35)
-		sessions:          []SessionInfo{}, // Issue #35: Requirement 3
-		knownSessions:     []SessionInfo{},
-		selectedSession:   0,                         // Issue #35: Requirement 3
-		sessionNodes:      make(map[string][]string), // Issue #59: Session-node mapping
-		sessionSnapshots:  make(map[string]status.SessionStatus),
-		nodeStates:        make(map[string]string), // Issue #55: Node state tracking
-		unreadInboxCounts: make(map[string]int),
-		config:            cfg,
-		daemonEvents:      daemonEvents,
-		tuiCommands:       tuiCommands,    // Issue #47: Command channel
-		events:            []EventEntry{}, // Issue #59: Session-tagged events
-		sessionStatus:     map[string]string{},
-		generalStatus:     "Starting...",
-		nodeCount:         0,
-		lastEvent:         "",
-		quitting:          false,
-		ownContextID:      ownContextID,
+		width:               80,              // Default width (Issue #35)
+		height:              24,              // Default height (Issue #35)
+		sessions:            []SessionInfo{}, // Issue #35: Requirement 3
+		knownSessions:       []SessionInfo{},
+		selectedSession:     0,                         // Issue #35: Requirement 3
+		sessionNodes:        make(map[string][]string), // Issue #59: Session-node mapping
+		sessionSnapshots:    make(map[string]status.SessionStatus),
+		nodeStates:          make(map[string]string), // Issue #55: Node state tracking
+		unreadInboxCounts:   make(map[string]int),
+		config:              cfg,
+		daemonEvents:        daemonEvents,
+		tuiCommands:         tuiCommands,    // Issue #47: Command channel
+		events:              []EventEntry{}, // Issue #59: Session-tagged events
+		sessionStatus:       map[string]string{},
+		generalStatus:       "Starting...",
+		nodeCount:           0,
+		lastEvent:           "",
+		quitting:            false,
+		startupPingReadyAt:  startupPingReadyAt,
+		startupReadinessNow: now,
+		ownContextID:        ownContextID,
 	}
 }
 
 // Init initializes the TUI and subscribes to daemon events.
 func (m Model) Init() tea.Cmd {
-	return waitForDaemonEvent(m.daemonEvents)
+	return tea.Batch(waitForDaemonEvent(m.daemonEvents), m.startupReadinessTickCmd())
 }
 
 // waitForDaemonEvent waits for the next daemon event from the channel.
@@ -279,6 +358,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		return m, nil
 
+	case startupReadinessTickMsg:
+		m.startupReadinessNow = time.Time(msg)
+		return m, m.startupReadinessTickCmd()
+
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -293,6 +376,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "p":
 			if m.selectedSession >= 0 && m.selectedSession < len(m.sessions) {
 				sess := m.sessions[m.selectedSession]
+				if m.startupPingLocked() {
+					remaining := formatStartupPingRemaining(m.startupPingRemaining())
+					m.sessionStatus[sess.Name] = fmt.Sprintf("Ping locked: startup readiness %s", remaining)
+					log.Printf("[PING] keypress ignored for session %q during startup readiness (%s remaining)\n", sess.Name, remaining)
+					return m, nil
+				}
 				m.sessionStatus[sess.Name] = "Sending ping..."
 				log.Printf("[PING] keypress received for session %q\n", sess.Name)
 				if m.tuiCommands != nil {
@@ -699,7 +788,15 @@ func (m Model) View() tea.View {
 	m.selectedSession = clampSelectedSession(m.sessions, m.selectedSession)
 
 	var b strings.Builder
-	b.WriteString("tmux-a2a-postman " + version.Version + "   [up/down:move] [p:ping] [q:quit]\n\n")
+	pingHint := "[p:ping]"
+	if m.startupPingLocked() {
+		pingHint = fmt.Sprintf("[p:locked %s]", formatStartupPingRemaining(m.startupPingRemaining()))
+	}
+	b.WriteString("tmux-a2a-postman " + version.Version + "   [up/down:move] " + pingHint + " [q:quit]\n")
+	if notice := m.startupReadinessNotice(); notice != "" {
+		b.WriteString(notice + "\n")
+	}
+	b.WriteString("\n")
 	b.WriteString(m.renderSessionsSection())
 	b.WriteString("\n")
 	b.WriteString(m.renderNodesSection())

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
@@ -338,6 +339,92 @@ func TestTUI_Update_DefaultSurfacePingDispatchesCommand(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected send_ping command after pressing p")
+	}
+}
+
+func TestTUI_Update_DefaultSurfacePingLockedDuringStartupReadiness(t *testing.T) {
+	ch := make(chan DaemonEvent, 10)
+	defer close(ch)
+	commands := make(chan TUICommand, 1)
+
+	cfg := config.DefaultConfig()
+	cfg.AutoPingDelaySeconds = 20
+	m := InitialModel(ch, commands, cfg, "")
+	startedAt := time.Date(2026, time.May, 17, 23, 45, 0, 0, time.UTC)
+	m.startupReadinessNow = startedAt
+	m.startupPingReadyAt = startedAt.Add(20 * time.Second)
+	m.sessions = []SessionInfo{
+		{Name: "main", Enabled: true},
+	}
+	m.selectedSession = 0
+
+	newModel, cmd := m.Update(tea.KeyPressMsg{Text: "p", Code: 'p'})
+	if cmd != nil {
+		t.Fatalf("Update(p) returned cmd %v, want nil", cmd)
+	}
+	m = newModel.(Model)
+
+	if got := m.sessionStatus["main"]; got != "Ping locked: startup readiness 20s" {
+		t.Fatalf("sessionStatus[main] = %q, want startup readiness lock", got)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("locked startup ping emitted %d command(s), want 0", len(commands))
+	}
+}
+
+func TestTUI_Update_DefaultSurfacePingDispatchesAfterStartupReadiness(t *testing.T) {
+	ch := make(chan DaemonEvent, 10)
+	defer close(ch)
+	commands := make(chan TUICommand, 1)
+
+	cfg := config.DefaultConfig()
+	cfg.AutoPingDelaySeconds = 20
+	m := InitialModel(ch, commands, cfg, "")
+	startedAt := time.Date(2026, time.May, 17, 23, 45, 0, 0, time.UTC)
+	m.startupReadinessNow = startedAt.Add(20 * time.Second)
+	m.startupPingReadyAt = startedAt.Add(20 * time.Second)
+	m.sessions = []SessionInfo{
+		{Name: "main", Enabled: true},
+	}
+	m.selectedSession = 0
+
+	newModel, cmd := m.Update(tea.KeyPressMsg{Text: "p", Code: 'p'})
+	if cmd != nil {
+		t.Fatalf("Update(p) returned cmd %v, want nil", cmd)
+	}
+	m = newModel.(Model)
+
+	if got := m.sessionStatus["main"]; got != "Sending ping..." {
+		t.Fatalf("sessionStatus[main] = %q, want %q", got, "Sending ping...")
+	}
+	select {
+	case sent := <-commands:
+		if sent.Type != "send_ping" || sent.Target != "main" {
+			t.Fatalf("sent command = %#v, want send_ping main", sent)
+		}
+	default:
+		t.Fatal("expected send_ping command after startup readiness")
+	}
+}
+
+func TestTUI_View_ShowsStartupReadinessCountdown(t *testing.T) {
+	ch := make(chan DaemonEvent, 10)
+	defer close(ch)
+
+	cfg := config.DefaultConfig()
+	cfg.AutoPingDelaySeconds = 20
+	m := InitialModel(ch, nil, cfg, "")
+	startedAt := time.Date(2026, time.May, 17, 23, 45, 0, 0, time.UTC)
+	m.startupReadinessNow = startedAt.Add(8 * time.Second)
+	m.startupPingReadyAt = startedAt.Add(20 * time.Second)
+
+	view := m.View().Content
+
+	if !strings.Contains(view, "[p:locked 12s]") {
+		t.Fatalf("view missing locked p header countdown: %q", view)
+	}
+	if !strings.Contains(view, "startup readiness: PING locked for 12s") {
+		t.Fatalf("view missing startup readiness countdown notice: %q", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- lock the TUI `p` ping action during startup auto-PING readiness
- show `[p:locked Ns]` and a startup readiness countdown line
- document operator-facing startup PING lock behavior in `docs/ping-events.md`

## Tests
- `TestTUI_Update_DefaultSurfacePingLockedDuringStartupReadiness` covers early `p` lock behavior and verifies no `send_ping` command is emitted
- `TestTUI_Update_DefaultSurfacePingDispatchesAfterStartupReadiness` covers `p` dispatch after readiness expires
- `TestTUI_View_ShowsStartupReadinessCountdown` covers the header lock hint and readiness countdown display

## Verification
- `go test ./internal/tui`
- `go test ./...`
- `nix flake check`
- `nix build`