### PR TITLE
fix(daemon): reduce daemon-submit latency (#486)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ decision, or no-action or no-op decision. `messageType: ping`,
 Truncated output from bounded stdout does not count as a complete read. To
 inspect archived mail later, use `inspect-message --id <message_id>`.
 
+If a daemon-submit `send-heredoc` or `pop` times out, treat the result as
+unknown. The daemon may still commit the side effect after the CLI stops
+waiting, so inspect status, inbox/read state, archived message evidence, or
+recipient-side confirmation before retrying.
+
 Inspect live session state:
 
 ```sh

--- a/docs/design/daemon-tui-concurrency.md
+++ b/docs/design/daemon-tui-concurrency.md
@@ -26,7 +26,7 @@ or when results return to the event loop before shared state is updated.
 | Session status refresh     | Bounded per-session workers, latest gen   | status/config/activity/alive events     | atomic latest status generation            | `refreshProjectedSessionStatus`, tmux pane/window listing  | worker cap, stale generation drop         | emit only matching generation results          |
 | Session scan tick          | Serialized apply                          | `sessionScanInterval` ticker            | previous session snapshot in runtime       | `discovery.DiscoverAllSessions`                            | blocking TUI status send                  | daemon-submit workers cannot block this tick   |
 | Full scan tick             | Serialized apply                          | `ScanInterval` ticker                   | runtime nodes, known nodes, pane snapshots | node discovery, tmux pane state, projection scan           | event-loop ownership                      | collect IO before mutating runtime state       |
-| Daemon-submit requests     | Bounded workers, per-session active guard | fsnotify create/rename, scan recovery   | active submit session map in event loop    | request claim/read, post write, inbox pop, projection sync | worker cap, per-session filesystem queue  | worker result returns to event loop            |
+| Daemon-submit requests     | Bounded workers, per-operation active key | fsnotify create/rename, scan recovery   | active submit key map in event loop        | request claim/read, post write, inbox pop                  | worker cap, per-key filesystem queue      | send and unrelated inbox pops may run together |
 | Submit send post wake      | Serialized result handling                | daemon-submit worker result             | runtime post guards and route state        | post reconciliation, projection sync, node discovery       | event loop ordering                       | worker only writes response and post file      |
 | Post reconciliation        | Serialized reservation                    | post fsnotify, submit result, backlog   | active post events, delivery route state   | projection sync, node discovery                            | same-route retry timer                    | pane delivery starts after reservation         |
 | Pane delivery              | Goroutine per accepted delivery           | post reservation success                | route reservation completed in defer       | tmux notification, inbox/archive filesystem writes         | route gap, active post guard              | different accepted routes may run concurrently |
@@ -35,16 +35,17 @@ or when results return to the event loop before shared state is updated.
 
 ## 3. Regression contracts
 
-| Contract                         | Guardrail                                                                 |
-| -------------------------------- | ------------------------------------------------------------------------- |
-| Raw TUI session snapshots        | A blocked status probe must not delay a newer `status_update`.            |
-| Status batch parallelism         | A slow session status probe must not block a fast session in the batch.   |
-| Status latest-wins               | A stale status generation must not publish after a newer snapshot exists. |
-| Daemon-submit responsiveness     | A blocked submit worker must not block session status scan propagation.   |
-| Daemon-submit durability         | Saturated workers leave request files pending for the next scan/watcher.  |
-| Same-session submit ordering     | Only one daemon-submit worker per session may be active at a time.        |
-| Post delivery completion         | Route reservation and post active guards prevent duplicate completion.    |
-| Notification buffer correctness  | tmux `set-buffer`/`paste-buffer` remains protected by notification mutex. |
+| Contract                         | Guardrail                                                                  |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| Raw TUI session snapshots        | A blocked status probe must not delay a newer `status_update`.             |
+| Status batch parallelism         | A slow session status probe must not block a fast session in the batch.    |
+| Status latest-wins               | A stale status generation must not publish after a newer snapshot exists.  |
+| Daemon-submit responsiveness     | A blocked submit worker must not block session status scan propagation.    |
+| Daemon-submit durability         | Saturated workers leave request files pending for the next scan/watcher.   |
+| Same-inbox pop ordering          | Only one daemon-submit `pop` per session/node inbox may be active.         |
+| Submit send independence         | `send` must not wait behind an unrelated active `pop` in the same session. |
+| Post delivery completion         | Route reservation and post active guards prevent duplicate completion.     |
+| Notification buffer correctness  | tmux `set-buffer`/`paste-buffer` remains protected by notification mutex.  |
 
 ## 4. Serialized by design
 
@@ -68,8 +69,11 @@ The Go-like concurrency shape is:
 - use bounded workers for daemon-submit request processing
 - leave daemon-submit request files unclaimed when workers are saturated so the
   next watcher or scan pass can pick them up
-- keep only one daemon-submit worker active per session so inbox pops and
-  projection writes for that session remain ordered
+- keep only one daemon-submit `pop` active per session/node inbox, while
+  allowing independent `send` requests and unrelated node inbox pops to run
+  under the global worker cap
+- defer full mailbox projection sync after daemon-submit `pop` responses and
+  coalesce one active projection sync per session
 - return daemon-submit results to the daemon event loop before waking post
   reconciliation
 - use bounded workers inside a session status refresh batch
@@ -87,6 +91,8 @@ direct shared-state mutation outside the owning loop.
 - Daemon-submit concurrency is capped by `daemonSubmitWorkerLimit`.
 - Saturated daemon-submit workers apply filesystem backpressure: the request
   remains pending instead of being claimed and forgotten.
+- A same-inbox `pop` already in flight defers later `pop` requests for that
+  inbox, but it does not defer independent `send` requests.
 - Session status refresh concurrency is capped by
   `sessionStatusRefreshWorkerLimit`.
 - TUI session snapshots retain latest-wins behavior when the TUI channel is

--- a/internal/cli/daemon_submit.go
+++ b/internal/cli/daemon_submit.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -26,12 +27,16 @@ func roundTripDaemonSubmit(sessionDir string, request projection.DaemonSubmitReq
 		return projection.DaemonSubmitResponse{}, err
 	}
 	request.RequestID = requestID
-	request.CreatedAt = now.UTC().Format(time.RFC3339)
+	request.CreatedAt = now.UTC().Format(time.RFC3339Nano)
 	if _, err := projection.WriteDaemonSubmitRequest(sessionDir, request); err != nil {
 		return projection.DaemonSubmitResponse{}, err
 	}
 	response, responsePath, err := projection.WaitDaemonSubmitResponse(sessionDir, requestID, timeout)
 	if err != nil {
+		var timeoutErr projection.DaemonSubmitResponseTimeoutError
+		if errors.As(err, &timeoutErr) {
+			return projection.DaemonSubmitResponse{}, fmt.Errorf("daemon-submit %s request %q timed out after %s; the request may still commit after this timeout; do not retry blindly; inspect status, inbox, read, or recipient-side evidence before retrying", request.Command, requestID, timeoutErr.Timeout)
+		}
 		return projection.DaemonSubmitResponse{}, err
 	}
 	if removeErr := os.Remove(responsePath); removeErr != nil && !os.IsNotExist(removeErr) {

--- a/internal/cli/daemon_submit_test.go
+++ b/internal/cli/daemon_submit_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
+)
+
+func TestRoundTripDaemonSubmitTimeoutWarnsRequestMayStillCommit(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	_, err := roundTripDaemonSubmit(sessionDir, projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitPop,
+		Node:    "worker",
+	}, time.Millisecond)
+	if err == nil {
+		t.Fatal("roundTripDaemonSubmit() error = nil, want timeout")
+	}
+
+	got := err.Error()
+	for _, want := range []string{
+		"daemon-submit pop request",
+		"timed out",
+		"may still commit",
+		"do not retry blindly",
+		"inspect status, inbox, read, or recipient-side evidence",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("timeout error missing %q: %q", want, got)
+		}
+	}
+}

--- a/internal/cli/helptext/pop.txt
+++ b/internal/cli/helptext/pop.txt
@@ -42,3 +42,8 @@ Body-read invariant:
   bounded stdout paths is not a valid archived-body read. If full file reads are
   unavailable, read verified chunks until EOF or stop with a clear
   body-not-fully-read state.
+
+Timeouts:
+  A daemon-submit timeout does not prove failure. The daemon may still claim and
+  archive the message after the CLI stops waiting. Do not retry blindly; inspect
+  status, inbox/read evidence, or the archived message path before retrying.

--- a/internal/cli/helptext/send-heredoc.txt
+++ b/internal/cli/helptext/send-heredoc.txt
@@ -41,3 +41,9 @@ Status:
 submit_path:
   daemon-submit           Request/response path owned by the running daemon
   post                    Direct write to the session post/ queue
+
+Timeouts:
+  A daemon-submit timeout does not prove failure. The daemon may still commit a
+  side-effecting send after the CLI stops waiting. Do not retry blindly; inspect
+  status, recipient inbox/read evidence, or recipient-side confirmation before
+  resending.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -250,14 +250,14 @@ func recordDaemonSubmitPopRead(sessionDir, readPath, filename, fallbackContent s
 		filepath.Join("read", filename),
 		content,
 	))
-	syncMailboxProjection(sessionDir)
 }
 
 type daemonSubmitProcessResult struct {
-	Command    projection.DaemonSubmitCommand
-	SessionDir string
-	Filename   string
-	PostPath   string
+	Command                  projection.DaemonSubmitCommand
+	SessionDir               string
+	Filename                 string
+	PostPath                 string
+	ProjectionSyncSessionDir string
 }
 
 func (r daemonSubmitProcessResult) hasPostDispatch() bool {
@@ -296,8 +296,10 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		Command:    request.Command,
 		SessionDir: sessionDir,
 	}
-	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename)
+	processingStartedAt := time.Now()
+	queueMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, processingStartedAt))
+	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s queue_ms=%d\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename, queueMs)
 
 	var response projection.DaemonSubmitResponse
 	switch request.Command {
@@ -309,6 +311,9 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		}
 	case projection.DaemonSubmitPop:
 		response, err = handleDaemonSubmitPop(sessionDir, request)
+		if err == nil && !response.Empty {
+			result.ProjectionSyncSessionDir = sessionDir
+		}
 	default:
 		err = fmt.Errorf("unsupported daemon submit command %q", request.Command)
 		response = projection.DaemonSubmitResponse{
@@ -323,12 +328,33 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 	if _, writeErr := projection.WriteDaemonSubmitResponse(sessionDir, response); writeErr != nil {
 		return result, writeErr
 	}
-	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "")
+	responseWrittenAt := time.Now()
+	handlerMs := daemonSubmitDurationMillis(responseWrittenAt.Sub(processingStartedAt))
+	totalMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, responseWrittenAt))
+	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t queue_ms=%d handler_ms=%d total_ms=%d\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "", queueMs, handlerMs, totalMs)
 	if removeErr := os.Remove(claimedPath); removeErr != nil && !os.IsNotExist(removeErr) {
 		log.Printf("postman: WARNING: component=%s event=request_remove_failed submit_path=%s path=%s err=%v\n", projection.SubmitPathDaemon, projection.SubmitPathDaemon, claimedPath, removeErr)
 	}
 	return result, nil
+}
+
+func daemonSubmitDurationSince(createdAt string, now time.Time) time.Duration {
+	if createdAt == "" {
+		return -1
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return -1
+	}
+	return now.Sub(parsed)
+}
+
+func daemonSubmitDurationMillis(duration time.Duration) int64 {
+	if duration < 0 {
+		return -1
+	}
+	return duration.Milliseconds()
 }
 
 // DaemonState manages daemon state (Issue #71).
@@ -475,14 +501,17 @@ func RunDaemonLoop(
 		select {
 		case <-ctx.Done():
 			runtime.handleContextDone()
+			runtime.waitForMailboxProjectionSyncs()
 			return
 		case event, ok := <-watcher.Events:
 			if !ok {
+				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherEvent(event)
 		case err, ok := <-watcher.Errors:
 			if !ok {
+				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherError(err)

--- a/internal/daemon/daemon_submit_benchmark_test.go
+++ b/internal/daemon/daemon_submit_benchmark_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
+)
+
+const (
+	loadedSessionJournalRecords = 10000
+	loadedSessionReadFiles      = 500
+)
+
+func benchmarkLoadedDaemonSubmitSession(b *testing.B) string {
+	b.Helper()
+
+	sessionDir := filepath.Join(b.TempDir(), "loaded-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		b.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	restoreDurableWrites := journal.SetDurableWritesForTesting(false)
+	b.Cleanup(restoreDurableWrites)
+	manager := journal.NewManager("ctx-loaded-submit", os.Getpid())
+	journal.InstallProcessManager(manager)
+	b.Cleanup(journal.ClearProcessManager)
+	now := time.Date(2026, time.May, 21, 9, 30, 0, 0, time.UTC)
+	if err := manager.Bootstrap(sessionDir, "loaded-session", now); err != nil {
+		b.Fatalf("Bootstrap: %v", err)
+	}
+
+	readDir := filepath.Join(sessionDir, "read")
+	if err := os.MkdirAll(readDir, 0o700); err != nil {
+		b.Fatalf("MkdirAll read: %v", err)
+	}
+	for i := 0; i < loadedSessionJournalRecords; i++ {
+		filename := fmt.Sprintf("20260521-%06d-r%04x-from-orchestrator-to-worker.md", i%1000000, i%0xffff)
+		content := fmt.Sprintf("---\nparams:\n  from: orchestrator\n  to: worker\n  messageId: %s\n---\n\nloaded message %d\n", filename, i)
+		eventType := projection.MailboxProjectionDeliveredEventType
+		relativePath := filepath.Join("inbox", "worker", filename)
+		if i < loadedSessionReadFiles {
+			eventType = projection.MailboxProjectionReadEventType
+			relativePath = filepath.Join("read", filename)
+			if err := os.WriteFile(filepath.Join(readDir, filename), []byte(content), 0o600); err != nil {
+				b.Fatalf("WriteFile read fixture: %v", err)
+			}
+		}
+		if err := journal.RecordProcessMailboxPayload(sessionDir, "loaded-session", eventType, journal.VisibilityMailboxProjection, journal.MailboxEventPayload{
+			MessageID: filename,
+			From:      "orchestrator",
+			To:        "worker",
+			Path:      relativePath,
+			Content:   content,
+		}, now.Add(time.Duration(i+1)*time.Millisecond)); err != nil {
+			b.Fatalf("RecordProcessMailboxPayload: %v", err)
+		}
+	}
+	return sessionDir
+}
+
+func BenchmarkProcessDaemonSubmitRequest_LoadedSessionSend(b *testing.B) {
+	sessionDir := benchmarkLoadedDaemonSubmitSession(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestID := fmt.Sprintf("bench-send-%d", i)
+		filename := fmt.Sprintf("20260521-100000-r%04x-from-orchestrator-to-worker.md", i%0xffff)
+		requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+			RequestID: requestID,
+			Command:   projection.DaemonSubmitSend,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Filename:  filename,
+			Content:   "benchmark send\n",
+		})
+		if err != nil {
+			b.Fatalf("WriteDaemonSubmitRequest: %v", err)
+		}
+		if _, err := processDaemonSubmitRequest(requestPath); err != nil {
+			b.Fatalf("processDaemonSubmitRequest: %v", err)
+		}
+		_ = os.Remove(projection.DaemonSubmitResponsePath(sessionDir, requestID))
+		_ = os.Remove(filepath.Join(sessionDir, "post", filename))
+	}
+}
+
+func BenchmarkProcessDaemonSubmitRequest_LoadedSessionEmptyPop(b *testing.B) {
+	sessionDir := benchmarkLoadedDaemonSubmitSession(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestID := fmt.Sprintf("bench-empty-pop-%d", i)
+		requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+			RequestID: requestID,
+			Command:   projection.DaemonSubmitPop,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Node:      "operator",
+		})
+		if err != nil {
+			b.Fatalf("WriteDaemonSubmitRequest: %v", err)
+		}
+		if _, err := processDaemonSubmitRequest(requestPath); err != nil {
+			b.Fatalf("processDaemonSubmitRequest: %v", err)
+		}
+		_ = os.Remove(projection.DaemonSubmitResponsePath(sessionDir, requestID))
+	}
+}
+
+func BenchmarkProcessDaemonSubmitRequest_LoadedSessionPop(b *testing.B) {
+	sessionDir := benchmarkLoadedDaemonSubmitSession(b)
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		b.Fatalf("MkdirAll inbox: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestID := fmt.Sprintf("bench-pop-%d", i)
+		filename := fmt.Sprintf("20260521-110000-r%04x-from-orchestrator-to-worker.md", i%0xffff)
+		if err := os.WriteFile(filepath.Join(inboxDir, filename), []byte("benchmark pop\n"), 0o600); err != nil {
+			b.Fatalf("WriteFile inbox: %v", err)
+		}
+		requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+			RequestID: requestID,
+			Command:   projection.DaemonSubmitPop,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Node:      "worker",
+		})
+		if err != nil {
+			b.Fatalf("WriteDaemonSubmitRequest: %v", err)
+		}
+		if _, err := processDaemonSubmitRequest(requestPath); err != nil {
+			b.Fatalf("processDaemonSubmitRequest: %v", err)
+		}
+		_ = os.Remove(projection.DaemonSubmitResponsePath(sessionDir, requestID))
+	}
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -62,10 +62,14 @@ type daemonRuntime struct {
 	autoPingEventsMu sync.Mutex
 	activeAutoPings  map[string]bool
 
-	processDaemonSubmit        daemonSubmitProcessor
-	daemonSubmitSem            chan struct{}
-	daemonSubmitResults        chan daemonSubmitRuntimeResult
-	activeDaemonSubmitSessions map[string]bool
+	processDaemonSubmit           daemonSubmitProcessor
+	daemonSubmitSem               chan struct{}
+	daemonSubmitResults           chan daemonSubmitRuntimeResult
+	activeDaemonSubmitKeys        map[string]bool
+	mailboxProjectionSyncMu       sync.Mutex
+	activeMailboxProjectionSyncs  map[string]bool
+	pendingMailboxProjectionSyncs map[string]bool
+	mailboxProjectionSyncWG       sync.WaitGroup
 }
 
 const daemonSubmitWorkerLimit = 4
@@ -74,7 +78,7 @@ type daemonSubmitProcessor func(requestPath string) (daemonSubmitProcessResult, 
 
 type daemonSubmitRuntimeResult struct {
 	requestPath string
-	sessionKey  string
+	dispatchKey string
 	result      daemonSubmitProcessResult
 	err         error
 }
@@ -114,31 +118,33 @@ func newDaemonRuntime(
 	selfSession string,
 ) *daemonRuntime {
 	return &daemonRuntime{
-		baseDir:                    baseDir,
-		sessionDir:                 sessionDir,
-		contextID:                  contextID,
-		configPath:                 configPath,
-		selfSession:                selfSession,
-		cfg:                        cfg,
-		watcher:                    watcher,
-		adjacency:                  adjacency,
-		nodes:                      nodes,
-		knownNodes:                 knownNodes,
-		events:                     events,
-		configPaths:                configPaths,
-		nodesDirs:                  nodesDirs,
-		daemonState:                daemonState,
-		idleTracker:                idleTracker,
-		sharedNodes:                sharedNodes,
-		watchedDirs:                make(map[string]bool),
-		claimedPanes:               make(map[string]bool),
-		prevSessionNodes:           make(map[string][]string),
-		activePostEvents:           make(map[string]bool),
-		activeAutoPings:            make(map[string]bool),
-		processDaemonSubmit:        processDaemonSubmitRequest,
-		daemonSubmitSem:            make(chan struct{}, daemonSubmitWorkerLimit),
-		daemonSubmitResults:        make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
-		activeDaemonSubmitSessions: make(map[string]bool),
+		baseDir:                       baseDir,
+		sessionDir:                    sessionDir,
+		contextID:                     contextID,
+		configPath:                    configPath,
+		selfSession:                   selfSession,
+		cfg:                           cfg,
+		watcher:                       watcher,
+		adjacency:                     adjacency,
+		nodes:                         nodes,
+		knownNodes:                    knownNodes,
+		events:                        events,
+		configPaths:                   configPaths,
+		nodesDirs:                     nodesDirs,
+		daemonState:                   daemonState,
+		idleTracker:                   idleTracker,
+		sharedNodes:                   sharedNodes,
+		watchedDirs:                   make(map[string]bool),
+		claimedPanes:                  make(map[string]bool),
+		prevSessionNodes:              make(map[string][]string),
+		activePostEvents:              make(map[string]bool),
+		activeAutoPings:               make(map[string]bool),
+		processDaemonSubmit:           processDaemonSubmitRequest,
+		daemonSubmitSem:               make(chan struct{}, daemonSubmitWorkerLimit),
+		daemonSubmitResults:           make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
+		activeDaemonSubmitKeys:        make(map[string]bool),
+		activeMailboxProjectionSyncs:  make(map[string]bool),
+		pendingMailboxProjectionSyncs: make(map[string]bool),
 	}
 }
 
@@ -314,8 +320,8 @@ const (
 
 func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonSubmitDispatchStatus {
 	rt.ensureDaemonSubmitRuntime()
-	sessionKey := daemonSubmitSessionKey(requestPath)
-	if rt.activeDaemonSubmitSessions[sessionKey] {
+	dispatchKey := daemonSubmitDispatchKey(requestPath)
+	if rt.activeDaemonSubmitKeys[dispatchKey] {
 		return daemonSubmitDispatchDeferred
 	}
 	select {
@@ -323,13 +329,13 @@ func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonS
 	default:
 		return daemonSubmitDispatchSaturated
 	}
-	rt.activeDaemonSubmitSessions[sessionKey] = true
+	rt.activeDaemonSubmitKeys[dispatchKey] = true
 	processor := rt.processDaemonSubmit
 
 	go func() {
 		workerResult := daemonSubmitRuntimeResult{
 			requestPath: requestPath,
-			sessionKey:  sessionKey,
+			dispatchKey: dispatchKey,
 		}
 		defer func() {
 			if r := recover(); r != nil {
@@ -354,27 +360,44 @@ func (rt *daemonRuntime) ensureDaemonSubmitRuntime() {
 	if rt.daemonSubmitResults == nil {
 		rt.daemonSubmitResults = make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit)
 	}
-	if rt.activeDaemonSubmitSessions == nil {
-		rt.activeDaemonSubmitSessions = make(map[string]bool)
+	if rt.activeDaemonSubmitKeys == nil {
+		rt.activeDaemonSubmitKeys = make(map[string]bool)
 	}
 }
 
-func daemonSubmitSessionKey(requestPath string) string {
+func daemonSubmitDispatchKey(requestPath string) string {
 	if sessionDir, ok := daemonSubmitSessionDir(requestPath); ok {
-		return sessionDir
+		request, err := projection.ReadDaemonSubmitRequest(requestPath)
+		if err != nil {
+			return "session:" + sessionDir
+		}
+		switch request.Command {
+		case projection.DaemonSubmitPop:
+			if request.Node == "" {
+				return "pop:" + sessionDir
+			}
+			return "pop:" + sessionDir + ":" + request.Node
+		case projection.DaemonSubmitSend:
+			return "send:" + requestPath
+		default:
+			return "request:" + requestPath
+		}
 	}
-	return filepath.Dir(requestPath)
+	return "path:" + requestPath
 }
 
 func (rt *daemonRuntime) handleDaemonSubmitResult(workerResult daemonSubmitRuntimeResult) {
 	rt.ensureDaemonSubmitRuntime()
-	delete(rt.activeDaemonSubmitSessions, workerResult.sessionKey)
+	delete(rt.activeDaemonSubmitKeys, workerResult.dispatchKey)
 	if workerResult.err != nil {
 		rt.events <- tui.DaemonEvent{
 			Type:    "error",
 			Message: fmt.Sprintf("%s %s: %v", projection.SubmitPathDaemon, filepath.Base(workerResult.requestPath), workerResult.err),
 		}
 		return
+	}
+	if workerResult.result.ProjectionSyncSessionDir != "" {
+		rt.scheduleMailboxProjectionSync(workerResult.result.ProjectionSyncSessionDir)
 	}
 	if workerResult.result.hasPostDispatch() {
 		log.Printf("postman: component=%s event=send_reconcile submit_path=%s session=%s file=%s\n",
@@ -652,7 +675,7 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, time.Now())
 	sourceSessionDir := filepath.Dir(filepath.Dir(eventPath))
 	sourceSessionName := filepath.Base(sourceSessionDir)
-	syncMailboxProjection(sourceSessionDir)
+	rt.scheduleMailboxProjectionSync(sourceSessionDir)
 
 	if info.To == "postman" || info.To == "daemon" {
 		return
@@ -667,6 +690,55 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 			"source": "read_move",
 		},
 	}
+}
+
+func (rt *daemonRuntime) ensureMailboxProjectionSyncRuntime() {
+	if rt.activeMailboxProjectionSyncs == nil {
+		rt.activeMailboxProjectionSyncs = make(map[string]bool)
+	}
+	if rt.pendingMailboxProjectionSyncs == nil {
+		rt.pendingMailboxProjectionSyncs = make(map[string]bool)
+	}
+}
+
+func (rt *daemonRuntime) scheduleMailboxProjectionSync(sessionDir string) {
+	if sessionDir == "" {
+		return
+	}
+	rt.ensureMailboxProjectionSyncRuntime()
+	rt.mailboxProjectionSyncMu.Lock()
+	if rt.activeMailboxProjectionSyncs[sessionDir] {
+		rt.pendingMailboxProjectionSyncs[sessionDir] = true
+		rt.mailboxProjectionSyncMu.Unlock()
+		return
+	}
+	rt.activeMailboxProjectionSyncs[sessionDir] = true
+	rt.mailboxProjectionSyncMu.Unlock()
+
+	rt.mailboxProjectionSyncWG.Add(1)
+	go func() {
+		defer rt.mailboxProjectionSyncWG.Done()
+		rt.runMailboxProjectionSync(sessionDir)
+	}()
+}
+
+func (rt *daemonRuntime) runMailboxProjectionSync(sessionDir string) {
+	for {
+		syncMailboxProjection(sessionDir)
+
+		rt.mailboxProjectionSyncMu.Lock()
+		if !rt.pendingMailboxProjectionSyncs[sessionDir] {
+			delete(rt.activeMailboxProjectionSyncs, sessionDir)
+			rt.mailboxProjectionSyncMu.Unlock()
+			return
+		}
+		delete(rt.pendingMailboxProjectionSyncs, sessionDir)
+		rt.mailboxProjectionSyncMu.Unlock()
+	}
+}
+
+func (rt *daemonRuntime) waitForMailboxProjectionSyncs() {
+	rt.mailboxProjectionSyncWG.Wait()
 }
 
 func (rt *daemonRuntime) handleWatcherError(err error) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -410,6 +410,138 @@ func TestHandleWatcherEvent_DaemonSubmitWorkerDoesNotBlockSessionStatusTick(t *t
 	}
 }
 
+func TestDispatchDaemonSubmitRequest_AllowsSendWhilePopActive(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	popPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-pop",
+		Command:   projection.DaemonSubmitPop,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Node:      "worker",
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(pop): %v", err)
+	}
+	sendPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-send",
+		Command:   projection.DaemonSubmitSend,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Filename:  "20260521-093000-r1111-from-orchestrator-to-worker.md",
+		Content:   "hello",
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(send): %v", err)
+	}
+
+	started := make(chan projection.DaemonSubmitCommand, 2)
+	releasePop := make(chan struct{})
+	rt := &daemonRuntime{
+		processDaemonSubmit: func(requestPath string) (daemonSubmitProcessResult, error) {
+			request, err := projection.ReadDaemonSubmitRequest(requestPath)
+			if err != nil {
+				return daemonSubmitProcessResult{}, err
+			}
+			started <- request.Command
+			if request.Command == projection.DaemonSubmitPop {
+				<-releasePop
+			}
+			return daemonSubmitProcessResult{}, nil
+		},
+	}
+	defer close(releasePop)
+
+	if status := rt.dispatchDaemonSubmitRequest(popPath); status != daemonSubmitDispatched {
+		t.Fatalf("dispatch pop status = %v, want dispatched", status)
+	}
+	if got := <-started; got != projection.DaemonSubmitPop {
+		t.Fatalf("first started command = %q, want pop", got)
+	}
+
+	if status := rt.dispatchDaemonSubmitRequest(sendPath); status != daemonSubmitDispatched {
+		t.Fatalf("dispatch send status = %v, want dispatched while pop is active", status)
+	}
+	select {
+	case got := <-started:
+		if got != projection.DaemonSubmitSend {
+			t.Fatalf("second started command = %q, want send", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("send did not start while unrelated pop was active")
+	}
+}
+
+func TestDispatchDaemonSubmitRequest_SerializesSameNodePopOnly(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	popWorker1, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-pop-worker-1",
+		Command:   projection.DaemonSubmitPop,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Node:      "worker",
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(worker 1): %v", err)
+	}
+	popWorker2, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-pop-worker-2",
+		Command:   projection.DaemonSubmitPop,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Node:      "worker",
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(worker 2): %v", err)
+	}
+	popReviewer, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-pop-reviewer",
+		Command:   projection.DaemonSubmitPop,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Node:      "reviewer",
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(reviewer): %v", err)
+	}
+
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	rt := &daemonRuntime{
+		processDaemonSubmit: func(requestPath string) (daemonSubmitProcessResult, error) {
+			request, err := projection.ReadDaemonSubmitRequest(requestPath)
+			if err != nil {
+				return daemonSubmitProcessResult{}, err
+			}
+			started <- request.RequestID
+			<-release
+			return daemonSubmitProcessResult{}, nil
+		},
+	}
+	defer close(release)
+
+	if status := rt.dispatchDaemonSubmitRequest(popWorker1); status != daemonSubmitDispatched {
+		t.Fatalf("dispatch first worker pop status = %v, want dispatched", status)
+	}
+	if got := <-started; got != "req-pop-worker-1" {
+		t.Fatalf("first started request = %q, want req-pop-worker-1", got)
+	}
+	if status := rt.dispatchDaemonSubmitRequest(popWorker2); status != daemonSubmitDispatchDeferred {
+		t.Fatalf("dispatch second worker pop status = %v, want deferred", status)
+	}
+	if status := rt.dispatchDaemonSubmitRequest(popReviewer); status != daemonSubmitDispatched {
+		t.Fatalf("dispatch reviewer pop status = %v, want dispatched", status)
+	}
+	select {
+	case got := <-started:
+		if got != "req-pop-reviewer" {
+			t.Fatalf("second started request = %q, want req-pop-reviewer", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("different-node pop did not start while worker pop was active")
+	}
+}
+
 func TestHandleSessionScanTick_EmitsRenameAndDeleteSnapshots(t *testing.T) {
 	tmpDir := t.TempDir()
 	installRuntimeSessionScanTmux(t, tmpDir, []string{"review"})

--- a/internal/daemon/watcher_event_test.go
+++ b/internal/daemon/watcher_event_test.go
@@ -207,6 +207,7 @@ func TestHandleWatcherEvent_ReadRenameMarksRecipientAliveAndSyncsProjection(t *t
 	if got := projected.Read[readKey].Content; got != content {
 		t.Fatalf("projected read content = %q, want %q", got, content)
 	}
+	rt.waitForMailboxProjectionSyncs()
 }
 
 func TestRunDaemonLoop_WatcherErrorIsNonFatalAndLaterReadEventIsProcessed(t *testing.T) {

--- a/internal/projection/daemon_submit.go
+++ b/internal/projection/daemon_submit.go
@@ -48,6 +48,15 @@ type DaemonSubmitResponse struct {
 	Error         string              `json:"error,omitempty"`
 }
 
+type DaemonSubmitResponseTimeoutError struct {
+	RequestID string
+	Timeout   time.Duration
+}
+
+func (e DaemonSubmitResponseTimeoutError) Error() string {
+	return fmt.Sprintf("timed out waiting for daemon submit response %q after %s", e.RequestID, e.Timeout)
+}
+
 func DaemonSubmitRequestsDir(sessionDir string) string {
 	return filepath.Join(sessionDir, "snapshot", string(SubmitPathDaemon), "requests")
 }
@@ -134,7 +143,10 @@ func WaitDaemonSubmitResponse(sessionDir, requestID string, timeout time.Duratio
 			return DaemonSubmitResponse{}, "", err
 		}
 		if time.Now().After(deadline) {
-			return DaemonSubmitResponse{}, "", fmt.Errorf("timed out waiting for daemon submit response %q", requestID)
+			return DaemonSubmitResponse{}, "", DaemonSubmitResponseTimeoutError{
+				RequestID: requestID,
+				Timeout:   timeout,
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary
- Reduces daemon-submit queue latency by narrowing worker scheduling and moving expensive pop projection sync work out of the response path.
- Adds daemon-submit latency accounting, stale response cleanup, and timeout guidance for side-effecting submit requests.
- Adds loaded-session latency benchmark coverage plus focused runtime and CLI tests for queueing, cleanup, and timeout output.

Closes #486.

## Verification
- `git diff --check`
- `go test ./internal/cli ./internal/daemon ./internal/projection -run Test`
- `go test ./...`
- `nix flake check`
- `nix build`
