### PR TITLE
test(tmuxtest): add fake tmux session testkit

### DIFF
--- a/internal/cli/session_status_projection_test.go
+++ b/internal/cli/session_status_projection_test.go
@@ -249,6 +249,7 @@ func TestSessionStatusExposesChangedAndUnchangedScreenProgressEvidence(t *testin
 	worker := nodeByName["worker"].ScreenProgress
 	if worker == nil {
 		t.Fatal("worker ScreenProgress is nil, want unchanged evidence")
+		return
 	}
 	if worker.EvidenceState != "unchanged" {
 		t.Fatalf("worker evidence_state = %q, want unchanged", worker.EvidenceState)
@@ -266,6 +267,7 @@ func TestSessionStatusExposesChangedAndUnchangedScreenProgressEvidence(t *testin
 	critic := nodeByName["critic"].ScreenProgress
 	if critic == nil {
 		t.Fatal("critic ScreenProgress is nil, want changed evidence")
+		return
 	}
 	if critic.EvidenceState != "changed" {
 		t.Fatalf("critic evidence_state = %q, want changed", critic.EvidenceState)
@@ -306,6 +308,7 @@ func TestSessionStatusExposesMissingAndStaleScreenProgressEvidence(t *testing.T)
 	worker := nodeByName["worker"].ScreenProgress
 	if worker == nil {
 		t.Fatal("worker ScreenProgress is nil, want missing evidence")
+		return
 	}
 	if worker.EvidenceState != "missing" {
 		t.Fatalf("worker evidence_state = %q, want missing", worker.EvidenceState)
@@ -317,6 +320,7 @@ func TestSessionStatusExposesMissingAndStaleScreenProgressEvidence(t *testing.T)
 	critic := nodeByName["critic"].ScreenProgress
 	if critic == nil {
 		t.Fatal("critic ScreenProgress is nil, want stale evidence")
+		return
 	}
 	if critic.EvidenceState != "stale" {
 		t.Fatalf("critic evidence_state = %q, want stale", critic.EvidenceState)

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
+	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxtest"
 )
 
 func TestMain(m *testing.M) {
@@ -40,19 +41,11 @@ func installFakeTmuxForCLI(t *testing.T, postmanHome, sessionName, paneTitle str
 	t.Helper()
 	t.Setenv("POSTMAN_HOME", postmanHome)
 	t.Setenv("TMUX_PANE", "%99")
-	scriptDir := t.TempDir()
-	scriptPath := filepath.Join(scriptDir, "tmux")
-	script := "#!/bin/sh\n" +
-		"case \"$*\" in\n" +
-		"  *\"#{session_name}\"*) printf '%s\\n' \"" + sessionName + "\" ;;\n" +
-		"  *\"#{pane_title}\"*) printf '%s\\n' \"" + paneTitle + "\" ;;\n" +
-		"  *\"#{pane_id}\"*) printf '%s\\n' \"%99\" ;;\n" +
-		"  *) exit 1 ;;\n" +
-		"esac\n"
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("WriteFile fake tmux: %v", err)
-	}
-	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	tmuxtest.Install(t, tmuxtest.WithPane(tmuxtest.Pane{
+		ID:          "%99",
+		SessionName: sessionName,
+		Title:       paneTitle,
+	}))
 }
 
 func messageFixture(from, to, body string) string {

--- a/internal/tmuxtest/tmux.go
+++ b/internal/tmuxtest/tmux.go
@@ -1,0 +1,294 @@
+package tmuxtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type Pane struct {
+	ID             string
+	SessionName    string
+	Title          string
+	ContextID      string
+	CurrentCommand string
+	Capture        string
+	WindowIndex    string
+	PaneIndex      string
+	SessionID      string
+}
+
+type Command struct {
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type Option func(*fakeTmuxConfig)
+
+type FakeTmux struct {
+	tb      testing.TB
+	Dir     string
+	BinPath string
+	LogPath string
+}
+
+type fakeTmuxConfig struct {
+	panes    []Pane
+	commands []Command
+}
+
+func Install(tb testing.TB, opts ...Option) *FakeTmux {
+	tb.Helper()
+
+	cfg := fakeTmuxConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	for idx := range cfg.panes {
+		cfg.panes[idx] = normalizePane(cfg.panes[idx], idx)
+	}
+
+	dir := tb.TempDir()
+	fake := &FakeTmux{
+		tb:      tb,
+		Dir:     dir,
+		BinPath: filepath.Join(dir, "tmux"),
+		LogPath: filepath.Join(dir, "tmux.log"),
+	}
+
+	commands := append([]Command(nil), cfg.commands...)
+	commands = append(commands, defaultCommands(cfg.panes)...)
+	if err := os.WriteFile(fake.BinPath, []byte(fakeScript(fake.LogPath, commands)), 0o755); err != nil {
+		tb.Fatalf("WriteFile fake tmux: %v", err)
+	}
+	tb.Setenv("PATH", prependPath(dir, os.Getenv("PATH")))
+	return fake
+}
+
+func InstallMissing(tb testing.TB) *FakeTmux {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	tb.Setenv("PATH", dir)
+	return &FakeTmux{
+		tb:      tb,
+		Dir:     dir,
+		BinPath: filepath.Join(dir, "tmux"),
+		LogPath: filepath.Join(dir, "tmux.log"),
+	}
+}
+
+func WithPane(pane Pane) Option {
+	return func(cfg *fakeTmuxConfig) {
+		cfg.panes = append(cfg.panes, pane)
+	}
+}
+
+func WithCommand(command Command) Option {
+	return func(cfg *fakeTmuxConfig) {
+		cfg.commands = append(cfg.commands, command)
+	}
+}
+
+func (f *FakeTmux) Invocations() []string {
+	f.tb.Helper()
+
+	data, err := os.ReadFile(f.LogPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		f.tb.Fatalf("ReadFile fake tmux log: %v", err)
+	}
+	text := strings.TrimRight(string(data), "\n")
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
+}
+
+func normalizePane(pane Pane, idx int) Pane {
+	if pane.ID == "" {
+		pane.ID = fmt.Sprintf("%%%d", 99+idx)
+	}
+	if pane.SessionName == "" {
+		pane.SessionName = "test-session"
+	}
+	if pane.Title == "" {
+		pane.Title = "worker"
+	}
+	if pane.CurrentCommand == "" {
+		pane.CurrentCommand = "bash"
+	}
+	if pane.WindowIndex == "" {
+		pane.WindowIndex = "0"
+	}
+	if pane.PaneIndex == "" {
+		pane.PaneIndex = fmt.Sprintf("%d", idx)
+	}
+	if pane.SessionID == "" {
+		pane.SessionID = fmt.Sprintf("$%d", idx)
+	}
+	return pane
+}
+
+func defaultCommands(panes []Pane) []Command {
+	if len(panes) == 0 {
+		return nil
+	}
+
+	commands := []Command{}
+	first := panes[0]
+	for _, query := range []struct {
+		format string
+		value  string
+	}{
+		{format: "#{session_name}", value: first.SessionName + "\n"},
+		{format: "#{pane_title}", value: first.Title + "\n"},
+		{format: "#{pane_id}", value: first.ID + "\n"},
+		{format: "#{pane_current_command}", value: first.CurrentCommand + "\n"},
+	} {
+		commands = append(commands, Command{
+			Args:   []string{"display-message", "-p", query.format},
+			Stdout: query.value,
+		})
+	}
+
+	for _, pane := range panes {
+		for _, query := range []struct {
+			format string
+			value  string
+		}{
+			{format: "#{session_name}", value: pane.SessionName + "\n"},
+			{format: "#{pane_title}", value: pane.Title + "\n"},
+			{format: "#{pane_id}", value: pane.ID + "\n"},
+			{format: "#{pane_current_command}", value: pane.CurrentCommand + "\n"},
+		} {
+			commands = append(commands, Command{
+				Args:   []string{"display-message", "-t", pane.ID, "-p", query.format},
+				Stdout: query.value,
+			})
+		}
+		commands = append(
+			commands,
+			Command{Args: []string{"capture-pane", "-p", "-t", pane.ID}, Stdout: pane.Capture},
+			Command{Args: []string{"capture-pane", "-p", "-t", pane.ID, "-S", "-100"}, Stdout: pane.Capture},
+		)
+	}
+
+	for _, format := range []string{
+		"#{pane_id}\t#{@a2a_context_id}\t#{session_name}\t#{pane_title}",
+		"#{pane_id}\t#{@a2a_context_id}\t#{session_name}\t#{pane_title} ",
+		"#{pane_id}\t#{pane_current_command}",
+		"#{pane_id} #{session_name} #{pane_title}",
+		"#{window_index}\t#{pane_index}\t#{pane_id}\t#{pane_title}\t#{pane_current_command}",
+	} {
+		commands = append(commands, Command{
+			Args:   []string{"list-panes", "-a", "-F", format},
+			Stdout: renderPaneList(panes, format, ""),
+		})
+	}
+
+	sessionsSeen := map[string]bool{}
+	for _, pane := range panes {
+		if sessionsSeen[pane.SessionName] {
+			continue
+		}
+		sessionsSeen[pane.SessionName] = true
+		commands = append(commands, Command{
+			Args:   []string{"list-panes", "-s", "-t", pane.SessionName, "-F", "#{pane_id} #{pane_title}"},
+			Stdout: renderPaneList(panes, "#{pane_id} #{pane_title}", pane.SessionName),
+		})
+	}
+
+	commands = append(commands, Command{
+		Args:   []string{"list-sessions", "-F", "#{session_name}\t#{session_id}"},
+		Stdout: renderSessions(panes),
+	})
+	return commands
+}
+
+func renderPaneList(panes []Pane, format, sessionName string) string {
+	lines := []string{}
+	for _, pane := range panes {
+		if sessionName != "" && pane.SessionName != sessionName {
+			continue
+		}
+		lines = append(lines, renderPaneFormat(format, pane))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderSessions(panes []Pane) string {
+	lines := []string{}
+	seen := map[string]bool{}
+	for _, pane := range panes {
+		if seen[pane.SessionName] {
+			continue
+		}
+		seen[pane.SessionName] = true
+		lines = append(lines, renderPaneFormat("#{session_name}\t#{session_id}", pane))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderPaneFormat(format string, pane Pane) string {
+	replacements := map[string]string{
+		"#{pane_id}":              pane.ID,
+		"#{@a2a_context_id}":      pane.ContextID,
+		"#{session_name}":         pane.SessionName,
+		"#{pane_title}":           pane.Title,
+		"#{pane_current_command}": pane.CurrentCommand,
+		"#{window_index}":         pane.WindowIndex,
+		"#{pane_index}":           pane.PaneIndex,
+		"#{session_id}":           pane.SessionID,
+	}
+	for old, value := range replacements {
+		format = strings.ReplaceAll(format, old, value)
+	}
+	return format
+}
+
+func fakeScript(logPath string, commands []Command) string {
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	b.WriteString("printf '%s\\n' \"$*\" >> " + shQuote(logPath) + "\n")
+	for _, command := range commands {
+		b.WriteString("if [ \"$*\" = " + shQuote(strings.Join(command.Args, " ")) + " ]; then\n")
+		if command.Stdout != "" {
+			b.WriteString("  printf '%s' " + shQuote(command.Stdout) + "\n")
+		}
+		if command.Stderr != "" {
+			b.WriteString("  printf '%s' " + shQuote(command.Stderr) + " >&2\n")
+		}
+		b.WriteString(fmt.Sprintf("  exit %d\n", command.ExitCode))
+		b.WriteString("fi\n")
+	}
+	b.WriteString("case \"$1\" in\n")
+	b.WriteString("  set-buffer|paste-buffer|send-keys|set-option) exit 0 ;;\n")
+	b.WriteString("esac\n")
+	b.WriteString("printf '%s\\n' \"unexpected tmux command: $*\" >&2\n")
+	b.WriteString("exit 1\n")
+	return b.String()
+}
+
+func shQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func prependPath(dir, path string) string {
+	if path == "" {
+		return dir
+	}
+	return dir + string(os.PathListSeparator) + path
+}

--- a/internal/tmuxtest/tmux.go
+++ b/internal/tmuxtest/tmux.go
@@ -271,7 +271,7 @@ func fakeScript(logPath string, commands []Command) string {
 		if command.Stderr != "" {
 			b.WriteString("  printf '%s' " + shQuote(command.Stderr) + " >&2\n")
 		}
-		b.WriteString(fmt.Sprintf("  exit %d\n", command.ExitCode))
+		fmt.Fprintf(&b, "  exit %d\n", command.ExitCode)
 		b.WriteString("fi\n")
 	}
 	b.WriteString("case \"$1\" in\n")

--- a/internal/tmuxtest/tmux_test.go
+++ b/internal/tmuxtest/tmux_test.go
@@ -1,0 +1,99 @@
+package tmuxtest
+
+import (
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFakeTmuxProvidesPaneOutputsAndRecordsInvocations(t *testing.T) {
+	fake := Install(t, WithPane(Pane{
+		ID:             "%42",
+		SessionName:    "review",
+		Title:          "worker",
+		ContextID:      "ctx-test",
+		CurrentCommand: "bash",
+		Capture:        "captured pane\n",
+	}))
+
+	assertTmuxOutput(t, "review\n", "display-message", "-t", "%42", "-p", "#{session_name}")
+	assertTmuxOutput(t, "worker\n", "display-message", "-t", "%42", "-p", "#{pane_title}")
+	assertTmuxOutput(t, "%42\n", "display-message", "-t", "%42", "-p", "#{pane_id}")
+	assertTmuxOutput(t, "bash\n", "display-message", "-t", "%42", "-p", "#{pane_current_command}")
+	assertTmuxOutput(t, "%42\tctx-test\treview\tworker\n", "list-panes", "-a", "-F", "#{pane_id}\t#{@a2a_context_id}\t#{session_name}\t#{pane_title}")
+	assertTmuxOutput(t, "%42 worker\n", "list-panes", "-s", "-t", "review", "-F", "#{pane_id} #{pane_title}")
+	assertTmuxOutput(t, "captured pane\n", "capture-pane", "-p", "-t", "%42")
+	runTmux(t, "send-keys", "-t", "%42", "C-m")
+	runTmux(t, "set-option", "-p", "-t", "%42", "@a2a_context_id", "ctx-test")
+
+	want := []string{
+		"display-message -t %42 -p #{session_name}",
+		"display-message -t %42 -p #{pane_title}",
+		"display-message -t %42 -p #{pane_id}",
+		"display-message -t %42 -p #{pane_current_command}",
+		"list-panes -a -F #{pane_id}\t#{@a2a_context_id}\t#{session_name}\t#{pane_title}",
+		"list-panes -s -t review -F #{pane_id} #{pane_title}",
+		"capture-pane -p -t %42",
+		"send-keys -t %42 C-m",
+		"set-option -p -t %42 @a2a_context_id ctx-test",
+	}
+	if got := fake.Invocations(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Invocations() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFakeTmuxReturnsConfiguredCommandErrors(t *testing.T) {
+	Install(t, WithCommand(Command{
+		Args:     []string{"display-message", "-p", "boom"},
+		Stderr:   "tmux failed\n",
+		ExitCode: 7,
+	}))
+
+	cmd := exec.Command("tmux", "display-message", "-p", "boom")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("tmux command error = nil, want failure; output=%q", out)
+	}
+	if !strings.Contains(string(out), "tmux failed") {
+		t.Fatalf("tmux combined output = %q, want stderr", out)
+	}
+}
+
+func TestConfiguredCommandsOverridePaneDefaults(t *testing.T) {
+	Install(
+		t,
+		WithCommand(Command{
+			Args:   []string{"display-message", "-p", "#{session_name}"},
+			Stdout: "override\n",
+		}),
+		WithPane(Pane{SessionName: "default-session"}),
+	)
+
+	assertTmuxOutput(t, "override\n", "display-message", "-p", "#{session_name}")
+}
+
+func TestInstallMissingTmuxHidesSystemTmux(t *testing.T) {
+	InstallMissing(t)
+
+	if path, err := exec.LookPath("tmux"); err == nil {
+		t.Fatalf("LookPath(tmux) = %q, want missing tmux", path)
+	}
+}
+
+func assertTmuxOutput(t *testing.T, want string, args ...string) {
+	t.Helper()
+	got := runTmux(t, args...)
+	if got != want {
+		t.Fatalf("tmux %v output = %q, want %q", args, got, want)
+	}
+}
+
+func runTmux(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("tmux %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

- Add `internal/tmuxtest` for reusable fake `tmux` command behavior and invocation recording.
- Cover pane output, custom command errors, command override behavior, and missing tmux scenarios.
- Migrate the shared CLI fake-tmux helper to the new testkit.

## Related Issue

Refs #473

## Verification

- `go test ./internal/tmuxtest ./internal/cli`
- `go test ./...`
- `nix flake check`
- `nix build`
