### PR TITLE
refactor(daemon): add localized clock seams (#478)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -250,14 +250,14 @@ func recordDaemonSubmitPopRead(sessionDir, readPath, filename, fallbackContent s
 		filepath.Join("read", filename),
 		content,
 	))
+	syncMailboxProjection(sessionDir)
 }
 
 type daemonSubmitProcessResult struct {
-	Command                  projection.DaemonSubmitCommand
-	SessionDir               string
-	Filename                 string
-	PostPath                 string
-	ProjectionSyncSessionDir string
+	Command    projection.DaemonSubmitCommand
+	SessionDir string
+	Filename   string
+	PostPath   string
 }
 
 func (r daemonSubmitProcessResult) hasPostDispatch() bool {
@@ -296,10 +296,8 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		Command:    request.Command,
 		SessionDir: sessionDir,
 	}
-	processingStartedAt := time.Now()
-	queueMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, processingStartedAt))
-	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s queue_ms=%d\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename, queueMs)
+	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename)
 
 	var response projection.DaemonSubmitResponse
 	switch request.Command {
@@ -311,9 +309,6 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		}
 	case projection.DaemonSubmitPop:
 		response, err = handleDaemonSubmitPop(sessionDir, request)
-		if err == nil && !response.Empty {
-			result.ProjectionSyncSessionDir = sessionDir
-		}
 	default:
 		err = fmt.Errorf("unsupported daemon submit command %q", request.Command)
 		response = projection.DaemonSubmitResponse{
@@ -328,33 +323,12 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 	if _, writeErr := projection.WriteDaemonSubmitResponse(sessionDir, response); writeErr != nil {
 		return result, writeErr
 	}
-	responseWrittenAt := time.Now()
-	handlerMs := daemonSubmitDurationMillis(responseWrittenAt.Sub(processingStartedAt))
-	totalMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, responseWrittenAt))
-	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t queue_ms=%d handler_ms=%d total_ms=%d\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "", queueMs, handlerMs, totalMs)
+	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "")
 	if removeErr := os.Remove(claimedPath); removeErr != nil && !os.IsNotExist(removeErr) {
 		log.Printf("postman: WARNING: component=%s event=request_remove_failed submit_path=%s path=%s err=%v\n", projection.SubmitPathDaemon, projection.SubmitPathDaemon, claimedPath, removeErr)
 	}
 	return result, nil
-}
-
-func daemonSubmitDurationSince(createdAt string, now time.Time) time.Duration {
-	if createdAt == "" {
-		return -1
-	}
-	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
-	if err != nil {
-		return -1
-	}
-	return now.Sub(parsed)
-}
-
-func daemonSubmitDurationMillis(duration time.Duration) int64 {
-	if duration < 0 {
-		return -1
-	}
-	return duration.Milliseconds()
 }
 
 // DaemonState manages daemon state (Issue #71).
