### PR TITLE
refactor(config): add PID liveness probe seam

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	_ "embed"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,13 +10,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/BurntSushi/toml"
 	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 )
-
-var currentUID = os.Getuid
 
 //go:embed postman.default.toml
 var defaultConfigBytes []byte
@@ -961,11 +957,7 @@ func ValidateSessionName(name string) (string, error) {
 // Issue #249: liveness check for context disambiguation.
 func IsSessionPIDAlive(baseDir, contextName, sessionName string) bool {
 	pidPath := filepath.Join(baseDir, contextName, sessionName, "postman.pid")
-	sigErr, ok := sessionPIDSignal(pidPath)
-	if !ok {
-		return false
-	}
-	return sigErr == nil || errors.Is(sigErr, syscall.EPERM)
+	return sessionPIDs.isPIDAlive(pidPath)
 }
 
 // IsSessionPIDOwnedByCurrentUser reads postman.pid from
@@ -975,47 +967,7 @@ func IsSessionPIDAlive(baseDir, contextName, sessionName string) bool {
 // stop/ownership decisions.
 func IsSessionPIDOwnedByCurrentUser(baseDir, contextName, sessionName string) bool {
 	pidPath := filepath.Join(baseDir, contextName, sessionName, "postman.pid")
-	if !pidFileOwnedByCurrentUser(pidPath) {
-		return false
-	}
-	sigErr, ok := sessionPIDSignal(pidPath)
-	return ok && sigErr == nil
-}
-
-func sessionPIDSignal(pidPath string) (error, bool) {
-	pid, ok := readSessionPID(pidPath)
-	if !ok {
-		return nil, false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return nil, false
-	}
-	return proc.Signal(syscall.Signal(0)), true
-}
-
-func readSessionPID(pidPath string) (int, bool) {
-	data, err := os.ReadFile(pidPath)
-	if err != nil {
-		return 0, false
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 {
-		return 0, false
-	}
-	return pid, true
-}
-
-func pidFileOwnedByCurrentUser(pidPath string) bool {
-	info, err := os.Stat(pidPath)
-	if err != nil {
-		return false
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-	return int(stat.Uid) == currentUID()
+	return sessionPIDs.isPIDOwnedByCurrentUser(pidPath)
 }
 
 // isContextDaemonAlive checks if any session subdirectory under
@@ -1066,7 +1018,7 @@ func ContextHasLiveDaemon(baseDir, contextName string) bool {
 }
 
 func CurrentUserDaemonLockPath(baseDir string) string {
-	return filepath.Join(baseDir, "lock", fmt.Sprintf("user-%d.lock", currentUID()))
+	return filepath.Join(baseDir, "lock", fmt.Sprintf("user-%d.lock", sessionPIDs.currentUserID()))
 }
 
 func FindCurrentUserDaemon(baseDir string) (string, string, bool) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1355,9 +1355,9 @@ func pidFileOwnerUID(t *testing.T, baseDir, contextName, sessionName string) int
 
 func withCurrentUID(t *testing.T, uid int) {
 	t.Helper()
-	orig := currentUID
-	currentUID = func() int { return uid }
-	t.Cleanup(func() { currentUID = orig })
+	orig := sessionPIDs
+	sessionPIDs.currentUID = func() int { return uid }
+	t.Cleanup(func() { sessionPIDs = orig })
 }
 
 func TestResolveContextIDFromSession(t *testing.T) {

--- a/internal/config/process_probe.go
+++ b/internal/config/process_probe.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type signalProcess interface {
+	Signal(os.Signal) error
+}
+
+type sessionPIDProbe struct {
+	readFile     func(string) ([]byte, error)
+	findProcess  func(int) (signalProcess, error)
+	stat         func(string) (os.FileInfo, error)
+	fileOwnerUID func(os.FileInfo) (int, bool)
+	currentUID   func() int
+}
+
+var sessionPIDs = defaultSessionPIDProbe()
+
+func defaultSessionPIDProbe() sessionPIDProbe {
+	return sessionPIDProbe{
+		readFile: os.ReadFile,
+		findProcess: func(pid int) (signalProcess, error) {
+			return os.FindProcess(pid)
+		},
+		stat:         os.Stat,
+		fileOwnerUID: unixFileOwnerUID,
+		currentUID:   os.Getuid,
+	}
+}
+
+func (p sessionPIDProbe) withDefaults() sessionPIDProbe {
+	defaults := defaultSessionPIDProbe()
+	if p.readFile == nil {
+		p.readFile = defaults.readFile
+	}
+	if p.findProcess == nil {
+		p.findProcess = defaults.findProcess
+	}
+	if p.stat == nil {
+		p.stat = defaults.stat
+	}
+	if p.fileOwnerUID == nil {
+		p.fileOwnerUID = defaults.fileOwnerUID
+	}
+	if p.currentUID == nil {
+		p.currentUID = defaults.currentUID
+	}
+	return p
+}
+
+func (p sessionPIDProbe) isPIDAlive(pidPath string) bool {
+	sigErr, ok := p.signalPID(pidPath)
+	if !ok {
+		return false
+	}
+	return sigErr == nil || errors.Is(sigErr, syscall.EPERM)
+}
+
+func (p sessionPIDProbe) isPIDOwnedByCurrentUser(pidPath string) bool {
+	p = p.withDefaults()
+	if !p.pidFileOwnedByCurrentUser(pidPath) {
+		return false
+	}
+	sigErr, ok := p.signalPID(pidPath)
+	return ok && sigErr == nil
+}
+
+func (p sessionPIDProbe) signalPID(pidPath string) (error, bool) {
+	p = p.withDefaults()
+	pid, ok := p.readSessionPID(pidPath)
+	if !ok {
+		return nil, false
+	}
+	proc, err := p.findProcess(pid)
+	if err != nil {
+		return nil, false
+	}
+	return proc.Signal(syscall.Signal(0)), true
+}
+
+func (p sessionPIDProbe) readSessionPID(pidPath string) (int, bool) {
+	p = p.withDefaults()
+	data, err := p.readFile(pidPath)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func (p sessionPIDProbe) pidFileOwnedByCurrentUser(pidPath string) bool {
+	p = p.withDefaults()
+	info, err := p.stat(pidPath)
+	if err != nil {
+		return false
+	}
+	uid, ok := p.fileOwnerUID(info)
+	return ok && uid == p.currentUserID()
+}
+
+func (p sessionPIDProbe) currentUserID() int {
+	p = p.withDefaults()
+	return p.currentUID()
+}
+
+func unixFileOwnerUID(info os.FileInfo) (int, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(stat.Uid), true
+}

--- a/internal/config/process_probe_test.go
+++ b/internal/config/process_probe_test.go
@@ -1,0 +1,266 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type fakeSignalProcess struct {
+	t   *testing.T
+	err error
+}
+
+func (p fakeSignalProcess) Signal(sig os.Signal) error {
+	p.t.Helper()
+	if sig != syscall.Signal(0) {
+		p.t.Fatalf("Signal(%v), want signal 0", sig)
+	}
+	return p.err
+}
+
+type fakeFileInfo struct {
+	name string
+	uid  int
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0o600 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func TestSessionPIDProbeLivenessMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		signalErr error
+		wantAlive bool
+		wantOwned bool
+	}{
+		{
+			name:      "nil signal result means alive and owned when UID matches",
+			wantAlive: true,
+			wantOwned: true,
+		},
+		{
+			name:      "EPERM means alive but not current-user owned",
+			signalErr: syscall.EPERM,
+			wantAlive: true,
+		},
+		{
+			name:      "ESRCH means dead",
+			signalErr: syscall.ESRCH,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := sessionPIDProbe{
+				readFile: func(string) ([]byte, error) {
+					return []byte("1234\n"), nil
+				},
+				findProcess: func(pid int) (signalProcess, error) {
+					if pid != 1234 {
+						t.Fatalf("findProcess(%d), want 1234", pid)
+					}
+					return fakeSignalProcess{t: t, err: tt.signalErr}, nil
+				},
+				stat: func(string) (os.FileInfo, error) {
+					return fakeFileInfo{uid: 501}, nil
+				},
+				fileOwnerUID: func(info os.FileInfo) (int, bool) {
+					return info.(fakeFileInfo).uid, true
+				},
+				currentUID: func() int {
+					return 501
+				},
+			}
+
+			pidPath := filepath.Join("ctx", "sess", "postman.pid")
+			if got := probe.isPIDAlive(pidPath); got != tt.wantAlive {
+				t.Fatalf("isPIDAlive() = %v, want %v", got, tt.wantAlive)
+			}
+			if got := probe.isPIDOwnedByCurrentUser(pidPath); got != tt.wantOwned {
+				t.Fatalf("isPIDOwnedByCurrentUser() = %v, want %v", got, tt.wantOwned)
+			}
+		})
+	}
+}
+
+func TestSessionPIDProbeRejectsInvalidPIDFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		err     error
+	}{
+		{name: "missing pid file", err: os.ErrNotExist},
+		{name: "unreadable pid file", err: os.ErrPermission},
+		{name: "invalid pid content", content: "not-a-pid"},
+		{name: "zero pid", content: "0"},
+		{name: "negative pid", content: "-7"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findCalled := false
+			probe := sessionPIDProbe{
+				readFile: func(string) ([]byte, error) {
+					if tt.err != nil {
+						return nil, tt.err
+					}
+					return []byte(tt.content), nil
+				},
+				findProcess: func(int) (signalProcess, error) {
+					findCalled = true
+					return fakeSignalProcess{t: t}, nil
+				},
+				stat: func(string) (os.FileInfo, error) {
+					return fakeFileInfo{uid: 501}, nil
+				},
+				fileOwnerUID: func(info os.FileInfo) (int, bool) {
+					return info.(fakeFileInfo).uid, true
+				},
+				currentUID: func() int {
+					return 501
+				},
+			}
+
+			pidPath := filepath.Join("ctx", "sess", "postman.pid")
+			if probe.isPIDAlive(pidPath) {
+				t.Fatal("isPIDAlive() = true, want false")
+			}
+			if probe.isPIDOwnedByCurrentUser(pidPath) {
+				t.Fatal("isPIDOwnedByCurrentUser() = true, want false")
+			}
+			if findCalled {
+				t.Fatal("findProcess was called for an invalid pid file")
+			}
+		})
+	}
+}
+
+func TestSessionPIDProbeOwnershipFallbacks(t *testing.T) {
+	tests := []struct {
+		name       string
+		ownerUID   int
+		ownerUIDOK bool
+		currentUID int
+		wantOwned  bool
+	}{
+		{
+			name:       "non-current UID is alive but not owned",
+			ownerUID:   502,
+			ownerUIDOK: true,
+			currentUID: 501,
+		},
+		{
+			name:       "non-Unix stat fallback is alive but not owned",
+			ownerUIDOK: false,
+			currentUID: 501,
+		},
+		{
+			name:       "current UID is owned",
+			ownerUID:   501,
+			ownerUIDOK: true,
+			currentUID: 501,
+			wantOwned:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := sessionPIDProbe{
+				readFile: func(string) ([]byte, error) {
+					return []byte("1234"), nil
+				},
+				findProcess: func(int) (signalProcess, error) {
+					return fakeSignalProcess{t: t}, nil
+				},
+				stat: func(string) (os.FileInfo, error) {
+					return fakeFileInfo{uid: tt.ownerUID}, nil
+				},
+				fileOwnerUID: func(info os.FileInfo) (int, bool) {
+					return info.(fakeFileInfo).uid, tt.ownerUIDOK
+				},
+				currentUID: func() int {
+					return tt.currentUID
+				},
+			}
+
+			pidPath := filepath.Join("ctx", "sess", "postman.pid")
+			if !probe.isPIDAlive(pidPath) {
+				t.Fatal("isPIDAlive() = false, want true")
+			}
+			if got := probe.isPIDOwnedByCurrentUser(pidPath); got != tt.wantOwned {
+				t.Fatalf("isPIDOwnedByCurrentUser() = %v, want %v", got, tt.wantOwned)
+			}
+		})
+	}
+}
+
+func TestFindCurrentUserDaemonUsesPIDProbeAcrossMultipleContexts(t *testing.T) {
+	baseDir := t.TempDir()
+	foreignPID := writePIDFileForProbeTest(t, baseDir, "ctx-foreign", "daemon", "1001")
+	currentPID := writePIDFileForProbeTest(t, baseDir, "ctx-current", "main", "1002")
+
+	withSessionPIDProbe(t, sessionPIDProbe{
+		readFile: os.ReadFile,
+		findProcess: func(int) (signalProcess, error) {
+			return fakeSignalProcess{t: t}, nil
+		},
+		stat: func(path string) (os.FileInfo, error) {
+			switch path {
+			case foreignPID:
+				return fakeFileInfo{name: "postman.pid", uid: 502}, nil
+			case currentPID:
+				return fakeFileInfo{name: "postman.pid", uid: 501}, nil
+			default:
+				t.Fatalf("unexpected stat path %q", path)
+				return nil, os.ErrNotExist
+			}
+		},
+		fileOwnerUID: func(info os.FileInfo) (int, bool) {
+			return info.(fakeFileInfo).uid, true
+		},
+		currentUID: func() int {
+			return 501
+		},
+	})
+
+	if !IsSessionPIDAlive(baseDir, "ctx-foreign", "daemon") {
+		t.Fatal("foreign daemon should still be considered live")
+	}
+	if IsSessionPIDOwnedByCurrentUser(baseDir, "ctx-foreign", "daemon") {
+		t.Fatal("foreign daemon should not be owned by current user")
+	}
+	contextID, sessionName, ok := FindCurrentUserDaemon(baseDir)
+	if !ok {
+		t.Fatal("FindCurrentUserDaemon() ok = false, want true")
+	}
+	if contextID != "ctx-current" || sessionName != "main" {
+		t.Fatalf("FindCurrentUserDaemon() = (%q, %q), want (ctx-current, main)", contextID, sessionName)
+	}
+}
+
+func writePIDFileForProbeTest(t *testing.T, baseDir, contextName, sessionName, pid string) string {
+	t.Helper()
+	dir := filepath.Join(baseDir, contextName, sessionName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dir, err)
+	}
+	pidPath := filepath.Join(dir, "postman.pid")
+	if err := os.WriteFile(pidPath, []byte(pid), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", pidPath, err)
+	}
+	return pidPath
+}
+
+func withSessionPIDProbe(t *testing.T, probe sessionPIDProbe) {
+	t.Helper()
+	orig := sessionPIDs
+	sessionPIDs = probe.withDefaults()
+	t.Cleanup(func() { sessionPIDs = orig })
+}


### PR DESCRIPTION
## Summary

- Add a package-private PID probe for session ownership and liveness checks.
- Keep production liveness based on `os.FindProcess(...).Signal(0)` instead of `/proc`.
- Cover PID parsing, signal result, ownership, and multi-context current-user daemon behavior.

## Related Issue

Refs #466

## Verification

- `go test ./internal/config`
- `go test ./...`
- `nix flake check`
- `nix build`
