### PR TITLE
refactor(template): inject shell executor for tests (#475)

### DIFF
--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -41,14 +41,6 @@ func defaultShellExecutor(ctx context.Context, command string) ([]byte, error) {
 	return exec.CommandContext(ctx, "sh", "-c", command).Output()
 }
 
-// expandShellCommands executes $(command) patterns via sh -c.
-// Each command runs with the given timeout. On error or timeout,
-// the expansion is replaced with an empty string.
-// Trailing newlines are stripped from command output.
-func expandShellCommands(template string, timeout time.Duration) string {
-	return expandShellCommandsWithExecutor(template, timeout, defaultShellExecutor)
-}
-
 func expandShellCommandsWithExecutor(template string, timeout time.Duration, executor shellExecutor) string {
 	return shellCommandPattern.ReplaceAllStringFunc(template, func(match string) string {
 		// Extract command (without $(...))

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -21,6 +21,8 @@ var (
 	shellCommandPattern = regexp.MustCompile(`\$\(([^)]+)\)`)
 )
 
+type shellExecutor func(ctx context.Context, command string) ([]byte, error)
+
 // ExpandVariables replaces {variable} patterns with values from the vars map.
 // Undefined variables remain as-is in the output.
 func ExpandVariables(template string, vars map[string]string) string {
@@ -35,11 +37,19 @@ func ExpandVariables(template string, vars map[string]string) string {
 	})
 }
 
+func defaultShellExecutor(ctx context.Context, command string) ([]byte, error) {
+	return exec.CommandContext(ctx, "sh", "-c", command).Output()
+}
+
 // expandShellCommands executes $(command) patterns via sh -c.
 // Each command runs with the given timeout. On error or timeout,
 // the expansion is replaced with an empty string.
 // Trailing newlines are stripped from command output.
 func expandShellCommands(template string, timeout time.Duration) string {
+	return expandShellCommandsWithExecutor(template, timeout, defaultShellExecutor)
+}
+
+func expandShellCommandsWithExecutor(template string, timeout time.Duration, executor shellExecutor) string {
 	return shellCommandPattern.ReplaceAllStringFunc(template, func(match string) string {
 		// Extract command (without $(...))
 		cmd := match[2 : len(match)-1]
@@ -47,7 +57,7 @@ func expandShellCommands(template string, timeout time.Duration) string {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		out, err := exec.CommandContext(ctx, "sh", "-c", cmd).Output()
+		out, err := executor(ctx, cmd)
 		if err != nil {
 			// Command failed or timed out: return empty string
 			return ""
@@ -62,9 +72,13 @@ func expandShellCommands(template string, timeout time.Duration) string {
 // 1. Execute shell commands $(...) — only when allowShell is true
 // 2. Expand variables {variable}
 func ExpandTemplate(tmpl string, vars map[string]string, timeout time.Duration, allowShell bool) string {
+	return expandTemplateWithExecutor(tmpl, vars, timeout, allowShell, defaultShellExecutor)
+}
+
+func expandTemplateWithExecutor(tmpl string, vars map[string]string, timeout time.Duration, allowShell bool, executor shellExecutor) string {
 	expanded := tmpl
 	if allowShell {
-		expanded = expandShellCommands(tmpl, timeout)
+		expanded = expandShellCommandsWithExecutor(tmpl, timeout, executor)
 	}
 	sanitizedVars := make(map[string]string, len(vars))
 	for k, v := range vars {

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -1,7 +1,8 @@
 package template
 
 import (
-	"strings"
+	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -48,49 +49,93 @@ func TestExpandVariables_Empty(t *testing.T) {
 	}
 }
 
-func TestExpandShellCommands(t *testing.T) {
-	template := "Current user: $(whoami)"
-	timeout := 5 * time.Second
-
-	got := expandShellCommands(template, timeout)
-
-	// Verify the pattern was replaced (result should not contain $(...))
-	if strings.Contains(got, "$(") {
-		t.Errorf("expandShellCommands() still contains $(: %q", got)
+func TestExpandShellCommandsWithExecutor_ReplacesCommandsInOrder(t *testing.T) {
+	var commands []string
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		commands = append(commands, command)
+		return []byte(command), nil
 	}
 
-	// Verify it starts with expected prefix
-	if !strings.HasPrefix(got, "Current user: ") {
-		t.Errorf("expandShellCommands() = %q, want prefix %q", got, "Current user: ")
-	}
+	got := expandShellCommandsWithExecutor(
+		"First: $(one), Second: $(two)",
+		5*time.Second,
+		executor,
+	)
+	want := "First: one, Second: two"
 
-	// Verify no trailing newline
-	if strings.HasSuffix(got, "\n") {
-		t.Errorf("expandShellCommands() has trailing newline: %q", got)
+	if got != want {
+		t.Errorf("expandShellCommandsWithExecutor() = %q, want %q", got, want)
+	}
+	if len(commands) != 2 || commands[0] != "one" || commands[1] != "two" {
+		t.Errorf("executor commands = %#v, want %#v", commands, []string{"one", "two"})
 	}
 }
 
-func TestExpandShellCommands_Timeout(t *testing.T) {
-	template := "Result: $(sleep 10 && echo done)"
+func TestExpandShellCommandsWithExecutor_TrimTrailingNewlines(t *testing.T) {
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		return []byte("value\n\n"), nil
+	}
+
+	got := expandShellCommandsWithExecutor("Result: $(echo value)", 5*time.Second, executor)
+	want := "Result: value"
+
+	if got != want {
+		t.Errorf("expandShellCommandsWithExecutor() = %q, want %q", got, want)
+	}
+}
+
+func TestExpandShellCommandsWithExecutor_FailureExpandsEmpty(t *testing.T) {
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		return nil, errors.New("command failed")
+	}
+
+	got := expandShellCommandsWithExecutor("Result: $(exit 1)", 5*time.Second, executor)
+	want := "Result: "
+
+	if got != want {
+		t.Errorf("expandShellCommandsWithExecutor() failure = %q, want %q", got, want)
+	}
+}
+
+func TestExpandShellCommandsWithExecutor_TimeoutExpandsEmpty(t *testing.T) {
 	timeout := 100 * time.Millisecond
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("executor context has no deadline")
+		}
+		if remaining := time.Until(deadline); remaining <= 0 || remaining > timeout {
+			t.Fatalf("executor deadline remaining = %v, want within %v", remaining, timeout)
+		}
+		return nil, context.DeadlineExceeded
+	}
 
-	got := expandShellCommands(template, timeout)
+	got := expandShellCommandsWithExecutor("Result: $(slow)", timeout, executor)
 	want := "Result: "
 
 	if got != want {
-		t.Errorf("expandShellCommands() timeout = %q, want %q", got, want)
+		t.Errorf("expandShellCommandsWithExecutor() timeout = %q, want %q", got, want)
 	}
 }
 
-func TestExpandShellCommands_Failure(t *testing.T) {
-	template := "Result: $(exit 1)"
-	timeout := 5 * time.Second
+func TestExpandTemplateWithExecutor_ShellDisabledDoesNotExecute(t *testing.T) {
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		t.Fatalf("executor called with %q while shell expansion is disabled", command)
+		return nil, nil
+	}
+	vars := map[string]string{"node": "worker"}
 
-	got := expandShellCommands(template, timeout)
-	want := "Result: "
+	got := expandTemplateWithExecutor(
+		"Command: $(echo no), Node: {node}",
+		vars,
+		5*time.Second,
+		false,
+		executor,
+	)
+	want := "Command: $(echo no), Node: worker"
 
 	if got != want {
-		t.Errorf("expandShellCommands() failure = %q, want %q", got, want)
+		t.Errorf("expandTemplateWithExecutor() = %q, want %q", got, want)
 	}
 }
 
@@ -99,9 +144,8 @@ func TestExpandTemplate_SanitizesInjection(t *testing.T) {
 	vars := map[string]string{
 		"node": "evil$(rm -rf /)",
 	}
-	timeout := 5 * time.Second
 
-	got := ExpandTemplate(tmpl, vars, timeout, false)
+	got := ExpandTemplate(tmpl, vars, 5*time.Second, false)
 	want := "Node: evil"
 
 	if got != want {
@@ -109,34 +153,40 @@ func TestExpandTemplate_SanitizesInjection(t *testing.T) {
 	}
 }
 
-func TestExpandTemplate(t *testing.T) {
+func TestExpandTemplateWithExecutor_SanitizesInjection(t *testing.T) {
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		return []byte("ignored"), nil
+	}
+	tmpl := "Node: {node}"
+	vars := map[string]string{
+		"node": "evil$(rm -rf /)",
+	}
+
+	got := expandTemplateWithExecutor(tmpl, vars, 5*time.Second, true, executor)
+	want := "Node: evil"
+
+	if got != want {
+		t.Errorf("expandTemplateWithExecutor() injection = %q, want %q", got, want)
+	}
+}
+
+func TestExpandTemplateWithExecutor_ExpandsShellAndVariables(t *testing.T) {
+	executor := func(ctx context.Context, command string) ([]byte, error) {
+		if command != "whoami" {
+			t.Fatalf("executor command = %q, want %q", command, "whoami")
+		}
+		return []byte("current-user\n"), nil
+	}
 	template := "User: $(whoami), Sender: {sender}, Recipient: {recipient}"
 	vars := map[string]string{
 		"sender":    "orchestrator",
 		"recipient": "worker",
 	}
-	timeout := 5 * time.Second
 
-	got := ExpandTemplate(template, vars, timeout, true)
+	got := expandTemplateWithExecutor(template, vars, 5*time.Second, true, executor)
+	want := "User: current-user, Sender: orchestrator, Recipient: worker"
 
-	// Verify shell command was executed (no $(...) left)
-	if strings.Contains(got, "$(") {
-		t.Errorf("ExpandTemplate() still contains $(: %q", got)
-	}
-
-	// Verify variables were expanded
-	if !strings.Contains(got, "orchestrator") {
-		t.Errorf("ExpandTemplate() missing 'orchestrator': %q", got)
-	}
-	if !strings.Contains(got, "worker") {
-		t.Errorf("ExpandTemplate() missing 'worker': %q", got)
-	}
-
-	// Verify no {variable} patterns left (for defined variables)
-	if strings.Contains(got, "{sender}") {
-		t.Errorf("ExpandTemplate() still contains {sender}: %q", got)
-	}
-	if strings.Contains(got, "{recipient}") {
-		t.Errorf("ExpandTemplate() still contains {recipient}: %q", got)
+	if got != want {
+		t.Errorf("expandTemplateWithExecutor() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a package-private shell executor seam for template shell expansion tests.
- Keeps `ExpandTemplate` as the stable production wrapper using the default shell executor.
- Replaces real-shell timeout and failure coverage with fake executor tests for command ordering, trimming, failures, timeouts, disabled shell execution, and variable sanitization.

Closes #475.

## Verification
- `go test ./internal/template -run Test`
- `git diff --check`
- `go test ./...`
- `nix flake check`
- `nix build`