@@ -517,17 +491,14 @@ func RunDaemonLoop(
 		select {
 		case <-ctx.Done():
 			runtime.handleContextDone()
-			runtime.waitForMailboxProjectionSyncs()
 			return
 		case event, ok := <-watcher.Events:
 			if !ok {
-				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherEvent(event)
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherError(err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -250,14 +250,14 @@ func recordDaemonSubmitPopRead(sessionDir, readPath, filename, fallbackContent s
 		filepath.Join("read", filename),
 		content,
 	))
-	syncMailboxProjection(sessionDir)
 }
 
 type daemonSubmitProcessResult struct {
-	Command    projection.DaemonSubmitCommand
-	SessionDir string
-	Filename   string
-	PostPath   string
+	Command                  projection.DaemonSubmitCommand
+	SessionDir               string
+	Filename                 string
+	PostPath                 string
+	ProjectionSyncSessionDir string
 }
 
 func (r daemonSubmitProcessResult) hasPostDispatch() bool {
@@ -296,8 +296,10 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		Command:    request.Command,
 		SessionDir: sessionDir,
 	}
-	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename)
+	processingStartedAt := time.Now()
+	queueMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, processingStartedAt))
+	log.Printf("postman: component=%s event=request_processing submit_path=%s command=%s session=%s request=%s file=%s queue_ms=%d\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, request.Filename, queueMs)
 
 	var response projection.DaemonSubmitResponse
 	switch request.Command {
@@ -309,6 +311,9 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 		}
 	case projection.DaemonSubmitPop:
 		response, err = handleDaemonSubmitPop(sessionDir, request)
+		if err == nil && !response.Empty {
+			result.ProjectionSyncSessionDir = sessionDir
+		}
 	default:
 		err = fmt.Errorf("unsupported daemon submit command %q", request.Command)
 		response = projection.DaemonSubmitResponse{
@@ -323,12 +328,33 @@ func processDaemonSubmitRequest(requestPath string) (daemonSubmitProcessResult, 
 	if _, writeErr := projection.WriteDaemonSubmitResponse(sessionDir, response); writeErr != nil {
 		return result, writeErr
 	}
-	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t\n",
-		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "")
+	responseWrittenAt := time.Now()
+	handlerMs := daemonSubmitDurationMillis(responseWrittenAt.Sub(processingStartedAt))
+	totalMs := daemonSubmitDurationMillis(daemonSubmitDurationSince(request.CreatedAt, responseWrittenAt))
+	log.Printf("postman: component=%s event=response_written submit_path=%s command=%s session=%s request=%s file=%s error=%t queue_ms=%d handler_ms=%d total_ms=%d\n",
+		projection.SubmitPathDaemon, projection.SubmitPathDaemon, request.Command, filepath.Base(sessionDir), request.RequestID, response.Filename, response.Error != "", queueMs, handlerMs, totalMs)
 	if removeErr := os.Remove(claimedPath); removeErr != nil && !os.IsNotExist(removeErr) {
 		log.Printf("postman: WARNING: component=%s event=request_remove_failed submit_path=%s path=%s err=%v\n", projection.SubmitPathDaemon, projection.SubmitPathDaemon, claimedPath, removeErr)
 	}
 	return result, nil
+}
+
+func daemonSubmitDurationSince(createdAt string, now time.Time) time.Duration {
+	if createdAt == "" {
+		return -1
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return -1
+	}
+	return now.Sub(parsed)
+}
+
+func daemonSubmitDurationMillis(duration time.Duration) int64 {
+	if duration < 0 {
+		return -1
+	}
+	return duration.Milliseconds()
 }
 
 // DaemonState manages daemon state (Issue #71).
@@ -491,14 +517,17 @@ func RunDaemonLoop(
 		select {
 		case <-ctx.Done():
 			runtime.handleContextDone()
+			runtime.waitForMailboxProjectionSyncs()
 			return
 		case event, ok := <-watcher.Events:
 			if !ok {
+				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherEvent(event)
 		case err, ok := <-watcher.Errors:
 			if !ok {
+				runtime.waitForMailboxProjectionSyncs()
 				return
 			}
 			runtime.handleWatcherError(err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -346,15 +346,23 @@ type DaemonState struct {
 	lastDeliveryMu                sync.RWMutex               // Issue #211: Mutex for lastDeliveryBySenderRecipient
 	swallowedRetryCount           map[string]int             // Issue #282: inbox file path -> re-delivery attempt count
 	swallowedRetryCountMu         sync.Mutex                 // Issue #282
+	clock                         func() time.Time
 }
 
 // NewDaemonState creates a new DaemonState instance (Issue #71).
 // drainWindowSeconds configures the startup drain window during which
 // IsSessionEnabled returns true for all sessions (#217).
 func NewDaemonState(drainWindowSeconds float64, contextID string) *DaemonState {
+	return newDaemonStateWithClock(drainWindowSeconds, contextID, time.Now)
+}
+
+func newDaemonStateWithClock(drainWindowSeconds float64, contextID string, clock func() time.Time) *DaemonState {
+	if clock == nil {
+		clock = time.Now
+	}
 	return &DaemonState{
 		contextID:                     contextID,
-		startedAt:                     time.Now(),
+		startedAt:                     clock(),
 		drainWindow:                   time.Duration(drainWindowSeconds * float64(time.Second)),
 		enabledSessions:               make(map[string]bool),
 		prevPaneStates:                make(map[string]uinode.PaneInfo), // Issue #98
@@ -362,7 +370,15 @@ func NewDaemonState(drainWindowSeconds float64, contextID string) *DaemonState {
 		lastDeliveryBySenderRecipient: make(map[string]time.Time),       // Issue #211
 		reservedDeliveryByRoute:       make(map[string]time.Time),
 		swallowedRetryCount:           make(map[string]int),
+		clock:                         clock,
 	}
+}
+
+func (ds *DaemonState) now() time.Time {
+	if ds.clock == nil {
+		return time.Now()
+	}
+	return ds.clock()
 }
 
 func (ds *DaemonState) reserveDeliveryRoute(route string, gap time.Duration, now time.Time) (time.Duration, time.Time, bool) {
@@ -649,7 +665,7 @@ func (ds *DaemonState) SetSessionEnabled(sessionName string, enabled bool) {
 	ds.enabledSessions[sessionName] = enabled
 	ds.enabledSessionsMu.Unlock()
 	log.Printf("postman: session state change: session=%s enabled=%v source=toggle ts=%s\n",
-		sessionName, enabled, time.Now().UTC().Format(time.RFC3339Nano))
+		sessionName, enabled, ds.now().UTC().Format(time.RFC3339Nano))
 	ds.persistSessionEnabledMarker(sessionName, enabled)
 }
 
@@ -676,7 +692,7 @@ func (ds *DaemonState) AutoEnableSessionIfNew(sessionName string) {
 	ds.enabledSessions[sessionName] = true
 	ds.enabledSessionsMu.Unlock()
 	log.Printf("postman: session state change: session=%s enabled=true source=auto-enable ts=%s\n",
-		sessionName, time.Now().UTC().Format(time.RFC3339Nano))
+		sessionName, ds.now().UTC().Format(time.RFC3339Nano))
 	ds.persistSessionEnabledMarker(sessionName, true)
 }
 
@@ -691,7 +707,7 @@ func (ds *DaemonState) hasConfiguredSession(sessionName string) bool {
 // During the startup drain window, returns true for all sessions to prevent
 // the race where messages are rejected before sessions are registered (#217).
 func (ds *DaemonState) IsSessionEnabled(sessionName string) bool {
-	if ds.drainWindow > 0 && time.Since(ds.startedAt) < ds.drainWindow {
+	if ds.drainWindow > 0 && ds.now().Sub(ds.startedAt) < ds.drainWindow {
 		return true
 	}
 	ds.enabledSessionsMu.RLock()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -46,6 +46,73 @@ func TestCheckPaneRestarts_IgnoresWinnerSwapWhileOldPaneStillLive(t *testing.T) 
 	}
 }
 
+func TestDaemonStateDrainWindowUsesInjectedClock(t *testing.T) {
+	now := time.Date(2026, time.May, 21, 5, 0, 0, 0, time.UTC)
+	ds := newDaemonStateWithClock(10, "ctx-main", func() time.Time { return now })
+
+	if !ds.IsSessionEnabled("review") {
+		t.Fatal("session should be enabled during startup drain window")
+	}
+
+	now = now.Add(11 * time.Second)
+	if ds.IsSessionEnabled("review") {
+		t.Fatal("unconfigured session stayed enabled after startup drain window")
+	}
+
+	ds.SetSessionEnabled("review", true)
+	if !ds.IsSessionEnabled("review") {
+		t.Fatal("configured session should be enabled after startup drain window")
+	}
+}
+
+func TestReserveDeliveryRouteUsesExplicitClock(t *testing.T) {
+	ds := NewDaemonState(0, "ctx-main")
+	route := "orchestrator:messenger"
+	gap := 10 * time.Second
+	start := time.Date(2026, time.May, 21, 6, 0, 0, 0, time.UTC)
+
+	remaining, reservedAt, ok := ds.reserveDeliveryRoute(route, gap, start)
+	if !ok {
+		t.Fatal("first reservation was rejected")
+	}
+	if remaining != 0 {
+		t.Fatalf("first reservation remaining = %s, want 0", remaining)
+	}
+	if !reservedAt.Equal(start) {
+		t.Fatalf("reservedAt = %v, want %v", reservedAt, start)
+	}
+
+	remaining, _, ok = ds.reserveDeliveryRoute(route, gap, start.Add(3*time.Second))
+	if ok {
+		t.Fatal("second reservation was allowed while the first was in flight")
+	}
+	if remaining != 7*time.Second {
+		t.Fatalf("in-flight remaining = %s, want 7s", remaining)
+	}
+
+	finishedAt := start.Add(4 * time.Second)
+	ds.finishDeliveryRoute(route, reservedAt, true, true, finishedAt)
+
+	remaining, _, ok = ds.reserveDeliveryRoute(route, gap, start.Add(9*time.Second))
+	if ok {
+		t.Fatal("reservation was allowed before delivery gap elapsed")
+	}
+	if remaining != 5*time.Second {
+		t.Fatalf("post-delivery remaining = %s, want 5s", remaining)
+	}
+
+	remaining, reservedAt, ok = ds.reserveDeliveryRoute(route, gap, start.Add(15*time.Second))
+	if !ok {
+		t.Fatal("reservation was rejected after delivery gap elapsed")
+	}
+	if remaining != 0 {
+		t.Fatalf("post-gap remaining = %s, want 0", remaining)
+	}
+	if !reservedAt.Equal(start.Add(15 * time.Second)) {
+		t.Fatalf("post-gap reservedAt = %v, want %v", reservedAt, start.Add(15*time.Second))
+	}
+}
+
 // TestHasNodeSentSince verifies swallowed-message detection logic (Issue #282).
 // NOTE: checkSwallowedMessages itself is not unit-tested because it depends on
 // filesystem state (real inbox/ directories), tmux (via notification.SendToPane),

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -45,6 +45,7 @@ type daemonRuntime struct {
 	nodesDirs   []string
 	daemonState *DaemonState
 	idleTracker *idle.IdleTracker
+	clock       func() time.Time
 
 	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]
 
@@ -62,15 +63,10 @@ type daemonRuntime struct {
 	autoPingEventsMu sync.Mutex
 	activeAutoPings  map[string]bool
 
-	processDaemonSubmit           daemonSubmitProcessor
-	daemonSubmitSem               chan struct{}
-	daemonSubmitResults           chan daemonSubmitRuntimeResult
-	activeDaemonSubmitKeys        map[string]bool
-	mailboxProjectionSyncMu       sync.Mutex
-	activeMailboxProjectionSyncs  map[string]bool
-	pendingMailboxProjectionSyncs map[string]bool
-	mailboxProjectionSyncWG       sync.WaitGroup
-	clock                         func() time.Time
+	processDaemonSubmit        daemonSubmitProcessor
+	daemonSubmitSem            chan struct{}
+	daemonSubmitResults        chan daemonSubmitRuntimeResult
+	activeDaemonSubmitSessions map[string]bool
 }
 
 const daemonSubmitWorkerLimit = 4
@@ -79,7 +75,7 @@ type daemonSubmitProcessor func(requestPath string) (daemonSubmitProcessResult, 
 
 type daemonSubmitRuntimeResult struct {
 	requestPath string
-	dispatchKey string
+	sessionKey  string
 	result      daemonSubmitProcessResult
 	err         error
 }
@@ -119,34 +115,31 @@ func newDaemonRuntime(
 	selfSession string,
 ) *daemonRuntime {
 	return &daemonRuntime{
-		baseDir:                       baseDir,
-		sessionDir:                    sessionDir,
-		contextID:                     contextID,
-		configPath:                    configPath,
-		selfSession:                   selfSession,
-		cfg:                           cfg,
-		watcher:                       watcher,
-		adjacency:                     adjacency,
-		nodes:                         nodes,
-		knownNodes:                    knownNodes,
-		events:                        events,
-		configPaths:                   configPaths,
-		nodesDirs:                     nodesDirs,
-		daemonState:                   daemonState,
-		idleTracker:                   idleTracker,
-		sharedNodes:                   sharedNodes,
-		watchedDirs:                   make(map[string]bool),
-		claimedPanes:                  make(map[string]bool),
-		prevSessionNodes:              make(map[string][]string),
-		activePostEvents:              make(map[string]bool),
-		activeAutoPings:               make(map[string]bool),
-		processDaemonSubmit:           processDaemonSubmitRequest,
-		daemonSubmitSem:               make(chan struct{}, daemonSubmitWorkerLimit),
-		daemonSubmitResults:           make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
-		activeDaemonSubmitKeys:        make(map[string]bool),
-		activeMailboxProjectionSyncs:  make(map[string]bool),
-		pendingMailboxProjectionSyncs: make(map[string]bool),
-		clock:                         time.Now,
+		baseDir:                    baseDir,
+		sessionDir:                 sessionDir,
+		contextID:                  contextID,
+		configPath:                 configPath,
+		selfSession:                selfSession,
+		cfg:                        cfg,
+		watcher:                    watcher,
+		adjacency:                  adjacency,
+		nodes:                      nodes,
+		knownNodes:                 knownNodes,
+		events:                     events,
+		configPaths:                configPaths,
+		nodesDirs:                  nodesDirs,
+		daemonState:                daemonState,
+		idleTracker:                idleTracker,
+		sharedNodes:                sharedNodes,
+		watchedDirs:                make(map[string]bool),
+		claimedPanes:               make(map[string]bool),
+		prevSessionNodes:           make(map[string][]string),
+		activePostEvents:           make(map[string]bool),
+		activeAutoPings:            make(map[string]bool),
+		processDaemonSubmit:        processDaemonSubmitRequest,
+		daemonSubmitSem:            make(chan struct{}, daemonSubmitWorkerLimit),
+		daemonSubmitResults:        make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
+		activeDaemonSubmitSessions: make(map[string]bool),
 	}
 }
 
@@ -330,8 +323,8 @@ const (
 
 func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonSubmitDispatchStatus {
 	rt.ensureDaemonSubmitRuntime()
-	dispatchKey := daemonSubmitDispatchKey(requestPath)
-	if rt.activeDaemonSubmitKeys[dispatchKey] {
+	sessionKey := daemonSubmitSessionKey(requestPath)
+	if rt.activeDaemonSubmitSessions[sessionKey] {
 		return daemonSubmitDispatchDeferred
 	}
 	select {
@@ -339,13 +332,13 @@ func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonS
 	default:
 		return daemonSubmitDispatchSaturated
 	}
-	rt.activeDaemonSubmitKeys[dispatchKey] = true
+	rt.activeDaemonSubmitSessions[sessionKey] = true
 	processor := rt.processDaemonSubmit
 
 	go func() {
 		workerResult := daemonSubmitRuntimeResult{
 			requestPath: requestPath,
-			dispatchKey: dispatchKey,
+			sessionKey:  sessionKey,
 		}
 		defer func() {
 			if r := recover(); r != nil {
@@ -370,44 +363,27 @@ func (rt *daemonRuntime) ensureDaemonSubmitRuntime() {
 	if rt.daemonSubmitResults == nil {
 		rt.daemonSubmitResults = make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit)
 	}
-	if rt.activeDaemonSubmitKeys == nil {
-		rt.activeDaemonSubmitKeys = make(map[string]bool)
+	if rt.activeDaemonSubmitSessions == nil {
+		rt.activeDaemonSubmitSessions = make(map[string]bool)
 	}
 }
 
-func daemonSubmitDispatchKey(requestPath string) string {
+func daemonSubmitSessionKey(requestPath string) string {
 	if sessionDir, ok := daemonSubmitSessionDir(requestPath); ok {
-		request, err := projection.ReadDaemonSubmitRequest(requestPath)
-		if err != nil {
-			return "session:" + sessionDir
-		}
-		switch request.Command {
-		case projection.DaemonSubmitPop:
-			if request.Node == "" {
-				return "pop:" + sessionDir
-			}
-			return "pop:" + sessionDir + ":" + request.Node
-		case projection.DaemonSubmitSend:
-			return "send:" + requestPath
-		default:
-			return "request:" + requestPath
-		}
+		return sessionDir
 	}
-	return "path:" + requestPath
+	return filepath.Dir(requestPath)
 }
 
 func (rt *daemonRuntime) handleDaemonSubmitResult(workerResult daemonSubmitRuntimeResult) {
 	rt.ensureDaemonSubmitRuntime()
-	delete(rt.activeDaemonSubmitKeys, workerResult.dispatchKey)
+	delete(rt.activeDaemonSubmitSessions, workerResult.sessionKey)
 	if workerResult.err != nil {
 		rt.events <- tui.DaemonEvent{
 			Type:    "error",
 			Message: fmt.Sprintf("%s %s: %v", projection.SubmitPathDaemon, filepath.Base(workerResult.requestPath), workerResult.err),
 		}
 		return
-	}
-	if workerResult.result.ProjectionSyncSessionDir != "" {
-		rt.scheduleMailboxProjectionSync(workerResult.result.ProjectionSyncSessionDir)
 	}
 	if workerResult.result.hasPostDispatch() {
 		log.Printf("postman: component=%s event=send_reconcile submit_path=%s session=%s file=%s\n",
@@ -686,7 +662,7 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, rt.now())
 	sourceSessionDir := filepath.Dir(filepath.Dir(eventPath))
 	sourceSessionName := filepath.Base(sourceSessionDir)
-	rt.scheduleMailboxProjectionSync(sourceSessionDir)
+	syncMailboxProjection(sourceSessionDir)
 
 	if info.To == "postman" || info.To == "daemon" {
 		return
@@ -701,55 +677,6 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 			"source": "read_move",
 		},
 	}
-}
-
-func (rt *daemonRuntime) ensureMailboxProjectionSyncRuntime() {
-	if rt.activeMailboxProjectionSyncs == nil {
-		rt.activeMailboxProjectionSyncs = make(map[string]bool)
-	}
-	if rt.pendingMailboxProjectionSyncs == nil {
-		rt.pendingMailboxProjectionSyncs = make(map[string]bool)
-	}
-}
-
-func (rt *daemonRuntime) scheduleMailboxProjectionSync(sessionDir string) {
-	if sessionDir == "" {
-		return
-	}
-	rt.ensureMailboxProjectionSyncRuntime()
-	rt.mailboxProjectionSyncMu.Lock()
-	if rt.activeMailboxProjectionSyncs[sessionDir] {
-		rt.pendingMailboxProjectionSyncs[sessionDir] = true
-		rt.mailboxProjectionSyncMu.Unlock()
-		return
-	}
-	rt.activeMailboxProjectionSyncs[sessionDir] = true
-	rt.mailboxProjectionSyncMu.Unlock()
-
-	rt.mailboxProjectionSyncWG.Add(1)
-	go func() {
-		defer rt.mailboxProjectionSyncWG.Done()
-		rt.runMailboxProjectionSync(sessionDir)
-	}()
-}
-
-func (rt *daemonRuntime) runMailboxProjectionSync(sessionDir string) {
-	for {
-		syncMailboxProjection(sessionDir)
-
-		rt.mailboxProjectionSyncMu.Lock()
-		if !rt.pendingMailboxProjectionSyncs[sessionDir] {
-			delete(rt.activeMailboxProjectionSyncs, sessionDir)
-			rt.mailboxProjectionSyncMu.Unlock()
-			return
-		}
-		delete(rt.pendingMailboxProjectionSyncs, sessionDir)
-		rt.mailboxProjectionSyncMu.Unlock()
-	}
-}
-
-func (rt *daemonRuntime) waitForMailboxProjectionSyncs() {
-	rt.mailboxProjectionSyncWG.Wait()
 }
 
 func (rt *daemonRuntime) handleWatcherError(err error) {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -66,6 +66,7 @@ type daemonRuntime struct {
 	daemonSubmitSem            chan struct{}
 	daemonSubmitResults        chan daemonSubmitRuntimeResult
 	activeDaemonSubmitSessions map[string]bool
+	clock                      func() time.Time
 }
 
 const daemonSubmitWorkerLimit = 4
@@ -139,7 +140,15 @@ func newDaemonRuntime(
 		daemonSubmitSem:            make(chan struct{}, daemonSubmitWorkerLimit),
 		daemonSubmitResults:        make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
 		activeDaemonSubmitSessions: make(map[string]bool),
+		clock:                      time.Now,
 	}
+}
+
+func (rt *daemonRuntime) now() time.Time {
+	if rt.clock == nil {
+		return time.Now()
+	}
+	return rt.clock()
 }
 
 func buildRuntimeStatusSnapshot(nodes map[string]discovery.NodeInfo, allSessions []string, isSessionEnabled func(string) bool) runtimeStatusSnapshot {
@@ -253,14 +262,15 @@ func resumeMailboxProjections(primarySessionDir string, nodes map[string]discove
 func (rt *daemonRuntime) bootstrap() {
 	rt.storeSharedNodes()
 
-	installShadowJournalManager(rt.sessionDir, rt.contextID, rt.selfSession, time.Now())
+	now := rt.now()
+	installShadowJournalManager(rt.sessionDir, rt.contextID, rt.selfSession, now)
 	if err := resumeMailboxProjections(rt.sessionDir, rt.nodes); err != nil {
 		log.Printf("postman: WARNING: %v\n", err)
 	}
 	rt.dispatchPendingDaemonSubmitRequests()
-	rt.recordPendingAutoPings(startupAutoPingNodeKeys(rt.nodes, rt.cfg), rt.nodes, "startup", time.Now())
+	rt.recordPendingAutoPings(startupAutoPingNodeKeys(rt.nodes, rt.cfg), rt.nodes, "startup", now)
 	autoEnableSessions := config.BoolVal(rt.cfg.AutoEnableNewSessions, true)
-	rt.dispatchPendingAutoPings(rt.nodes, autoEnableSessions, time.Now())
+	rt.dispatchPendingAutoPings(rt.nodes, autoEnableSessions, now)
 	rt.dispatchPendingPostMessages()
 }
 
@@ -460,7 +470,8 @@ func (rt *daemonRuntime) processActivePostEvent(eventPath, filename string) {
 		return
 	}
 
-	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionPostedEventType, journal.VisibilityMailboxProjection, time.Now())
+	now := rt.now()
+	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionPostedEventType, journal.VisibilityMailboxProjection, now)
 	sourceSessionDir := filepath.Dir(filepath.Dir(eventPath))
 	syncMailboxProjection(sourceSessionDir)
 
@@ -469,11 +480,11 @@ func (rt *daemonRuntime) processActivePostEvent(eventPath, filename string) {
 		rt.claimNewPanes(freshNodes)
 		rt.pruneKnownNodes(freshNodes)
 		newNodes := rt.detectNewNodes(freshNodes)
-		rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", time.Now())
+		rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", now)
 		rt.logPaneIDChanges(freshNodes)
 		rt.nodes = freshNodes
 		rt.storeSharedNodes()
-		rt.dispatchPendingAutoPings(freshNodes, config.BoolVal(rt.cfg.AutoEnableNewSessions, true), time.Now())
+		rt.dispatchPendingAutoPings(freshNodes, config.BoolVal(rt.cfg.AutoEnableNewSessions, true), now)
 
 		allSessions, _ := discovery.DiscoverAllSessions()
 		if allSessions == nil {
@@ -505,7 +516,7 @@ func (rt *daemonRuntime) reservePostDeliveryOrScheduleRetry(eventPath, filename 
 	}
 
 	gap := time.Duration(rt.cfg.MinDeliveryGapSeconds * float64(time.Second))
-	remaining, reservedAt, ok := rt.daemonState.reserveDeliveryRoute(deliveryKey, gap, time.Now())
+	remaining, reservedAt, ok := rt.daemonState.reserveDeliveryRoute(deliveryKey, gap, rt.now())
 	if !ok {
 		rt.scheduleRateLimitedPostRetry(eventPath, filename, msgInfo.From, msgInfo.To, remaining, rt.cfg.MinDeliveryGapSeconds)
 		return postDeliveryReservation{}, false
@@ -541,7 +552,7 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 		deliveredNormally := false
 		defer func() {
 			if reservation.route != "" {
-				rt.daemonState.finishDeliveryRoute(reservation.route, reservation.reservedAt, reservation.hasReservation, deliveredNormally, time.Now())
+				rt.daemonState.finishDeliveryRoute(reservation.route, reservation.reservedAt, reservation.hasReservation, deliveredNormally, rt.now())
 			}
 			rt.finishPostEvent(eventPath)
 		}()
@@ -649,7 +660,7 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 		return
 	}
 
-	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, time.Now())
+	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, rt.now())
 	sourceSessionDir := filepath.Dir(filepath.Dir(eventPath))
 	sourceSessionName := filepath.Base(sourceSessionDir)
 	syncMailboxProjection(sourceSessionDir)
@@ -699,7 +710,8 @@ func (rt *daemonRuntime) handleScanTick() {
 	autoEnableSessions := config.BoolVal(rt.cfg.AutoEnableNewSessions, true)
 	rt.pruneKnownNodes(freshNodes)
 	newNodes := rt.detectNewNodes(freshNodes)
-	rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", time.Now())
+	now := rt.now()
+	rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", now)
 	rt.nodes = freshNodes
 	rt.storeSharedNodes()
 
@@ -735,12 +747,12 @@ func (rt *daemonRuntime) handleScanTick() {
 
 			rt.daemonState.checkPaneDisappearance(paneStates, rt.daemonState.prevPaneToNode, rt.nodes, rt.events)
 			restartedNodes := rt.daemonState.checkPaneRestarts(paneStates, paneToNode, rt.nodes, rt.events)
-			rt.recordPendingAutoPings(restartedNodes, rt.nodes, "pane_restart", time.Now())
+			rt.recordPendingAutoPings(restartedNodes, rt.nodes, "pane_restart", now)
 			rt.prevPaneStatesJSON = currentJSONStr
 		}
 	}
 
-	rt.dispatchPendingAutoPings(freshNodes, autoEnableSessions, time.Now())
+	rt.dispatchPendingAutoPings(freshNodes, autoEnableSessions, now)
 	rt.dispatchPendingDaemonSubmitRequests()
 	rt.dispatchPendingPostMessages()
 
@@ -884,10 +896,11 @@ func (rt *daemonRuntime) refreshNodesAfterSessionActivation(allSessions []string
 	}
 	rt.pruneKnownNodes(freshNodes)
 	newNodes := rt.detectNewNodes(freshNodes)
-	rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", time.Now())
+	now := rt.now()
+	rt.recordPendingAutoPings(newNodes, freshNodes, "discovered", now)
 	rt.nodes = freshNodes
 	rt.storeSharedNodes()
-	rt.dispatchPendingAutoPings(freshNodes, config.BoolVal(rt.cfg.AutoEnableNewSessions, true), time.Now())
+	rt.dispatchPendingAutoPings(freshNodes, config.BoolVal(rt.cfg.AutoEnableNewSessions, true), now)
 	rt.emitStatusUpdateIfChanged(allSessions)
 }
 
@@ -1230,7 +1243,7 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 				return
 			}
 
-			rt.recordDeliveredAutoPing(dispatchNodeKey, dispatchNodeInfo, dispatchPending, time.Now())
+			rt.recordDeliveredAutoPing(dispatchNodeKey, dispatchNodeInfo, dispatchPending, rt.now())
 		}()
 	}
 }

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -62,11 +62,15 @@ type daemonRuntime struct {
 	autoPingEventsMu sync.Mutex
 	activeAutoPings  map[string]bool
 
-	processDaemonSubmit        daemonSubmitProcessor
-	daemonSubmitSem            chan struct{}
-	daemonSubmitResults        chan daemonSubmitRuntimeResult
-	activeDaemonSubmitSessions map[string]bool
-	clock                      func() time.Time
+	processDaemonSubmit           daemonSubmitProcessor
+	daemonSubmitSem               chan struct{}
+	daemonSubmitResults           chan daemonSubmitRuntimeResult
+	activeDaemonSubmitKeys        map[string]bool
+	mailboxProjectionSyncMu       sync.Mutex
+	activeMailboxProjectionSyncs  map[string]bool
+	pendingMailboxProjectionSyncs map[string]bool
+	mailboxProjectionSyncWG       sync.WaitGroup
+	clock                         func() time.Time
 }
 
 const daemonSubmitWorkerLimit = 4
@@ -75,7 +79,7 @@ type daemonSubmitProcessor func(requestPath string) (daemonSubmitProcessResult, 
 
 type daemonSubmitRuntimeResult struct {
 	requestPath string
-	sessionKey  string
+	dispatchKey string
 	result      daemonSubmitProcessResult
 	err         error
 }
@@ -115,32 +119,34 @@ func newDaemonRuntime(
 	selfSession string,
 ) *daemonRuntime {
 	return &daemonRuntime{
-		baseDir:                    baseDir,
-		sessionDir:                 sessionDir,
-		contextID:                  contextID,
-		configPath:                 configPath,
-		selfSession:                selfSession,
-		cfg:                        cfg,
-		watcher:                    watcher,
-		adjacency:                  adjacency,
-		nodes:                      nodes,
-		knownNodes:                 knownNodes,
-		events:                     events,
-		configPaths:                configPaths,
-		nodesDirs:                  nodesDirs,
-		daemonState:                daemonState,
-		idleTracker:                idleTracker,
-		sharedNodes:                sharedNodes,
-		watchedDirs:                make(map[string]bool),
-		claimedPanes:               make(map[string]bool),
-		prevSessionNodes:           make(map[string][]string),
-		activePostEvents:           make(map[string]bool),
-		activeAutoPings:            make(map[string]bool),
-		processDaemonSubmit:        processDaemonSubmitRequest,
-		daemonSubmitSem:            make(chan struct{}, daemonSubmitWorkerLimit),
-		daemonSubmitResults:        make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
-		activeDaemonSubmitSessions: make(map[string]bool),
-		clock:                      time.Now,
+		baseDir:                       baseDir,
+		sessionDir:                    sessionDir,
+		contextID:                     contextID,
+		configPath:                    configPath,
+		selfSession:                   selfSession,
+		cfg:                           cfg,
+		watcher:                       watcher,
+		adjacency:                     adjacency,
+		nodes:                         nodes,
+		knownNodes:                    knownNodes,
+		events:                        events,
+		configPaths:                   configPaths,
+		nodesDirs:                     nodesDirs,
+		daemonState:                   daemonState,
+		idleTracker:                   idleTracker,
+		sharedNodes:                   sharedNodes,
+		watchedDirs:                   make(map[string]bool),
+		claimedPanes:                  make(map[string]bool),
+		prevSessionNodes:              make(map[string][]string),
+		activePostEvents:              make(map[string]bool),
+		activeAutoPings:               make(map[string]bool),
+		processDaemonSubmit:           processDaemonSubmitRequest,
+		daemonSubmitSem:               make(chan struct{}, daemonSubmitWorkerLimit),
+		daemonSubmitResults:           make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit),
+		activeDaemonSubmitKeys:        make(map[string]bool),
+		activeMailboxProjectionSyncs:  make(map[string]bool),
+		pendingMailboxProjectionSyncs: make(map[string]bool),
+		clock:                         time.Now,
 	}
 }
 
@@ -324,8 +330,8 @@ const (
 
 func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonSubmitDispatchStatus {
 	rt.ensureDaemonSubmitRuntime()
-	sessionKey := daemonSubmitSessionKey(requestPath)
-	if rt.activeDaemonSubmitSessions[sessionKey] {
+	dispatchKey := daemonSubmitDispatchKey(requestPath)
+	if rt.activeDaemonSubmitKeys[dispatchKey] {
 		return daemonSubmitDispatchDeferred
 	}
 	select {
@@ -333,13 +339,13 @@ func (rt *daemonRuntime) dispatchDaemonSubmitRequest(requestPath string) daemonS
 	default:
 		return daemonSubmitDispatchSaturated
 	}
-	rt.activeDaemonSubmitSessions[sessionKey] = true
+	rt.activeDaemonSubmitKeys[dispatchKey] = true
 	processor := rt.processDaemonSubmit
 
 	go func() {
 		workerResult := daemonSubmitRuntimeResult{
 			requestPath: requestPath,
-			sessionKey:  sessionKey,
+			dispatchKey: dispatchKey,
 		}
 		defer func() {
 			if r := recover(); r != nil {
@@ -364,27 +370,44 @@ func (rt *daemonRuntime) ensureDaemonSubmitRuntime() {
 	if rt.daemonSubmitResults == nil {
 		rt.daemonSubmitResults = make(chan daemonSubmitRuntimeResult, daemonSubmitWorkerLimit)
 	}
-	if rt.activeDaemonSubmitSessions == nil {
-		rt.activeDaemonSubmitSessions = make(map[string]bool)
+	if rt.activeDaemonSubmitKeys == nil {
+		rt.activeDaemonSubmitKeys = make(map[string]bool)
 	}
 }
 
-func daemonSubmitSessionKey(requestPath string) string {
+func daemonSubmitDispatchKey(requestPath string) string {
 	if sessionDir, ok := daemonSubmitSessionDir(requestPath); ok {
-		return sessionDir
+		request, err := projection.ReadDaemonSubmitRequest(requestPath)
+		if err != nil {
+			return "session:" + sessionDir
+		}
+		switch request.Command {
+		case projection.DaemonSubmitPop:
+			if request.Node == "" {
+				return "pop:" + sessionDir
+			}
+			return "pop:" + sessionDir + ":" + request.Node
+		case projection.DaemonSubmitSend:
+			return "send:" + requestPath
+		default:
+			return "request:" + requestPath
+		}
 	}
-	return filepath.Dir(requestPath)
+	return "path:" + requestPath
 }
 
 func (rt *daemonRuntime) handleDaemonSubmitResult(workerResult daemonSubmitRuntimeResult) {
 	rt.ensureDaemonSubmitRuntime()
-	delete(rt.activeDaemonSubmitSessions, workerResult.sessionKey)
+	delete(rt.activeDaemonSubmitKeys, workerResult.dispatchKey)
 	if workerResult.err != nil {
 		rt.events <- tui.DaemonEvent{
 			Type:    "error",
 			Message: fmt.Sprintf("%s %s: %v", projection.SubmitPathDaemon, filepath.Base(workerResult.requestPath), workerResult.err),
 		}
 		return
+	}
+	if workerResult.result.ProjectionSyncSessionDir != "" {
+		rt.scheduleMailboxProjectionSync(workerResult.result.ProjectionSyncSessionDir)
 	}
 	if workerResult.result.hasPostDispatch() {
 		log.Printf("postman: component=%s event=send_reconcile submit_path=%s session=%s file=%s\n",
@@ -663,7 +686,7 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 	recordShadowMailboxPathEvent(eventPath, projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, rt.now())
 	sourceSessionDir := filepath.Dir(filepath.Dir(eventPath))
 	sourceSessionName := filepath.Base(sourceSessionDir)
-	syncMailboxProjection(sourceSessionDir)
+	rt.scheduleMailboxProjectionSync(sourceSessionDir)
 
 	if info.To == "postman" || info.To == "daemon" {
 		return
@@ -678,6 +701,55 @@ func (rt *daemonRuntime) handleReadWatcherEvent(eventPath string, op fsnotify.Op
 			"source": "read_move",
 		},
 	}
+}
+
+func (rt *daemonRuntime) ensureMailboxProjectionSyncRuntime() {
+	if rt.activeMailboxProjectionSyncs == nil {
+		rt.activeMailboxProjectionSyncs = make(map[string]bool)
+	}
+	if rt.pendingMailboxProjectionSyncs == nil {
+		rt.pendingMailboxProjectionSyncs = make(map[string]bool)
+	}
+}
+
+func (rt *daemonRuntime) scheduleMailboxProjectionSync(sessionDir string) {
+	if sessionDir == "" {
+		return
+	}
+	rt.ensureMailboxProjectionSyncRuntime()
+	rt.mailboxProjectionSyncMu.Lock()
+	if rt.activeMailboxProjectionSyncs[sessionDir] {
+		rt.pendingMailboxProjectionSyncs[sessionDir] = true
+		rt.mailboxProjectionSyncMu.Unlock()
+		return
+	}
+	rt.activeMailboxProjectionSyncs[sessionDir] = true
+	rt.mailboxProjectionSyncMu.Unlock()
+
+	rt.mailboxProjectionSyncWG.Add(1)
+	go func() {
+		defer rt.mailboxProjectionSyncWG.Done()
+		rt.runMailboxProjectionSync(sessionDir)
+	}()
+}
+
+func (rt *daemonRuntime) runMailboxProjectionSync(sessionDir string) {
+	for {
+		syncMailboxProjection(sessionDir)
+
+		rt.mailboxProjectionSyncMu.Lock()
+		if !rt.pendingMailboxProjectionSyncs[sessionDir] {
+			delete(rt.activeMailboxProjectionSyncs, sessionDir)
+			rt.mailboxProjectionSyncMu.Unlock()
+			return
+		}
+		delete(rt.pendingMailboxProjectionSyncs, sessionDir)
+		rt.mailboxProjectionSyncMu.Unlock()
+	}
+}
+
+func (rt *daemonRuntime) waitForMailboxProjectionSyncs() {
+	rt.mailboxProjectionSyncWG.Wait()
 }
 
 func (rt *daemonRuntime) handleWatcherError(err error) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1339,6 +1339,67 @@ func TestDispatchPendingAutoPings_DeliversDuePendingPingAndClearsDebt(t *testing
 	waitForAutoPingPending(t, sessionDir, "review:worker", false)
 }
 
+func TestDispatchPendingAutoPingsRecordsDeliveredAtWithRuntimeClock(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.May, 21, 7, 0, 0, 0, time.UTC)
+	deliveredAt := now.Add(9 * time.Second)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%61",
+		Reason:       "discovered",
+		TriggeredAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 0,
+		NotBeforeAt:  now.Add(-2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(pending): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg: &config.Config{
+			DaemonMessageTemplate: "PING {node} in {context_id}",
+		},
+		adjacency:   map[string][]string{},
+		daemonState: NewDaemonState(0, "ctx-self"),
+		nodes: map[string]discovery.NodeInfo{
+			"review:worker": {
+				PaneID:      "%61",
+				SessionName: "review",
+				SessionDir:  sessionDir,
+			},
+		},
+		sendAutoPing: func(discovery.NodeInfo, string, string, string, *config.Config, []string, map[string]bool, map[string][]string, map[string]discovery.NodeInfo) (controlplane.SystemMessageResult, error) {
+			return controlplane.SystemMessageResult{Delivered: true}, nil
+		},
+		clock: func() time.Time { return deliveredAt },
+	}
+	rt.daemonState.SetSessionEnabled("review", true)
+
+	rt.dispatchPendingAutoPings(rt.nodes, false, now)
+	waitForAutoPingPending(t, sessionDir, "review:worker", false)
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if got, want := state.Nodes["review:worker"].DeliveredAt, deliveredAt.Format(time.RFC3339Nano); got != want {
+		t.Fatalf("DeliveredAt = %q, want %q", got, want)
+	}
+}
+
 func TestDispatchPendingAutoPings_DoesNotBlockDaemonLoopWhilePaneDeliveryRuns(t *testing.T) {
 	baseDir := t.TempDir()
 	sessionDir := filepath.Join(baseDir, "ctx-self", "review")

--- a/internal/daemon/watcher_event_test.go
+++ b/internal/daemon/watcher_event_test.go
@@ -207,7 +207,6 @@ func TestHandleWatcherEvent_ReadRenameMarksRecipientAliveAndSyncsProjection(t *t
 	if got := projected.Read[readKey].Content; got != content {
 		t.Fatalf("projected read content = %q, want %q", got, content)
 	}
-	rt.waitForMailboxProjectionSyncs()
 }
 
 func TestRunDaemonLoop_WatcherErrorIsNonFatalAndLaterReadEventIsProcessed(t *testing.T) {

--- a/internal/daemon/watcher_event_test.go
+++ b/internal/daemon/watcher_event_test.go
@@ -207,6 +207,7 @@ func TestHandleWatcherEvent_ReadRenameMarksRecipientAliveAndSyncsProjection(t *t
 	if got := projected.Read[readKey].Content; got != content {
 		t.Fatalf("projected read content = %q, want %q", got, content)
 	}
+	rt.waitForMailboxProjectionSyncs()
 }
 
 func TestRunDaemonLoop_WatcherErrorIsNonFatalAndLaterReadEventIsProcessed(t *testing.T) {

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -64,14 +64,30 @@ type IdleTracker struct {
 	nodeActivity     map[string]NodeActivity
 	paneCaptureState map[string]PaneCaptureState // paneKey -> PaneCaptureState
 	mu               sync.Mutex
+	clock            func() time.Time
 }
 
 // NewIdleTracker creates a new IdleTracker instance (Issue #71).
 func NewIdleTracker() *IdleTracker {
+	return newIdleTrackerWithClock(time.Now)
+}
+
+func newIdleTrackerWithClock(clock func() time.Time) *IdleTracker {
+	if clock == nil {
+		clock = time.Now
+	}
 	return &IdleTracker{
 		nodeActivity:     make(map[string]NodeActivity),
 		paneCaptureState: make(map[string]PaneCaptureState),
+		clock:            clock,
 	}
+}
+
+func (t *IdleTracker) now() time.Time {
+	if t.clock == nil {
+		return time.Now()
+	}
+	return t.clock()
 }
 
 // UpdateSendActivity updates the last sent timestamp for a node (Issue #55).
@@ -80,7 +96,7 @@ func (t *IdleTracker) UpdateSendActivity(nodeKey string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	activity := t.nodeActivity[nodeKey]
-	activity.LastSent = time.Now()
+	activity.LastSent = t.now()
 	t.nodeActivity[nodeKey] = activity
 }
 
@@ -90,7 +106,7 @@ func (t *IdleTracker) UpdateReceiveActivity(nodeKey string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	activity := t.nodeActivity[nodeKey]
-	activity.LastReceived = time.Now()
+	activity.LastReceived = t.now()
 	t.nodeActivity[nodeKey] = activity
 }
 
@@ -150,7 +166,7 @@ func (t *IdleTracker) GetPaneActivityStatus(cfg *config.Config) map[string]strin
 	defer t.mu.Unlock()
 
 	result := make(map[string]string)
-	now := time.Now()
+	now := t.now()
 
 	for paneID, state := range t.paneCaptureState {
 		result[paneID] = statusForState(state, now, cfg)
@@ -164,7 +180,7 @@ func (t *IdleTracker) GetPaneActivityStatus(cfg *config.Config) map[string]strin
 // Issue #123: Enriched format — writes map[string]PaneActivityExport instead of map[string]string.
 func (t *IdleTracker) ExportPaneActivityToFile(cfg *config.Config, filePath string) error {
 	t.mu.Lock()
-	now := time.Now()
+	now := t.now()
 	export := make(map[string]PaneActivityExport, len(t.paneCaptureState))
 	for paneID, state := range t.paneCaptureState {
 		export[paneID] = PaneActivityExport{
@@ -374,7 +390,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		nodePaneIDs = nodePaneIDs[:maxPanes]
 	}
 
-	now := time.Now()
+	now := t.now()
 	compactionTargets := make(map[string]CompactionPingTarget)
 
 	for _, paneID := range nodePaneIDs {

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestUpdateActivity(t *testing.T) {
-	tracker := NewIdleTracker()
+	now := time.Date(2026, time.May, 21, 1, 2, 3, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
 	nodeKey := "test-session:test-node"
-	before := time.Now()
 
 	// Test UpdateSendActivity
 	tracker.UpdateSendActivity(nodeKey)
@@ -27,12 +27,12 @@ func TestUpdateActivity(t *testing.T) {
 		t.Fatalf("send activity not recorded for %s", nodeKey)
 	}
 
-	if activity.LastSent.Before(before) {
-		t.Errorf("send activity time %v is before test start %v", activity.LastSent, before)
+	if !activity.LastSent.Equal(now) {
+		t.Errorf("send activity time %v, want %v", activity.LastSent, now)
 	}
 
 	// Test UpdateReceiveActivity
-	before2 := time.Now()
+	now = now.Add(5 * time.Second)
 	tracker.UpdateReceiveActivity(nodeKey)
 
 	tracker.mu.Lock()
@@ -43,18 +43,18 @@ func TestUpdateActivity(t *testing.T) {
 		t.Fatalf("receive activity not recorded for %s", nodeKey)
 	}
 
-	if activity2.LastReceived.Before(before2) {
-		t.Errorf("receive activity time %v is before test start %v", activity2.LastReceived, before2)
+	if !activity2.LastReceived.Equal(now) {
+		t.Errorf("receive activity time %v, want %v", activity2.LastReceived, now)
 	}
 }
 
 // Issue #123: Test for ExportPaneActivityToFile — verifies new JSON schema (struct format)
 func TestExportPaneActivityToFile(t *testing.T) {
-	tracker := NewIdleTracker()
+	now := time.Date(2026, time.May, 21, 2, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
 	cfg := &config.Config{
 		NodeActiveSeconds: 300.0,
 	}
-	now := time.Now()
 
 	// Set up pane states
 	tracker.mu.Lock()
@@ -376,6 +376,98 @@ func TestFilterPaneCaptureNodes_PreservesBareKeys(t *testing.T) {
 	}
 }
 
+func TestCheckPaneCaptureUsesInjectedClockForPaneTimestamps(t *testing.T) {
+	scriptDir := t.TempDir()
+	capturePath := filepath.Join(scriptDir, "capture.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_CAPTURE\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_CAPTURE", capturePath)
+
+	now := time.Date(2026, time.May, 21, 3, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  filepath.Join(t.TempDir(), "review"),
+		},
+	}
+
+	if err := os.WriteFile(capturePath, []byte("ready"), 0o644); err != nil {
+		t.Fatalf("WriteFile(capture ready): %v", err)
+	}
+	if targets := tracker.checkPaneCapture(cfg, nodes); len(targets) != 0 {
+		t.Fatalf("initial checkPaneCapture() returned %d targets, want 0", len(targets))
+	}
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if !state.LastChangeAt.Equal(now) {
+		t.Fatalf("initial LastChangeAt = %v, want %v", state.LastChangeAt, now)
+	}
+	if !state.LastCaptureAt.Equal(now) {
+		t.Fatalf("initial LastCaptureAt = %v, want %v", state.LastCaptureAt, now)
+	}
+
+	now = now.Add(10 * time.Second)
+	if err := os.WriteFile(capturePath, []byte("working"), 0o644); err != nil {
+		t.Fatalf("WriteFile(capture working): %v", err)
+	}
+	if targets := tracker.checkPaneCapture(cfg, nodes); len(targets) != 0 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 0", len(targets))
+	}
+
+	tracker.mu.Lock()
+	state = tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if !state.LastChangeAt.Equal(now) {
+		t.Fatalf("changed LastChangeAt = %v, want %v", state.LastChangeAt, now)
+	}
+	if !state.LastCaptureAt.Equal(now) {
+		t.Fatalf("changed LastCaptureAt = %v, want %v", state.LastCaptureAt, now)
+	}
+
+	now = now.Add(10 * time.Second)
+	if err := os.WriteFile(capturePath, []byte("working again"), 0o644); err != nil {
+		t.Fatalf("WriteFile(capture working again): %v", err)
+	}
+	if targets := tracker.checkPaneCapture(cfg, nodes); len(targets) != 0 {
+		t.Fatalf("third checkPaneCapture() returned %d targets, want 0", len(targets))
+	}
+
+	tracker.mu.Lock()
+	state = tracker.paneCaptureState["%11"]
+	activity := tracker.nodeActivity["review:worker"]
+	tracker.mu.Unlock()
+	if !state.LastChangeAt.Equal(now) {
+		t.Fatalf("active LastChangeAt = %v, want %v", state.LastChangeAt, now)
+	}
+	if !state.LastCaptureAt.Equal(now) {
+		t.Fatalf("active LastCaptureAt = %v, want %v", state.LastCaptureAt, now)
+	}
+	if !activity.LastScreenChange.Equal(now) {
+		t.Fatalf("LastScreenChange = %v, want %v", activity.LastScreenChange, now)
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerRecordsInitialMarkerWithoutPing(t *testing.T) {
 	scriptDir := t.TempDir()
 	scriptPath := filepath.Join(scriptDir, "tmux")
@@ -529,7 +621,8 @@ func TestCheckPaneCapture_CompactionTriggerUsesRecentHistory(t *testing.T) {
 	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
 	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
 
-	tracker := NewIdleTracker()
+	now := time.Date(2026, time.May, 21, 4, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
 	cfg := &config.Config{
 		ActivityWindowSeconds: 120,
 		NodeStaleSeconds:      600,
@@ -617,7 +710,8 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenNewerHistoryMarkerAppearsA
 	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
 	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
 
-	tracker := NewIdleTracker()
+	now := time.Date(2026, time.May, 21, 4, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
 	cfg := &config.Config{
 		ActivityWindowSeconds: 120,
 		NodeStaleSeconds:      600,
@@ -664,8 +758,9 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenNewerHistoryMarkerAppearsA
 	if state.LastCompactionTrigger == "" {
 		t.Fatal("first checkPaneCapture() did not leave compaction trigger set")
 	}
-	state.LastCompactionPingAt = time.Now().Add(-compactionPingCooldown - time.Second)
-	tracker.paneCaptureState["%11"] = state
+	if !state.LastCompactionPingAt.Equal(now) {
+		t.Fatalf("first LastCompactionPingAt = %v, want %v", state.LastCompactionPingAt, now)
+	}
 	tracker.mu.Unlock()
 
 	secondVisible := "after second compaction"
@@ -676,6 +771,13 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenNewerHistoryMarkerAppearsA
 	if err := os.WriteFile(historyPath, []byte(secondHistory), 0o644); err != nil {
 		t.Fatalf("WriteFile(history second): %v", err)
 	}
+
+	withinCooldownTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(withinCooldownTargets) != 0 {
+		t.Fatalf("within-cooldown checkPaneCapture() returned %d targets, want 0", len(withinCooldownTargets))
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
 	secondTargets := tracker.checkPaneCapture(cfg, nodes)
 	if len(secondTargets) != 1 {
 		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 for newer compaction marker in retained history", len(secondTargets))
@@ -695,6 +797,9 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenNewerHistoryMarkerAppearsA
 	}
 	if state.LastCompactionMarkers != 2 {
 		t.Fatalf("checkPaneCapture() recorded %d compaction markers, want 2", state.LastCompactionMarkers)
+	}
+	if !state.LastCompactionPingAt.Equal(now) {
+		t.Fatalf("second LastCompactionPingAt = %v, want %v", state.LastCompactionPingAt, now)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add localized clock seams for idle and daemon timing paths
- keep default production constructors and behavior intact
- add deterministic coverage for idle activity, pane capture timestamps, compaction cooldowns, drain windows, rate-limit reservations, and auto-PING delivery timestamps

## Verification

- `go test ./internal/idle ./internal/daemon -run 'Test(UpdateActivity|ExportPaneActivityToFile|CheckPaneCaptureUsesInjectedClockForPaneTimestamps|CheckPaneCapture_CompactionTriggerRepeatsWhenNewerHistoryMarkerAppearsAfterCooldown|DaemonStateDrainWindowUsesInjectedClock|ReserveDeliveryRouteUsesExplicitClock|DispatchPendingAutoPingsRecordsDeliveredAtWithRuntimeClock)'`
- `go test ./internal/idle ./internal/daemon -run Test`
- `git diff --check`
- `go test ./...`
- `nix flake check`
- `nix build`

Closes #478
