### PR TITLE
Fix auto-ping contact hints before liveness

### DIFF
--- a/docs/design/notification.md
+++ b/docs/design/notification.md
@@ -121,6 +121,16 @@ TOML `role` text, only the first non-empty role line is shown as the summary;
 full node templates are not dumped into the contact list. Custom footers can
 keep using `{can_talk_to}` for the legacy comma-separated node list or
 `{contacts_section}` for the role-aware Markdown list.
+
+For daemon PING bodies, this contact list is an informational hint from
+configured or discovered same-session topology, effectively the `postman.md`
+routes known to the daemon. It is not a live-health guarantee. Startup PINGs
+can render configured contacts before adjacent nodes have confirmed liveness,
+so `- none` means no configured or discovered contact is known for that
+recipient, not merely that known contacts are currently non-live. Delivery and
+pane notification behavior remains liveness-aware and separate from daemon PING
+body rendering.
+
 Daemon PING mail uses the same generated-envelope pattern with
 `Recipient Instructions` and `Daemon Message`.
 

--- a/docs/ping-events.md
+++ b/docs/ping-events.md
@@ -73,7 +73,24 @@ because the target inbox queue is full, the pending auto-PING remains in the
 journal and the daemon tries again on later scans. One in-flight auto-PING per
 node is allowed at a time.
 
-## 2. Non-PING Traffic
+## 2. Contact Hints
+
+Daemon PING bodies include a `You can talk to:` contact hint. Treat this as
+informational route context derived from configured or discovered same-session
+topology, effectively the `postman.md` conversation edges known to the daemon.
+It is not a live-health guarantee.
+
+Startup auto-PINGs can arrive before adjacent nodes have confirmed liveness, so
+PING body rendering must not hide configured contacts only because liveness is
+still unknown. Configured contacts can therefore appear before liveness is
+confirmed. A `- none` contact hint means no configured or discovered adjacent
+contact is known for the recipient, not merely that every adjacent contact is
+currently non-live.
+
+Actual delivery and pane notification behavior remains separate from this body
+rendering and continues to use liveness-aware session state.
+
+## 3. Non-PING Traffic
 
 Some traffic can look like ping noise but does not create daemon PING mail.
 
@@ -91,7 +108,7 @@ Some traffic can look like ping noise but does not create daemon PING mail.
   directories. The activation step itself does not send mail; discovery can
   queue a later auto-PING.
 
-## 3. `skill_path.inject`
+## 4. `skill_path.inject`
 
 `skill_path.inject` controls where generated skill catalogs are appended. It
 does not create new ping events.
@@ -108,7 +125,7 @@ PING catalog paths must be explicit user-level paths such as `~/...` or
 absolute paths. Repo-local relative paths remain valid only for normal role
 catalogs.
 
-## 4. Noise Checks
+## 5. Noise Checks
 
 Expected PING mail should line up with one of the events above. Check the
 stored message metadata and daemon logs before treating it as suspicious:

--- a/internal/ping/ping.go
+++ b/internal/ping/ping.go
@@ -54,7 +54,9 @@ func SendPingToNodeWithOptions(nodeInfo discovery.NodeInfo, contextID, nodeName,
 	}
 	postPath := target.PostPath(filename)
 
-	content := envelope.BuildEnvelope(cfg, tmpl, simpleName, "postman", contextID, postPath, activeNodes, adjacency, nodes, sourceSessionName, livenessMap)
+	// Daemon PINGs bootstrap liveness, so their body route hints must come from
+	// discovered topology rather than the already-confirmed liveness map.
+	content := envelope.BuildEnvelope(cfg, tmpl, simpleName, "postman", contextID, postPath, activeNodes, adjacency, nodes, sourceSessionName, nil)
 
 	// Pass 2: inject daemon message variables.
 	var skillCatalogs []string

--- a/internal/ping/ping_test.go
+++ b/internal/ping/ping_test.go
@@ -236,6 +236,64 @@ func TestSendPingToNode_DefaultDaemonTemplateShowsContactRoles(t *testing.T) {
 	}
 }
 
+func TestSendPingToNode_DefaultDaemonTemplateShowsDiscoveredContactsBeforeLiveness(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+
+	sessionDir := filepath.Join(tmpDir, "test-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	nodeInfo := discovery.NodeInfo{
+		PaneID:      "%100",
+		SessionName: "test-session",
+		SessionDir:  sessionDir,
+	}
+	orchestratorInfo := discovery.NodeInfo{
+		PaneID:      "%101",
+		SessionName: "test-session",
+		SessionDir:  sessionDir,
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"test-session:messenger":    nodeInfo,
+		"test-session:orchestrator": orchestratorInfo,
+	}
+	cfg, err := config.LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	cfg.Edges = []string{"messenger --- orchestrator"}
+	cfg.Nodes = map[string]config.NodeConfig{
+		"messenger":    {Role: "Human interface."},
+		"orchestrator": {Role: "Delegates work and manages review."},
+	}
+
+	err = SendPingToNode(
+		nodeInfo,
+		"ctx-ping",
+		"test-session:messenger",
+		cfg.DaemonMessageTemplate,
+		cfg,
+		[]string{"messenger", "orchestrator"},
+		map[string]bool{},
+		map[string][]string{"messenger": {"orchestrator"}, "orchestrator": {"messenger"}},
+		nodes,
+	)
+	if err != nil {
+		t.Fatalf("SendPingToNode() error = %v", err)
+	}
+
+	_, body := readSingleInboxMessage(t, sessionDir, "messenger")
+	if !strings.Contains(body, "You can talk to:\n- orchestrator: Delegates work and manages review.") {
+		t.Fatalf("default startup ping missing discovered contact before liveness confirmation:\n%s", body)
+	}
+	if strings.Contains(body, "You can talk to:\n- none") {
+		t.Fatalf("default startup ping hid configured contact behind empty liveness map:\n%s", body)
+	}
+}
+
 func TestSendPingToNodeWithOptions_AppendsRuntimeAgnosticPingAndCompactionCatalogs(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionDir := filepath.Join(tmpDir, "test-session")


### PR DESCRIPTION
## Summary
- render daemon PING body contact hints from discovered same-session topology before liveness is confirmed
- keep delivery and notification behavior liveness-aware
- add regression coverage for startup-style auto-PING contact rendering

## Root Cause
Startup auto-PINGs can run before adjacent nodes have confirmed liveness. The daemon PING body reused liveness-filtered contact rendering, so valid configured neighbors could appear as `You can talk to: - none`.

## Tests
- `TestSendPingToNode_DefaultDaemonTemplateShowsDiscoveredContactsBeforeLiveness` covers a discovered adjacent node with an empty liveness map

## Verification
- `go test ./internal/ping -run TestSendPingToNode_DefaultDaemonTemplateShowsDiscoveredContactsBeforeLiveness -count=1`
- `go test ./internal/ping -count=1`
- `go test ./...`
- `git diff --check`
- `nix flake check`
- `nix build`