### PR TITLE
refactor(cli): add pop command context

### DIFF
--- a/internal/cli/command_context.go
+++ b/internal/cli/command_context.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/cliutil"
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
+)
+
+type commandContext struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+
+	loadConfig            func(string) (*config.Config, error)
+	resolveInboxPath      func([]string) (string, error)
+	contextOwnsSession    func(baseDir, contextID, sessionName string) bool
+	roundTripDaemonSubmit func(sessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration) (projection.DaemonSubmitResponse, error)
+}
+
+func defaultCommandContext() commandContext {
+	return commandContext{}.withDefaults()
+}
+
+func (ctx commandContext) withDefaults() commandContext {
+	if ctx.stdin == nil {
+		ctx.stdin = os.Stdin
+	}
+	if ctx.stdout == nil {
+		ctx.stdout = os.Stdout
+	}
+	if ctx.stderr == nil {
+		ctx.stderr = os.Stderr
+	}
+	if ctx.loadConfig == nil {
+		ctx.loadConfig = config.LoadConfig
+	}
+	if ctx.resolveInboxPath == nil {
+		ctx.resolveInboxPath = cliutil.ResolveInboxPath
+	}
+	if ctx.contextOwnsSession == nil {
+		ctx.contextOwnsSession = config.ContextOwnsSession
+	}
+	if ctx.roundTripDaemonSubmit == nil {
+		ctx.roundTripDaemonSubmit = roundTripDaemonSubmit
+	}
+	return ctx
+}

