### PR TITLE
refactor(store): split mailbox archive planning

### DIFF
--- a/internal/store/mailbox_store.go
+++ b/internal/store/mailbox_store.go
@@ -2,21 +2,59 @@ package store
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+// DeadLetterPlan is the pure path plan for writing or moving a message to dead-letter/.
+type DeadLetterPlan struct {
+	SessionDir      string
+	Filename        string
+	Suffix          string
+	DeadLetterDir   string
+	DestinationPath string
+}
+
 // DeadLetterPath builds the dead-letter destination path with a reason suffix.
 func DeadLetterPath(sessionDir, filename, suffix string) string {
+	return PlanDeadLetterMessage(sessionDir, filename, suffix).DestinationPath
+}
+
+// PlanDeadLetterMessage builds the dead-letter destination path without touching the filesystem.
+func PlanDeadLetterMessage(sessionDir, filename, suffix string) DeadLetterPlan {
 	base := strings.TrimSuffix(filename, ".md")
-	return filepath.Join(sessionDir, "dead-letter", base+suffix+".md")
+	deadLetterDir := filepath.Join(sessionDir, "dead-letter")
+	return DeadLetterPlan{
+		SessionDir:      sessionDir,
+		Filename:        filename,
+		Suffix:          suffix,
+		DeadLetterDir:   deadLetterDir,
+		DestinationPath: filepath.Join(deadLetterDir, base+suffix+".md"),
+	}
+}
+
+type deadLetterFileOps struct {
+	lstat     func(string) (fs.FileInfo, error)
+	rename    func(string, string) error
+	writeFile func(string, []byte, fs.FileMode) error
+}
+
+var osDeadLetterFileOps = deadLetterFileOps{
+	lstat:     os.Lstat,
+	rename:    os.Rename,
+	writeFile: os.WriteFile,
 }
 
 // ValidateDeadLetterTarget rejects symlinked dead-letter destinations.
 func ValidateDeadLetterTarget(dstPath string) error {
+	return validateDeadLetterTargetWithOps(dstPath, osDeadLetterFileOps)
+}
+
+func validateDeadLetterTargetWithOps(dstPath string, ops deadLetterFileOps) error {
 	deadLetterDir := filepath.Dir(dstPath)
-	dirInfo, err := os.Lstat(deadLetterDir)
+	dirInfo, err := ops.lstat(deadLetterDir)
 	if err != nil {
 		return fmt.Errorf("lstat dead-letter dir: %w", err)
 	}
@@ -24,7 +62,7 @@ func ValidateDeadLetterTarget(dstPath string) error {
 		return fmt.Errorf("dead-letter target dir is symlink: %s", deadLetterDir)
 	}
 
-	dstInfo, err := os.Lstat(dstPath)
+	dstInfo, err := ops.lstat(dstPath)
 	if err == nil {
 		if dstInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("dead-letter target is symlink: %s", dstPath)
@@ -37,18 +75,26 @@ func ValidateDeadLetterTarget(dstPath string) error {
 
 // MoveToDeadLetter moves a live mailbox file to a validated dead-letter path.
 func MoveToDeadLetter(srcPath, dstPath string) error {
-	if err := ValidateDeadLetterTarget(dstPath); err != nil {
+	return moveToDeadLetterWithOps(srcPath, dstPath, osDeadLetterFileOps)
+}
+
+func moveToDeadLetterWithOps(srcPath, dstPath string, ops deadLetterFileOps) error {
+	if err := validateDeadLetterTargetWithOps(dstPath, ops); err != nil {
 		return err
 	}
-	return os.Rename(srcPath, dstPath)
+	return ops.rename(srcPath, dstPath)
 }
 
 // WriteDeadLetterFile writes a dead-letter record to a validated path.
 func WriteDeadLetterFile(dstPath string, content []byte) error {
-	if err := ValidateDeadLetterTarget(dstPath); err != nil {
+	return writeDeadLetterFileWithOps(dstPath, content, osDeadLetterFileOps)
+}
+
+func writeDeadLetterFileWithOps(dstPath string, content []byte, ops deadLetterFileOps) error {
+	if err := validateDeadLetterTargetWithOps(dstPath, ops); err != nil {
 		return err
 	}
-	return os.WriteFile(dstPath, content, 0o600)
+	return ops.writeFile(dstPath, content, 0o600)
 }
 
 // DeliverPostToInbox moves a live post file into a recipient inbox.
@@ -95,23 +141,86 @@ func ShadowRelativePath(sessionDir, fullPath string) string {
 	return rel
 }
 
+// InboxArchivePlan is the pure path plan for moving an inbox message to read/.
+type InboxArchivePlan struct {
+	SourcePath string
+	Filename   string
+	SessionDir string
+	ReadDir    string
+	ReadPath   string
+}
+
+// PlanArchiveInboxMessage derives the read archive path from an absolute inbox message path.
+func PlanArchiveInboxMessage(absPath, filename string) (InboxArchivePlan, error) {
+	if absPath == "" {
+		return InboxArchivePlan{}, fmt.Errorf("archive inbox message: source path is empty")
+	}
+	if !filepath.IsAbs(absPath) {
+		return InboxArchivePlan{}, fmt.Errorf("archive inbox message: source path must be absolute: %s", absPath)
+	}
+	if filename == "" || filename != filepath.Base(filename) {
+		return InboxArchivePlan{}, fmt.Errorf("archive inbox message: filename must be a base name: %s", filename)
+	}
+
+	sourcePath := filepath.Clean(absPath)
+	if filepath.Base(sourcePath) != filename {
+		return InboxArchivePlan{}, fmt.Errorf("archive inbox message: source filename %q does not match %q", filepath.Base(sourcePath), filename)
+	}
+
+	nodeInboxDir := filepath.Dir(sourcePath)
+	inboxDir := filepath.Dir(nodeInboxDir)
+	sessionDir := filepath.Dir(inboxDir)
+	if filepath.Base(inboxDir) != "inbox" || sessionDir == "." || sessionDir == string(filepath.Separator) {
+		return InboxArchivePlan{}, fmt.Errorf("archive inbox message: source path is not under <session>/inbox/<node>: %s", sourcePath)
+	}
+
+	readDir := filepath.Join(sessionDir, "read")
+	return InboxArchivePlan{
+		SourcePath: sourcePath,
+		Filename:   filename,
+		SessionDir: sessionDir,
+		ReadDir:    readDir,
+		ReadPath:   filepath.Join(readDir, filename),
+	}, nil
+}
+
+type archiveFileOps struct {
+	mkdirAll func(string, fs.FileMode) error
+	stat     func(string) (fs.FileInfo, error)
+	remove   func(string) error
+	rename   func(string, string) error
+}
+
+var osArchiveFileOps = archiveFileOps{
+	mkdirAll: os.MkdirAll,
+	stat:     os.Stat,
+	remove:   os.Remove,
+	rename:   os.Rename,
+}
+
 // ArchiveInboxMessage moves an inbox message to read/ or removes duplicates.
 func ArchiveInboxMessage(absPath, filename string) (string, error) {
-	readDir := filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(absPath))), "read")
-	if err := os.MkdirAll(readDir, 0o700); err != nil {
+	plan, err := PlanArchiveInboxMessage(absPath, filename)
+	if err != nil {
+		return "", err
+	}
+	return archiveInboxMessageWithOps(plan, osArchiveFileOps)
+}
+
+func archiveInboxMessageWithOps(plan InboxArchivePlan, ops archiveFileOps) (string, error) {
+	if err := ops.mkdirAll(plan.ReadDir, 0o700); err != nil {
 		return "", fmt.Errorf("creating read directory: %w", err)
 	}
-	dst := filepath.Join(readDir, filename)
-	if _, err := os.Stat(dst); err == nil {
-		if err := os.Remove(absPath); err != nil {
+	if _, err := ops.stat(plan.ReadPath); err == nil {
+		if err := ops.remove(plan.SourcePath); err != nil {
 			return "", fmt.Errorf("archiving message: %w", err)
 		}
-		return dst, nil
+		return plan.ReadPath, nil
 	} else if !os.IsNotExist(err) {
 		return "", fmt.Errorf("archiving message: %w", err)
 	}
-	if err := os.Rename(absPath, dst); err != nil {
+	if err := ops.rename(plan.SourcePath, plan.ReadPath); err != nil {
 		return "", fmt.Errorf("archiving message: %w", err)
 	}
-	return dst, nil
+	return plan.ReadPath, nil
 }

--- a/internal/store/mailbox_store_test.go
+++ b/internal/store/mailbox_store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,19 @@ func TestDeadLetterPath(t *testing.T) {
 	want := filepath.Join("/state/ctx/review", "dead-letter", "20260502-120000-from-a-to-b-dl-test.md")
 	if got != want {
 		t.Fatalf("DeadLetterPath() = %q, want %q", got, want)
+	}
+}
+
+func TestPlanDeadLetterMessage(t *testing.T) {
+	plan := PlanDeadLetterMessage("/state/ctx/review", "20260502-120000-from-a-to-b.md", "-dl-test")
+	if plan.DeadLetterDir != filepath.Join("/state/ctx/review", "dead-letter") {
+		t.Fatalf("DeadLetterDir = %q", plan.DeadLetterDir)
+	}
+	if plan.DestinationPath != filepath.Join("/state/ctx/review", "dead-letter", "20260502-120000-from-a-to-b-dl-test.md") {
+		t.Fatalf("DestinationPath = %q", plan.DestinationPath)
+	}
+	if plan.Filename != "20260502-120000-from-a-to-b.md" || plan.Suffix != "-dl-test" {
+		t.Fatalf("filename/suffix = %q/%q", plan.Filename, plan.Suffix)
 	}
 }
 
@@ -31,6 +45,32 @@ func TestMoveToDeadLetterRejectsSymlinkedTargetDir(t *testing.T) {
 
 	if err := MoveToDeadLetter(src, filepath.Join(linkDir, "post-dl-test.md")); err == nil {
 		t.Fatal("MoveToDeadLetter() error = nil, want symlink rejection")
+	}
+}
+
+func TestWriteDeadLetterFileWithOpsReturnsWriteErrorWithoutCreatingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	deadLetterDir := filepath.Join(tmpDir, "dead-letter")
+	if err := os.MkdirAll(deadLetterDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(dead-letter): %v", err)
+	}
+	dst := filepath.Join(deadLetterDir, "post-dl-test.md")
+	writeErr := errors.New("write failed")
+
+	err := writeDeadLetterFileWithOps(dst, []byte("payload"), deadLetterFileOps{
+		lstat: os.Lstat,
+		writeFile: func(name string, data []byte, perm os.FileMode) error {
+			if name != dst {
+				t.Fatalf("write path = %q, want %q", name, dst)
+			}
+			return writeErr
+		},
+	})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("writeDeadLetterFileWithOps() error = %v, want %v", err, writeErr)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("dead-letter file exists or wrong error: %v", err)
 	}
 }
 
@@ -64,6 +104,61 @@ func TestDeliverPostToInboxAndCountInboxMessages(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("CountInboxMessages() = %d, want 1", count)
+	}
+}
+
+func TestPlanArchiveInboxMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "ctx", "review")
+	filename := "20260502-120000-r1111-from-a-to-b.md"
+	inboxPath := filepath.Join(sessionDir, "inbox", "worker", filename)
+
+	plan, err := PlanArchiveInboxMessage(inboxPath, filename)
+	if err != nil {
+		t.Fatalf("PlanArchiveInboxMessage() error = %v", err)
+	}
+	if plan.SourcePath != inboxPath {
+		t.Fatalf("SourcePath = %q, want %q", plan.SourcePath, inboxPath)
+	}
+	if plan.SessionDir != sessionDir {
+		t.Fatalf("SessionDir = %q, want %q", plan.SessionDir, sessionDir)
+	}
+	if plan.ReadDir != filepath.Join(sessionDir, "read") {
+		t.Fatalf("ReadDir = %q", plan.ReadDir)
+	}
+	if plan.ReadPath != filepath.Join(sessionDir, "read", filename) {
+		t.Fatalf("ReadPath = %q", plan.ReadPath)
+	}
+	if _, err := os.Stat(plan.ReadDir); !os.IsNotExist(err) {
+		t.Fatalf("plan created read dir or wrong error: %v", err)
+	}
+}
+
+func TestArchiveInboxMessageMalformedAbsolutePathRejectedBeforeMutation(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "ctx", "review")
+	filename := "20260502-120000-r1111-from-a-to-b.md"
+	malformedPath := filepath.Join(sessionDir, "read", filename)
+	if err := os.MkdirAll(filepath.Dir(malformedPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(read): %v", err)
+	}
+	if err := os.WriteFile(malformedPath, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("WriteFile(read): %v", err)
+	}
+
+	if _, err := ArchiveInboxMessage(malformedPath, filename); err == nil {
+		t.Fatal("ArchiveInboxMessage() error = nil, want malformed path rejection")
+	}
+	got, err := os.ReadFile(malformedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(malformedPath): %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("malformed source content changed: %q", got)
+	}
+	unexpectedReadPath := filepath.Join(tmpDir, "ctx", "read", filename)
+	if _, err := os.Stat(unexpectedReadPath); !os.IsNotExist(err) {
+		t.Fatalf("unexpected read artifact or wrong error: %v", err)
 	}
 }
 
@@ -101,5 +196,50 @@ func TestArchiveInboxMessageMovesToReadAndRemovesDuplicate(t *testing.T) {
 	}
 	if _, err := os.Stat(inboxPath); !os.IsNotExist(err) {
 		t.Fatalf("duplicate inbox still exists or wrong error: %v", err)
+	}
+}
+
+func TestArchiveInboxMessageFailedRenamePreservesOriginalContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "ctx", "review")
+	filename := "20260502-120000-r1111-from-a-to-b.md"
+	inboxPath := filepath.Join(sessionDir, "inbox", "worker", filename)
+	if err := os.MkdirAll(filepath.Dir(inboxPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(inbox): %v", err)
+	}
+	if err := os.WriteFile(inboxPath, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("WriteFile(inbox): %v", err)
+	}
+	plan, err := PlanArchiveInboxMessage(inboxPath, filename)
+	if err != nil {
+		t.Fatalf("PlanArchiveInboxMessage() error = %v", err)
+	}
+	renameErr := errors.New("rename failed")
+
+	readPath, err := archiveInboxMessageWithOps(plan, archiveFileOps{
+		mkdirAll: os.MkdirAll,
+		stat: func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+		remove: os.Remove,
+		rename: func(oldPath, newPath string) error {
+			if oldPath != inboxPath || newPath != plan.ReadPath {
+				t.Fatalf("rename = %q -> %q, want %q -> %q", oldPath, newPath, inboxPath, plan.ReadPath)
+			}
+			return renameErr
+		},
+	})
+	if readPath != "" {
+		t.Fatalf("readPath = %q, want empty on failure", readPath)
+	}
+	if !errors.Is(err, renameErr) {
+		t.Fatalf("archiveInboxMessageWithOps() error = %v, want %v", err, renameErr)
+	}
+	got, readErr := os.ReadFile(inboxPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(inbox): %v", readErr)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("source content changed: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds pure store planners for inbox archive and dead-letter paths.
- Keeps public archive/dead-letter functions while moving file effects behind narrow test seams.
- Adds tests for planning, duplicate archive handling, malformed archive paths, failed archive rename, and dead-letter write failure.

## Scope

This is a partial slice of #468. It does not claim the remaining pop read-path display / absolute-path behavior item.

## Verification

- `git diff --check`
- `go test ./internal/store`
- `go test ./internal/cli ./internal/message ./internal/store`
- `go test ./...`
- `nix flake check`
- `nix build`

Refs #468
