### PR TITLE
refactor(uinode): extract pane parser seams (#474)

### DIFF
--- a/internal/paneutil/pane.go
+++ b/internal/paneutil/pane.go
@@ -5,26 +5,31 @@ import (
 	"os/exec"
 )
 
+type tmuxCombinedOutputFunc func(args ...string) ([]byte, error)
+
+func runTmuxCombinedOutput(args ...string) ([]byte, error) {
+	return exec.Command("tmux", args...).CombinedOutput()
+}
+
 // CaptureContent captures the visible content of a tmux pane.
 // Returns the content as a string, or empty string on error.
 func CaptureContent(paneID string) (string, error) {
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", paneID)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("capturing pane %s: %w", paneID, err)
-	}
-	return string(output), nil
+	return captureContent(paneID, 0, runTmuxCombinedOutput)
 }
 
 // CaptureRecentContent captures visible content plus recent scrollback lines.
 func CaptureRecentContent(paneID string, tailLines int) (string, error) {
-	if tailLines <= 0 {
-		return CaptureContent(paneID)
+	return captureContent(paneID, tailLines, runTmuxCombinedOutput)
+}
+
+func captureContent(paneID string, tailLines int, run tmuxCombinedOutputFunc) (string, error) {
+	args := []string{"capture-pane", "-p", "-t", paneID}
+	if tailLines > 0 {
+		args = append(args, "-S", fmt.Sprintf("-%d", tailLines))
 	}
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", paneID, "-S", fmt.Sprintf("-%d", tailLines))
-	output, err := cmd.CombinedOutput()
+	output, err := run(args...)
 	if err != nil {
-		return "", fmt.Errorf("capturing recent pane %s: %w", paneID, err)
+		return "", fmt.Errorf("capturing pane %s: %w", paneID, err)
 	}
 	return string(output), nil
 }

--- a/internal/paneutil/pane_test.go
+++ b/internal/paneutil/pane_test.go
@@ -1,0 +1,65 @@
+package paneutil
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCaptureContentWithRunner(t *testing.T) {
+	var gotArgs []string
+	run := func(args ...string) ([]byte, error) {
+		gotArgs = append(gotArgs, args...)
+		return []byte("pane content"), nil
+	}
+
+	got, err := captureContent("%11", 0, run)
+	if err != nil {
+		t.Fatalf("captureContent: %v", err)
+	}
+	if got != "pane content" {
+		t.Fatalf("captureContent() = %q, want %q", got, "pane content")
+	}
+	wantArgs := []string{"capture-pane", "-p", "-t", "%11"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
+func TestCaptureRecentContentWithRunner(t *testing.T) {
+	var gotArgs []string
+	run := func(args ...string) ([]byte, error) {
+		gotArgs = append(gotArgs, args...)
+		return []byte("recent content"), nil
+	}
+
+	got, err := captureContent("%11", 100, run)
+	if err != nil {
+		t.Fatalf("captureContent: %v", err)
+	}
+	if got != "recent content" {
+		t.Fatalf("captureContent() = %q, want %q", got, "recent content")
+	}
+	wantArgs := []string{"capture-pane", "-p", "-t", "%11", "-S", "-100"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
+func TestCaptureContentWithRunner_PropagatesFailure(t *testing.T) {
+	run := func(args ...string) ([]byte, error) {
+		return nil, errors.New("tmux failed")
+	}
+
+	got, err := captureContent("%11", 0, run)
+	if err == nil {
+		t.Fatal("captureContent() error = nil, want error")
+	}
+	if got != "" {
+		t.Fatalf("captureContent() = %q, want empty string on failure", got)
+	}
+	if !strings.Contains(err.Error(), "capturing pane %11") || !strings.Contains(err.Error(), "tmux failed") {
+		t.Fatalf("error = %q, want capture context and source error", err.Error())
+	}
+}

--- a/internal/uinode/monitor.go
+++ b/internal/uinode/monitor.go
@@ -30,6 +30,12 @@ type PaneInfo struct {
 	LastChecked  time.Time
 }
 
+type tmuxOutputFunc func(args ...string) ([]byte, error)
+
+func runTmuxOutput(args ...string) ([]byte, error) {
+	return exec.Command("tmux", args...).Output()
+}
+
 // NotificationLog tracks notification timestamps per context.
 type NotificationLog struct {
 	mu            sync.RWMutex
@@ -76,62 +82,27 @@ func (nl *NotificationLog) GetNotifications(contextID string) []NotificationEntr
 // Returns map[paneID]PaneInfo with optimized batch processing.
 // Only queries window_active for panes where pane_active=0.
 func GetAllPanesInfo() (map[string]PaneInfo, error) {
+	return getAllPanesInfo(runTmuxOutput, time.Now)
+}
+
+func getAllPanesInfo(run tmuxOutputFunc, now func() time.Time) (map[string]PaneInfo, error) {
 	// Get all pane info: pane_id, pane_active, pane_activity
-	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}:#{pane_active}:#{pane_activity}")
-	output, err := cmd.Output()
+	output, err := run("list-panes", "-a", "-F", "#{pane_id}:#{pane_active}:#{pane_activity}")
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes failed: %w", err)
 	}
 
-	result := make(map[string]PaneInfo)
-	inactivePanes := []string{}
-
-	// First pass: collect all panes, identify inactive ones
-	for _, line := range strings.Split(string(output), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.Split(line, ":")
-		if len(parts) != 3 {
-			continue
-		}
-
-		paneID := parts[0]
-		paneActive := parts[1] == "1"
-		paneActivity, _ := strconv.ParseInt(parts[2], 10, 64)
-
-		if paneActive {
-			result[paneID] = PaneInfo{
-				PaneID:       paneID,
-				PaneActive:   true,
-				PaneActivity: paneActivity,
-				Status:       StatusVisible,
-				LastChecked:  time.Now(),
-			}
-		} else {
-			// Mark as inactive, will check window_active later
-			result[paneID] = PaneInfo{
-				PaneID:       paneID,
-				PaneActive:   false,
-				PaneActivity: paneActivity,
-				Status:       StatusUnknown,
-				LastChecked:  time.Now(),
-			}
-			inactivePanes = append(inactivePanes, paneID)
-		}
-	}
+	result, inactivePanes := parseListPanesInfo(output, now())
 
 	// Second pass: check window_active only for inactive panes (Issue #94 optimization)
 	for _, paneID := range inactivePanes {
-		cmd := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{window_active}")
-		windowActiveOutput, err := cmd.Output()
+		windowActiveOutput, err := run("display-message", "-p", "-t", paneID, "#{window_active}")
 		if err != nil {
 			// Keep StatusUnknown
 			continue
 		}
 
-		windowActive := strings.TrimSpace(string(windowActiveOutput)) == "1"
+		windowActive := parseWindowActive(windowActiveOutput)
 		paneInfo := result[paneID]
 		paneInfo.WindowActive = windowActive
 		if windowActive {
@@ -148,20 +119,58 @@ func GetAllPanesInfo() (map[string]PaneInfo, error) {
 // GetPaneInfo retrieves target pane information using tmux commands.
 // Returns PaneInfo with status based on pane and window active states.
 func GetPaneInfo(targetPaneID string) (*PaneInfo, error) {
+	return getPaneInfo(targetPaneID, runTmuxOutput, time.Now)
+}
+
+func getPaneInfo(targetPaneID string, run tmuxOutputFunc, now func() time.Time) (*PaneInfo, error) {
 	if targetPaneID == "" {
-		return &PaneInfo{Status: StatusUnknown, LastChecked: time.Now()}, nil
+		return &PaneInfo{Status: StatusUnknown, LastChecked: now()}, nil
 	}
 
 	// Get pane info: pane_id, pane_active, pane_activity
-	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}:#{pane_active}:#{pane_activity}")
-	output, err := cmd.Output()
+	output, err := run("list-panes", "-a", "-F", "#{pane_id}:#{pane_active}:#{pane_activity}")
 	if err != nil {
-		return &PaneInfo{Status: StatusUnknown, LastChecked: time.Now()}, fmt.Errorf("tmux list-panes failed: %w", err)
+		return &PaneInfo{Status: StatusUnknown, LastChecked: now()}, fmt.Errorf("tmux list-panes failed: %w", err)
 	}
 
-	var paneActive bool
-	var paneActivity int64
-	found := false
+	panes, _ := parseListPanesInfo(output, now())
+	paneInfo, found := panes[targetPaneID]
+	if !found {
+		return &PaneInfo{Status: StatusUnknown, LastChecked: now()}, nil
+	}
+
+	// If pane is active, it's visible
+	if paneInfo.PaneActive {
+		return &paneInfo, nil
+	}
+
+	// Pane not active, check window activity
+	_, err = run("list-windows", "-a", "-F", "#{window_id}:#{window_active}:#{window_panes}")
+	if err != nil {
+		return &paneInfo, nil
+	}
+
+	// Find which window contains our pane
+	windowActiveOutput, err := run("display-message", "-p", "-t", targetPaneID, "#{window_active}")
+	if err != nil {
+		return &paneInfo, nil
+	}
+
+	windowActive := parseWindowActive(windowActiveOutput)
+
+	status := StatusNotVisible
+	if windowActive {
+		status = StatusWindowVisible
+	}
+
+	paneInfo.WindowActive = windowActive
+	paneInfo.Status = status
+	return &paneInfo, nil
+}
+
+func parseListPanesInfo(output []byte, checkedAt time.Time) (map[string]PaneInfo, []string) {
+	result := make(map[string]PaneInfo)
+	var inactivePanes []string
 
 	for _, line := range strings.Split(string(output), "\n") {
 		line = strings.TrimSpace(line)
@@ -172,70 +181,31 @@ func GetPaneInfo(targetPaneID string) (*PaneInfo, error) {
 		if len(parts) != 3 {
 			continue
 		}
-		if parts[0] == targetPaneID {
-			found = true
-			paneActive = parts[1] == "1"
-			paneActivity, _ = strconv.ParseInt(parts[2], 10, 64)
-			break
+
+		paneID := parts[0]
+		paneActive := parts[1] == "1"
+		paneActivity, _ := strconv.ParseInt(parts[2], 10, 64)
+
+		paneInfo := PaneInfo{
+			PaneID:       paneID,
+			PaneActive:   paneActive,
+			PaneActivity: paneActivity,
+			LastChecked:  checkedAt,
 		}
+		if paneActive {
+			paneInfo.Status = StatusVisible
+		} else {
+			paneInfo.Status = StatusUnknown
+			inactivePanes = append(inactivePanes, paneID)
+		}
+		result[paneID] = paneInfo
 	}
 
-	if !found {
-		return &PaneInfo{Status: StatusUnknown, LastChecked: time.Now()}, nil
-	}
+	return result, inactivePanes
+}
 
-	// If pane is active, it's visible
-	if paneActive {
-		return &PaneInfo{
-			PaneID:       targetPaneID,
-			PaneActive:   true,
-			PaneActivity: paneActivity,
-			Status:       StatusVisible,
-			LastChecked:  time.Now(),
-		}, nil
-	}
-
-	// Pane not active, check window activity
-	cmd = exec.Command("tmux", "list-windows", "-a", "-F", "#{window_id}:#{window_active}:#{window_panes}")
-	_, err = cmd.Output()
-	if err != nil {
-		return &PaneInfo{
-			PaneID:       targetPaneID,
-			PaneActive:   false,
-			PaneActivity: paneActivity,
-			Status:       StatusUnknown,
-			LastChecked:  time.Now(),
-		}, nil
-	}
-
-	// Find which window contains our pane
-	cmd = exec.Command("tmux", "display-message", "-p", "-t", targetPaneID, "#{window_active}")
-	windowActiveOutput, err := cmd.Output()
-	if err != nil {
-		return &PaneInfo{
-			PaneID:       targetPaneID,
-			PaneActive:   false,
-			PaneActivity: paneActivity,
-			Status:       StatusUnknown,
-			LastChecked:  time.Now(),
-		}, nil
-	}
-
-	windowActive := strings.TrimSpace(string(windowActiveOutput)) == "1"
-
-	status := StatusNotVisible
-	if windowActive {
-		status = StatusWindowVisible
-	}
-
-	return &PaneInfo{
-		PaneID:       targetPaneID,
-		PaneActive:   false,
-		WindowActive: windowActive,
-		PaneActivity: paneActivity,
-		Status:       status,
-		LastChecked:  time.Now(),
-	}, nil
+func parseWindowActive(output []byte) bool {
+	return strings.TrimSpace(string(output)) == "1"
 }
 
 // FindTargetPaneID finds the pane_id for the pane whose title matches nodeName.

--- a/internal/uinode/monitor_test.go
+++ b/internal/uinode/monitor_test.go
@@ -1,6 +1,7 @@
 package uinode
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -40,6 +41,110 @@ func TestGetPaneInfo_EmptyPaneID(t *testing.T) {
 	}
 	if info.Status != StatusUnknown {
 		t.Errorf("expected StatusUnknown, got %v", info.Status)
+	}
+}
+
+func TestParseListPanesInfo_SkipsMalformedRows(t *testing.T) {
+	checkedAt := time.Date(2026, 5, 21, 7, 0, 0, 0, time.UTC)
+
+	got, inactive := parseListPanesInfo([]byte("%11:1:123\nmalformed\n%12:0:456\n%13:bad:not-int\n"), checkedAt)
+
+	if _, ok := got["malformed"]; ok {
+		t.Fatal("malformed row should be skipped")
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if got["%11"].Status != StatusVisible {
+		t.Fatalf("%%11 status = %s, want %s", got["%11"].Status, StatusVisible)
+	}
+	if got["%12"].Status != StatusUnknown {
+		t.Fatalf("%%12 status = %s, want %s before window lookup", got["%12"].Status, StatusUnknown)
+	}
+	if !got["%13"].LastChecked.Equal(checkedAt) {
+		t.Fatalf("%%13 LastChecked = %s, want %s", got["%13"].LastChecked, checkedAt)
+	}
+	if !reflect.DeepEqual(inactive, []string{"%12", "%13"}) {
+		t.Fatalf("inactive = %#v, want %#v", inactive, []string{"%12", "%13"})
+	}
+}
+
+func TestGetPaneInfoWithRunner_UnknownPane(t *testing.T) {
+	checkedAt := time.Date(2026, 5, 21, 7, 1, 0, 0, time.UTC)
+	run := func(args ...string) ([]byte, error) {
+		if args[0] != "list-panes" {
+			t.Fatalf("unexpected command: %#v", args)
+		}
+		return []byte("%11:1:123\n"), nil
+	}
+
+	info, err := getPaneInfo("%99", run, func() time.Time { return checkedAt })
+	if err != nil {
+		t.Fatalf("getPaneInfo: %v", err)
+	}
+	if info.Status != StatusUnknown {
+		t.Fatalf("status = %s, want %s", info.Status, StatusUnknown)
+	}
+	if !info.LastChecked.Equal(checkedAt) {
+		t.Fatalf("LastChecked = %s, want %s", info.LastChecked, checkedAt)
+	}
+}
+
+func TestGetPaneInfoWithRunner_ActivePane(t *testing.T) {
+	checkedAt := time.Date(2026, 5, 21, 7, 2, 0, 0, time.UTC)
+	var calls [][]string
+	run := func(args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if args[0] != "list-panes" {
+			t.Fatalf("unexpected command: %#v", args)
+		}
+		return []byte("%11:1:123\n"), nil
+	}
+
+	info, err := getPaneInfo("%11", run, func() time.Time { return checkedAt })
+	if err != nil {
+		t.Fatalf("getPaneInfo: %v", err)
+	}
+	if info.Status != StatusVisible || !info.PaneActive {
+		t.Fatalf("info = %#v, want active visible pane", info)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("command calls = %#v, want only list-panes", calls)
+	}
+}
+
+func TestGetPaneInfoWithRunner_InactiveVisibleWindow(t *testing.T) {
+	info, err := getPaneInfo("%11", paneInfoRunner("1\n"), time.Now)
+	if err != nil {
+		t.Fatalf("getPaneInfo: %v", err)
+	}
+	if info.Status != StatusWindowVisible || !info.WindowActive {
+		t.Fatalf("info = %#v, want inactive pane in visible window", info)
+	}
+}
+
+func TestGetPaneInfoWithRunner_InactiveHiddenWindow(t *testing.T) {
+	info, err := getPaneInfo("%11", paneInfoRunner("0\n"), time.Now)
+	if err != nil {
+		t.Fatalf("getPaneInfo: %v", err)
+	}
+	if info.Status != StatusNotVisible || info.WindowActive {
+		t.Fatalf("info = %#v, want inactive pane in hidden window", info)
+	}
+}
+
+func paneInfoRunner(windowActiveOutput string) tmuxOutputFunc {
+	return func(args ...string) ([]byte, error) {
+		switch args[0] {
+		case "list-panes":
+			return []byte("%11:0:123\n"), nil
+		case "list-windows":
+			return []byte("unused\n"), nil
+		case "display-message":
+			return []byte(windowActiveOutput), nil
+		default:
+			return nil, nil
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds pure pane visibility parsers for list-panes and display-message output.
- Adds fakeable tmux command seams around pane visibility and capture helpers while keeping production wrappers unchanged.
- Covers malformed pane rows, unknown panes, active panes, inactive visible and hidden windows, and capture failure propagation.

Closes #474.

## Verification
- `go test ./internal/uinode ./internal/paneutil -run Test`
- `git diff --check`
- `go test ./...`
- `nix flake check`
- `nix build`
