### PR TITLE
fix(tui): show ping feedback in default view

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -711,6 +711,18 @@ func (m Model) renderNodesSection() string {
 	return b.String()
 }
 
+func (m Model) renderSelectedSessionStatus() string {
+	selectedSession := m.getSelectedSessionName()
+	if selectedSession == "" {
+		return ""
+	}
+	message := strings.TrimSpace(m.sessionStatus[selectedSession])
+	if message == "" {
+		return ""
+	}
+	return "\n[status]\n" + message + "\n"
+}
+
 func visibleStateLabel(node status.NodeStatus) string {
 	if node.VisibleState != "" {
 		return node.VisibleState
@@ -800,6 +812,7 @@ func (m Model) View() tea.View {
 	b.WriteString(m.renderSessionsSection())
 	b.WriteString("\n")
 	b.WriteString(m.renderNodesSection())
+	b.WriteString(m.renderSelectedSessionStatus())
 	view.Content = b.String()
 	return view
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -340,6 +340,11 @@ func TestTUI_Update_DefaultSurfacePingDispatchesCommand(t *testing.T) {
 	default:
 		t.Fatal("expected send_ping command after pressing p")
 	}
+
+	view := m.View().Content
+	if !strings.Contains(view, "[status]\nSending ping...") {
+		t.Fatalf("view missing visible ping feedback: %q", view)
+	}
 }
 
 func TestTUI_Update_DefaultSurfacePingLockedDuringStartupReadiness(t *testing.T) {


### PR DESCRIPTION
## Summary

- Render the selected session status in the default TUI view so `p` feedback is visible.
- Add a regression assertion for the ping dispatch path.

## Verification

- `git diff --check`
- `go test ./internal/tui -run 'TestTUI_Update_DefaultSurfacePing|TestTUI_View_DefaultSurfaceRowsUseSettledShape|TestTUI_Update_DefaultSurfaceSessionNavigationKeys' -count=1`
- `go test ./internal/tui -count=1`
- `go test ./...`
- `nix flake check`
- `nix build`
- README.md and `skills/*/SKILL.md` deprecated-reference scan produced no matches

Closes #521
