### PR TITLE
refactor(envelope): split frontmatter scanning

### DIFF
--- a/internal/cli/pop.go
+++ b/internal/cli/pop.go
@@ -212,17 +212,12 @@ func displayMarkdownPath(markdownPath string) string {
 }
 
 func frontmatterFromContent(content string) map[string]any {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
-		return nil
-	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
+	frontmatterContent, _, ok, err := envelope.ScanFrontmatter(content)
+	if !ok || err != nil {
 		return nil
 	}
 	var frontmatter map[string]any
-	if err := yaml.Unmarshal([]byte(rest[:second]), &frontmatter); err != nil {
+	if err := yaml.Unmarshal([]byte(frontmatterContent), &frontmatter); err != nil {
 		return nil
 	}
 	return frontmatter

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fswatcher/fswatcher"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/envelope"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
@@ -71,16 +72,11 @@ func safeAfterFunc(d time.Duration, name string, events chan<- tui.DaemonEvent, 
 }
 
 func frontmatterValue(content, key string) string {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	frontmatter, _, ok, err := envelope.ScanFrontmatter(content)
+	if !ok || err != nil {
 		return ""
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return ""
-	}
-	for _, line := range strings.Split(rest[:second], "\n") {
+	for _, line := range strings.Split(frontmatter, "\n") {
 		prefix := key + ": "
 		if strings.HasPrefix(line, prefix) {
 			return strings.TrimSpace(strings.TrimPrefix(line, prefix))

--- a/internal/envelope/metadata.go
+++ b/internal/envelope/metadata.go
@@ -28,6 +28,41 @@ type Metadata struct {
 	Body                string
 }
 
+type frontmatterScan struct {
+	frontmatter      string
+	body             string
+	frontmatterStart int
+	closeStart       int
+}
+
+func ScanFrontmatter(content string) (frontmatter, body string, ok bool, err error) {
+	scan, ok, err := scanFrontmatter(content)
+	if !ok || err != nil {
+		return "", "", ok, err
+	}
+	return scan.frontmatter, scan.body, true, nil
+}
+
+func scanFrontmatter(content string) (frontmatterScan, bool, error) {
+	first := strings.Index(content, "---\n")
+	if first < 0 {
+		return frontmatterScan{}, false, nil
+	}
+	frontmatterStart := first + 4
+	rest := content[frontmatterStart:]
+	second := strings.Index(rest, "\n---")
+	if second < 0 {
+		return frontmatterScan{}, false, fmt.Errorf("frontmatter not closed")
+	}
+	closeStart := frontmatterStart + second
+	return frontmatterScan{
+		frontmatter:      content[frontmatterStart:closeStart],
+		body:             content[closeStart+4:],
+		frontmatterStart: frontmatterStart,
+		closeStart:       closeStart,
+	}, true, nil
+}
+
 func BodyFromContent(content string) string {
 	body, ok := rawBodyFromContent(content)
 	if !ok {
@@ -48,16 +83,11 @@ func SenderBodyFromContent(content string) (string, bool) {
 }
 
 func rawBodyFromContent(content string) (string, bool) {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	_, body, ok, err := ScanFrontmatter(content)
+	if err != nil {
 		return "", false
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return "", false
-	}
-	return rest[second+4:], true
+	return body, ok
 }
 
 func senderBodyAfterGeneratedEnvelopeSeparator(body string) (string, bool) {
@@ -101,18 +131,18 @@ func hasGeneratedSendEnvelopeContext(prefix string) bool {
 }
 
 func ParseMetadata(content string) (Metadata, error) {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	frontmatter, body, ok, err := ScanFrontmatter(content)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if !ok {
 		return Metadata{}, fmt.Errorf("no frontmatter block found")
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return Metadata{}, fmt.Errorf("frontmatter not closed")
-	}
-	frontmatter := rest[:second]
+	return DecodeEnvelopeMetadata(frontmatter, body)
+}
 
-	metadata := Metadata{Body: strings.TrimSpace(rest[second+4:])}
+func DecodeEnvelopeMetadata(frontmatter, body string) (Metadata, error) {
+	metadata := Metadata{Body: strings.TrimSpace(body)}
 	lines := strings.Split(frontmatter, "\n")
 	paramsIndex, paramsEnd := paramsBlockRange(lines)
 	if paramsIndex >= 0 {
@@ -226,16 +256,11 @@ type paramsReplyPolicyField struct {
 }
 
 func paramsReplyPolicyFields(content string) []paramsReplyPolicyField {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	frontmatter, _, ok, err := ScanFrontmatter(content)
+	if !ok || err != nil {
 		return nil
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return nil
-	}
-	lines := strings.Split(rest[:second], "\n")
+	lines := strings.Split(frontmatter, "\n")
 	paramsIndex, paramsEnd := paramsBlockRange(lines)
 	if paramsIndex < 0 {
 		return nil
@@ -321,16 +346,11 @@ func IsNoReplyBody(content string) bool {
 }
 
 func EnsureParams(content string, fields map[string]string) string {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	scan, ok, err := scanFrontmatter(content)
+	if !ok || err != nil {
 		return content
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return content
-	}
-	frontmatter := rest[:second]
+	frontmatter := scan.frontmatter
 	lines := strings.Split(frontmatter, "\n")
 	paramsIndex, paramsEnd := paramsBlockRange(lines)
 	if paramsIndex < 0 {
@@ -378,27 +398,22 @@ func EnsureParams(content string, fields map[string]string) string {
 		if !changed {
 			return content
 		}
-		return content[:first+4] + strings.Join(lines, "\n") + rest[second:]
+		return content[:scan.frontmatterStart] + strings.Join(lines, "\n") + content[scan.closeStart:]
 	}
 
 	updated := make([]string, 0, len(lines)+len(insert))
 	updated = append(updated, lines[:paramsIndex+1]...)
 	updated = append(updated, insert...)
 	updated = append(updated, lines[paramsIndex+1:]...)
-	return content[:first+4] + strings.Join(updated, "\n") + rest[second:]
+	return content[:scan.frontmatterStart] + strings.Join(updated, "\n") + content[scan.closeStart:]
 }
 
 func ParamsReplyPolicyUsesPlaceholder(content string) bool {
-	first := strings.Index(content, "---\n")
-	if first < 0 {
+	frontmatter, _, ok, err := ScanFrontmatter(content)
+	if !ok || err != nil {
 		return false
 	}
-	rest := content[first+4:]
-	second := strings.Index(rest, "\n---")
-	if second < 0 {
-		return false
-	}
-	lines := strings.Split(rest[:second], "\n")
+	lines := strings.Split(frontmatter, "\n")
 	paramsIndex, paramsEnd := paramsBlockRange(lines)
 	if paramsIndex < 0 {
 		return false

--- a/internal/envelope/metadata_test.go
+++ b/internal/envelope/metadata_test.go
@@ -276,6 +276,121 @@ func TestParseMetadataReplyPolicyDuplicatesUseLastWins(t *testing.T) {
 	}
 }
 
+func TestScanFrontmatterPreservesCurrentDelimiterSemantics(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		wantFrontmatter string
+		wantBody        string
+		wantOK          bool
+		wantErr         string
+	}{
+		{
+			name:            "standard envelope",
+			content:         "---\nparams:\n  from: orchestrator\n  to: worker\n---\n\nbody\n",
+			wantFrontmatter: "params:\n  from: orchestrator\n  to: worker",
+			wantBody:        "\n\nbody\n",
+			wantOK:          true,
+		},
+		{
+			name:            "body delimiters remain body content",
+			content:         "---\nparams:\n  from: orchestrator\n  to: worker\n---\n\nbody\n---\nnot frontmatter\n",
+			wantFrontmatter: "params:\n  from: orchestrator\n  to: worker",
+			wantBody:        "\n\nbody\n---\nnot frontmatter\n",
+			wantOK:          true,
+		},
+		{
+			name:            "leading text before first delimiter is ignored",
+			content:         "prefix\n---\nparams:\n  from: orchestrator\n  to: worker\n---\n\nbody\n",
+			wantFrontmatter: "params:\n  from: orchestrator\n  to: worker",
+			wantBody:        "\n\nbody\n",
+			wantOK:          true,
+		},
+		{
+			name:            "leading bom before first delimiter is ignored",
+			content:         "\ufeff---\nparams:\n  from: orchestrator\n  to: worker\n---\n\nbody\n",
+			wantFrontmatter: "params:\n  from: orchestrator\n  to: worker",
+			wantBody:        "\n\nbody\n",
+			wantOK:          true,
+		},
+		{
+			name:    "crlf opening delimiter does not match current scanner",
+			content: "---\r\nparams:\r\n  from: orchestrator\r\n  to: worker\r\n---\r\nbody\r\n",
+		},
+		{
+			name:    "bom before crlf opening delimiter does not match current scanner",
+			content: "\ufeff---\r\nparams:\r\n  from: orchestrator\r\n  to: worker\r\n---\r\nbody\r\n",
+		},
+		{
+			name:    "missing frontmatter",
+			content: "plain body\n",
+		},
+		{
+			name:    "unclosed frontmatter",
+			content: "---\nparams:\n  from: orchestrator\n",
+			wantErr: "frontmatter not closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFrontmatter, gotBody, gotOK, err := ScanFrontmatter(tt.content)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("ScanFrontmatter() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ScanFrontmatter() error = %v", err)
+			}
+			if gotOK != tt.wantOK {
+				t.Fatalf("ScanFrontmatter() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotFrontmatter != tt.wantFrontmatter {
+				t.Fatalf("frontmatter = %q, want %q", gotFrontmatter, tt.wantFrontmatter)
+			}
+			if gotBody != tt.wantBody {
+				t.Fatalf("body = %q, want %q", gotBody, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestDecodeEnvelopeMetadataPreservesParamsSemantics(t *testing.T) {
+	frontmatter := "params:\n" +
+		"  from: orchestrator\n" +
+		"  to: worker\n" +
+		"  replyPolicy: none\n" +
+		"  reply_policy: required\n" +
+		"  blocked_reason: \"value: with colon\"\n" +
+		"  blocked_scope: >\n" +
+		"    generated\n" +
+		"    value\n" +
+		"  audit:\n" +
+		"    replyPolicy: none\n"
+
+	got, err := DecodeEnvelopeMetadata(frontmatter, "\n\nbody\n")
+	if err != nil {
+		t.Fatalf("DecodeEnvelopeMetadata() error = %v", err)
+	}
+	if got.From != "orchestrator" || got.To != "worker" {
+		t.Fatalf("from/to = %q/%q, want orchestrator/worker", got.From, got.To)
+	}
+	if got.ReplyPolicy != "required" {
+		t.Fatalf("ReplyPolicy = %q, want required", got.ReplyPolicy)
+	}
+	if got.BlockedReason != "\"value: with colon\"" {
+		t.Fatalf("BlockedReason = %q, want quoted colon value", got.BlockedReason)
+	}
+	if got.BlockedScope != ">" {
+		t.Fatalf("BlockedScope = %q, want current folded marker value", got.BlockedScope)
+	}
+	if got.Body != "body" {
+		t.Fatalf("Body = %q, want body", got.Body)
+	}
+}
+
 func TestEnsureParamsUpdatesManagedFields(t *testing.T) {
 	content := "---\nparams:\n  from: orchestrator\n  to: worker\n  messageId: old.md\n  replyPolicy: none\n---\n\nplease review\n"
 


### PR DESCRIPTION
## Summary

- Add shared frontmatter scanning helpers for envelope content.
- Route metadata parsing, raw body extraction, CLI `pop`, and daemon frontmatter lookups through the shared scanner.
- Add compatibility tests for current delimiter and metadata interpretation semantics.

## Related Issue

Refs #469

## Verification

- `go test ./internal/envelope ./internal/cli ./internal/daemon`
- `go test ./...`
- `nix flake check`
- `nix build`
