### PR TITLE
docs(skills): document bounded status polling (#463)

### DIFF
--- a/skills/postman-send-message/SKILL.md
+++ b/skills/postman-send-message/SKILL.md
@@ -37,9 +37,10 @@ Send first-contact messages to another node.
    before a visible separator.
 4. The sender is auto-detected from the current tmux pane title. Use
    `tmux-a2a-postman help send-heredoc` for details.
-5. After a successful send, do not start a continuous polling loop. The daemon
-   notifies the recipient pane; use status only for explicit status requests,
-   timeout/watchdog boundaries, or suspected delivery failure.
+5. After a successful send, do not eagerly poll or start a continuous
+   `get-status` loop. The daemon notifies the recipient pane; use status only
+   for explicit status requests, timeout/watchdog boundaries, or suspected
+   delivery failure.
 
 ## 3. DO NOT USE FOR
 

--- a/skills/postman-session-operator/SKILL.md
+++ b/skills/postman-session-operator/SKILL.md
@@ -2,18 +2,18 @@
 name: postman-session-operator
 license: MIT
 description: |
-  USE FOR: Operate live tmux-a2a-postman sessions with existing mail,
-  get-status state, exact replies, waits, blocked/stale/dead-letter signals.
+  USE FOR: Live mailbox/session operation, mail triage, exact replies, waits,
+  blocked/stale/dead-letter state.
   DO NOT USE FOR: first contact or topology audits.
 ---
 
 # postman-session-operator
 
-**UTILITY SKILL**. INVOKES: status and mailbox commands.
+**UTILITY SKILL**. INVOKES: status/mailbox commands.
 
 ## 1. USE FOR
 
-- Interpret pending, waiting, blocked, stale, and dead-letter state.
+- Interpret pending, waiting, blocked, stale, dead-letter state.
 - Claim unread mail, read complete archives, and close exact requests.
 - Use `tmux-a2a-postman inspect-message --id <message_id>` as a read-only
   historical lookup. Use `--path` for the stored Markdown path and `--body` for
@@ -21,9 +21,10 @@ description: |
 
 ## 2. Procedure
 
-1. Use `tmux-a2a-postman get-status` for on-demand decisions, not polling.
-   After delegation/reply-required mail, wait for pane notifications, exact
-   replies, timeouts, or suspected delivery trouble.
+1. Use `tmux-a2a-postman get-status` for on-demand decisions, not polling. Do
+   not start eager, habitual, or continuous status loops after delegated or
+   reply-required mail. Wait for pane notifications, exact replies,
+   timeout/watchdog boundaries, or suspected delivery trouble.
 2. After every successful `pop` with `status=message`, read the complete
    archived Markdown body before any handling, routing, reply, status decision,
    or no-action or no-op decision.
@@ -35,17 +36,17 @@ description: |
    `Remaining blockers: none`. Use `BLOCKED` with `Original checklist: FAIL`;
    receivers should verify checklist status, durable references, evidence, and
    blockers before relaying, approving, or closing work.
-5. Treat dead letters, missing routes, or stale topology as
-   `postman-config-auditor` work. Details:
+5. Route dead letters, missing routes, or stale topology to
+   `postman-config-auditor`. Details:
    [Session Flow](references/session-flow.md).
 
 ## 3. DO NOT USE FOR
 
-- First-contact message sending; use `postman-send-message`.
-- Config, topology, or skill catalog audits; use `postman-config-auditor`.
-- Infrastructure management or low-level daemon repair.
+- First contact; use `postman-send-message`.
+- Config/topology/skill audits; use `postman-config-auditor`.
+- Infrastructure management or daemon repair.
 
 ## 4. Troubleshooting
 
-If status remains unavailable or delivery stays stuck after route checks, send
-`BLOCKED` to the operator instead of manually editing mailbox files.
+If status is unavailable/stuck after route checks, send `BLOCKED`; do not edit
+mailbox files.


### PR DESCRIPTION
## Summary

- Clarifies that `postman-send-message` must not eagerly poll or start a continuous `get-status` loop after successful sends.
- Clarifies that `postman-session-operator` uses `get-status` for on-demand decisions, not habitual polling, while preserving bounded watchdog/troubleshooting use.
- Keeps the archived-body read contract intact.

Closes #463.

## Verification

- `nix run nixpkgs#rumdl -- check skills/postman-send-message/SKILL.md skills/postman-session-operator/SKILL.md`
- `git diff --check`
- `nix run '.#skill-check'`
- `go test ./internal/cli -run TestArchivedBodyReadPublicDocsContract`
- `nix flake check`
- `nix build`