--- a/internal/cli/pop.go
+++ b/internal/cli/pop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/cliutil"
-	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/envelope"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
@@ -22,6 +22,11 @@ import (
 
 // RunPop reads and optionally archives the oldest unread inbox message (#277).
 func RunPop(args []string) error {
+	return runPopWithContext(defaultCommandContext(), args)
+}
+
+func runPopWithContext(ctx commandContext, args []string) error {
+	ctx = ctx.withDefaults()
 	fs := flag.NewFlagSet("pop", flag.ContinueOnError)
 	cliutil.SetUsageWithoutContextID(fs)
 	contextID := fs.String("context-id", "", "context ID") // Issue #315: forward global --context-id
@@ -41,7 +46,7 @@ func RunPop(args []string) error {
 	if *configPath != "" {
 		inboxArgs = append([]string{"--config", *configPath}, inboxArgs...)
 	}
-	inboxPath, err := cliutil.ResolveInboxPath(inboxArgs)
+	inboxPath, err := ctx.resolveInboxPath(inboxArgs)
 	if err != nil {
 		return err
 	}
@@ -52,12 +57,12 @@ func RunPop(args []string) error {
 	sessionName := filepath.Base(sessionDir)
 	nodeName := filepath.Base(inboxPath)
 
-	cfg, err := config.LoadConfig(*configPath)
+	cfg, err := ctx.loadConfig(*configPath)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
-	if config.ContextOwnsSession(baseDir, resolvedContextID, sessionName) {
-		response, err := roundTripDaemonSubmit(sessionDir, projection.DaemonSubmitRequest{
+	if ctx.contextOwnsSession(baseDir, resolvedContextID, sessionName) {
+		response, err := ctx.roundTripDaemonSubmit(sessionDir, projection.DaemonSubmitRequest{
 			Command: projection.DaemonSubmitPop,
 			Node:    nodeName,
 		}, daemonSubmitTimeout(cfg.TmuxTimeout))
@@ -65,7 +70,7 @@ func RunPop(args []string) error {
 			return fmt.Errorf("daemon submit pop: %w", err)
 		}
 		if response.Empty {
-			return writeEmptyPopOutput(popSessionDiagnosticsForSession(sessionDir))
+			return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
 		}
 		remaining := response.UnreadBefore - 1
 		if remaining < 0 {
@@ -75,12 +80,12 @@ func RunPop(args []string) error {
 		if markdownPath == "" && response.Filename != "" {
 			markdownPath = filepath.Join(sessionDir, "read", response.Filename)
 		}
-		return writePopMessageOutput(response.Content, response.Filename, markdownPath, intPtr(response.UnreadBefore), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
+		return writePopMessageOutput(ctx.stdout, response.Content, response.Filename, markdownPath, intPtr(response.UnreadBefore), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
 	}
 
 	msgs := message.ScanInboxMessages(inboxPath)
 	if len(msgs) == 0 {
-		return writeEmptyPopOutput(popSessionDiagnosticsForSession(sessionDir))
+		return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
 	}
 	sort.Slice(msgs, func(i, j int) bool {
 		return msgs[i].Filename < msgs[j].Filename
@@ -93,7 +98,7 @@ func RunPop(args []string) error {
 			// Race: file disappeared between listing and reading; retry once.
 			msgs = message.ScanInboxMessages(inboxPath)
 			if len(msgs) == 0 {
-				return writeEmptyPopOutput(popSessionDiagnosticsForSession(sessionDir))
+				return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
 			}
 			sort.Slice(msgs, func(i, j int) bool {
 				return msgs[i].Filename < msgs[j].Filename
@@ -102,7 +107,7 @@ func RunPop(args []string) error {
 			data, err = os.ReadFile(abs)
 			if err != nil {
 				if os.IsNotExist(err) {
-					return writeEmptyPopOutput(popSessionDiagnosticsForSession(sessionDir))
+					return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
 				}
 				return fmt.Errorf("reading message: %w", err)
 			}
@@ -117,7 +122,7 @@ func RunPop(args []string) error {
 		return err
 	}
 	remaining--
-	return writePopMessageOutput(string(data), msgs[0].Filename, readPath, intPtr(len(msgs)), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
+	return writePopMessageOutput(ctx.stdout, string(data), msgs[0].Filename, readPath, intPtr(len(msgs)), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
 }
 
 func archivePoppedMessage(absPath, filename string) (string, error) {
@@ -167,11 +172,11 @@ type popSessionDiagnostics struct {
 
 const archivedBodyReadInstruction = "Read the complete archived Markdown body from markdown_absolute_path when present, otherwise markdown_path, before any handling, routing, reply, status decision, or no-action or no-op decision; messageType, replyPolicy, and other metadata do not waive this; truncated command output is not a complete read."
 
-func writeEmptyPopOutput(diagnostics *popSessionDiagnostics) error {
-	return json.NewEncoder(os.Stdout).Encode(popEmptyOutput{Status: "empty", SessionDiagnostics: diagnostics})
+func writeEmptyPopOutput(stdout io.Writer, diagnostics *popSessionDiagnostics) error {
+	return json.NewEncoder(stdout).Encode(popEmptyOutput{Status: "empty", SessionDiagnostics: diagnostics})
 }
 
-func writePopMessageOutput(content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics) error {
+func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics) error {
 	output := parseMessageContent(content, filename)
 	output.MarkdownPath = displayMarkdownPath(markdownPath)
 	if output.MarkdownPath != markdownPath {
@@ -185,7 +190,7 @@ func writePopMessageOutput(content, filename, markdownPath string, unreadBefore,
 	output.ArchivedBodyReadRequired = true
 	output.ArchivedBodyReadInstruction = archivedBodyReadInstruction
 	output.SessionDiagnostics = diagnostics
-	return json.NewEncoder(os.Stdout).Encode(output)
+	return json.NewEncoder(stdout).Encode(output)
 }
 
 func popSessionDiagnosticsForSession(sessionDir string) *popSessionDiagnostics {

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -63,6 +63,99 @@ func TestRunPop_HelpHidesContextIDFlag(t *testing.T) {
 	}
 }
 
+func TestRunPopWithContextWritesJSONToConfiguredStdout(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "ctx-pop-context"
+	sessionDir := filepath.Join(tmpDir, contextID, "test-session")
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+	filename := "20260414-032800-from-orchestrator-to-worker.md"
+	inboxPath := filepath.Join(inboxDir, filename)
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll inbox: %v", err)
+	}
+	if err := os.WriteFile(inboxPath, []byte(messageFixture("orchestrator", "worker", "context stdout payload")), 0o600); err != nil {
+		t.Fatalf("WriteFile inbox: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := runPopWithContext(commandContext{
+		stdout: &stdout,
+		resolveInboxPath: func(args []string) (string, error) {
+			if strings.Join(args, " ") != "--context-id "+contextID {
+				t.Fatalf("resolveInboxPath args = %#v", args)
+			}
+			return inboxDir, nil
+		},
+		loadConfig: func(path string) (*config.Config, error) {
+			if path != "" {
+				t.Fatalf("config path = %q, want empty", path)
+			}
+			return config.DefaultConfig(), nil
+		},
+		contextOwnsSession: func(baseDir, resolvedContextID, sessionName string) bool {
+			if baseDir != tmpDir || resolvedContextID != contextID || sessionName != "test-session" {
+				t.Fatalf("ownership args = %q/%q/%q", baseDir, resolvedContextID, sessionName)
+			}
+			return false
+		},
+	}, []string{"--context-id", contextID})
+	if err != nil {
+		t.Fatalf("runPopWithContext: %v", err)
+	}
+	payload := decodePopMessageOutputForTest(t, stdout.String())
+	if payload.MarkdownPath != filepath.Join(sessionDir, "read", filename) {
+		t.Fatalf("MarkdownPath = %q, want read path", payload.MarkdownPath)
+	}
+	if !strings.Contains(readPopArchiveForTest(t, payload), "context stdout payload") {
+		t.Fatalf("archived body missing expected payload")
+	}
+}
+
+func TestRunPopWithContextUsesDaemonSubmitDependencyWithoutDaemon(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "ctx-pop-submit-context"
+	sessionDir := filepath.Join(tmpDir, contextID, "test-session")
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+	filename := "20260414-032800-from-orchestrator-to-worker.md"
+
+	var stdout bytes.Buffer
+	var gotRequest projection.DaemonSubmitRequest
+	err := runPopWithContext(commandContext{
+		stdout: &stdout,
+		resolveInboxPath: func(args []string) (string, error) {
+			return inboxDir, nil
+		},
+		loadConfig: func(path string) (*config.Config, error) {
+			return config.DefaultConfig(), nil
+		},
+		contextOwnsSession: func(baseDir, resolvedContextID, sessionName string) bool {
+			return true
+		},
+		roundTripDaemonSubmit: func(gotSessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration) (projection.DaemonSubmitResponse, error) {
+			if gotSessionDir != sessionDir {
+				t.Fatalf("sessionDir = %q, want %q", gotSessionDir, sessionDir)
+			}
+			gotRequest = request
+			return projection.DaemonSubmitResponse{
+				Command:      request.Command,
+				Filename:     filename,
+				Content:      messageFixture("orchestrator", "worker", "daemon dependency payload"),
+				UnreadBefore: 1,
+			}, nil
+		},
+	}, []string{"--context-id", contextID})
+	if err != nil {
+		t.Fatalf("runPopWithContext: %v", err)
+	}
+	if gotRequest.Command != projection.DaemonSubmitPop || gotRequest.Node != "worker" {
+		t.Fatalf("daemon request = %#v, want pop for worker", gotRequest)
+	}
+	payload := decodePopMessageOutputForTest(t, stdout.String())
+	if payload.MarkdownPath != filepath.Join(sessionDir, "read", filename) {
+		t.Fatalf("MarkdownPath = %q, want inferred daemon read path", payload.MarkdownPath)
+	}
+}
+
 func TestRunPop_RequeuedMessagePreservesOriginalPayload(t *testing.T) {
 	tmpDir := t.TempDir()
 	installFakeTmuxForCLI(t, tmpDir, "test-session", "worker")


### PR DESCRIPTION
## Summary

- Adds a package-private CLI command context for command streams and selected runtime dependencies.
- Wires `RunPop` through injectable stdout, config loading, inbox resolution, ownership, and daemon-submit dependencies.
- Adds pop tests for configured stdout without global stream swaps and daemon-submit behavior without a daemon.

## Scope

This is a partial slice of #482 focused on `pop`. It preserves exported command behavior and does not claim the remaining command families.

## Verification

- `go test ./internal/cli -run 'TestRunPop'`
- `go test ./...`
- `git diff --check`
- `nix flake check`
- `nix build`

Refs #482
