### PR TITLE
refactor(notification): add pane notifier state

### DIFF
--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -307,10 +307,10 @@ func TestRunPop_IncludesFilesystemSessionDiagnostics(t *testing.T) {
 		t.Fatalf("RunPop: %v\nstderr=%s", err, stderr)
 	}
 	payload := decodePopMessageOutputForTest(t, stdout)
-	diag := payload.SessionDiagnostics
-	if diag == nil {
+	if payload.SessionDiagnostics == nil {
 		t.Fatalf("SessionDiagnostics missing: %s", stdout)
 	}
+	diag := *payload.SessionDiagnostics
 	if diag.Source != "filesystem" {
 		t.Fatalf("diagnostics source = %q, want filesystem", diag.Source)
 	}
@@ -343,10 +343,12 @@ func TestPopSessionDiagnosticsUsesInputRequestProjection(t *testing.T) {
 	appendSessionStatusObligationEvent(t, writer, projection.MailboxProjectionPostConsumedEventType, "m1.md", "critic", "worker", content, now.Add(time.Second))
 	appendSessionStatusObligationEvent(t, writer, projection.MailboxProjectionDeliveredEventType, "m1.md", "critic", "worker", content, now.Add(2*time.Second))
 
-	diag := popSessionDiagnosticsForSession(sessionDir)
-	if diag == nil {
+	diagnostics := popSessionDiagnosticsForSession(sessionDir)
+	if diagnostics == nil {
 		t.Fatal("popSessionDiagnosticsForSession returned nil")
+		return
 	}
+	diag := *diagnostics
 	if diag.Source != "projection" {
 		t.Fatalf("diagnostics source = %q, want projection", diag.Source)
 	}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -17,9 +18,7 @@ import (
 )
 
 var (
-	paneNotifyMu       sync.Mutex
-	paneLastNotified   = map[string]time.Time{}
-	paneNotifyCooldown = 10 * time.Minute
+	defaultPaneNotifier = NewPaneNotifier(10 * time.Minute)
 
 	// bufferMu serializes tmux set-buffer + paste-buffer pairs.
 	// tmux uses a single global paste buffer; concurrent SendToPane calls
@@ -28,12 +27,38 @@ var (
 	bufferMu sync.Mutex
 )
 
+// PaneNotifier sends notifications to tmux panes with instance-scoped cooldown state.
+type PaneNotifier struct {
+	mu           sync.Mutex
+	lastNotified map[string]time.Time
+	cooldown     time.Duration
+
+	now     func() time.Time
+	sleep   func(time.Duration)
+	runTmux func(args ...string) error
+	capture func(paneID string) (string, error)
+	stderr  io.Writer
+}
+
+// NewPaneNotifier creates a pane notifier with the given per-pane cooldown.
+func NewPaneNotifier(cooldown time.Duration) *PaneNotifier {
+	return &PaneNotifier{
+		lastNotified: make(map[string]time.Time),
+		cooldown:     cooldown,
+	}
+}
+
 // InitPaneCooldown sets the per-pane notification cooldown duration.
 // Must be called once at startup before any SendToPane calls.
 func InitPaneCooldown(d time.Duration) {
-	paneNotifyMu.Lock()
-	paneNotifyCooldown = d
-	paneNotifyMu.Unlock()
+	defaultPaneNotifier.InitCooldown(d)
+}
+
+// InitCooldown sets this notifier's per-pane cooldown duration.
+func (n *PaneNotifier) InitCooldown(d time.Duration) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.cooldown = d
 }
 
 // BuildNotification builds a notification message using notification_template.
@@ -53,65 +78,74 @@ func BuildNotification(cfg *config.Config, adjacency map[string][]string, nodes 
 // verifyDelay > 0 enables post-Enter capture comparison: after C-m, waits verifyDelay,
 // captures pane, waits again, captures again; if identical, retries C-m up to maxRetries.
 func SendToPane(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error {
+	return defaultPaneNotifier.SendToPane(paneID, message, enterDelay, tmuxTimeout, enterCount, bypassCooldown, verifyDelay, maxRetries)
+}
+
+// SendToPane sends a message to a tmux pane using this notifier's dependencies and cooldown state.
+func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error {
+	if n == nil {
+		n = defaultPaneNotifier
+	}
 	if strings.TrimSpace(message) == "" {
 		err := fmt.Errorf("empty notification body for pane %s", paneID)
-		fmt.Fprintf(os.Stderr, "postman: notification: %v\n", err)
+		fmt.Fprintf(n.stderrWriter(), "postman: notification: %v\n", err)
 		return err
 	}
 	// Rate limit: skip if pane was notified within cooldown window (#273).
 	// paneNotifyCooldown <= 0 disables the limiter (used in tests).
-	paneNotifyMu.Lock()
-	if !bypassCooldown && paneNotifyCooldown > 0 {
-		if last, ok := paneLastNotified[paneID]; ok && time.Since(last) < paneNotifyCooldown {
-			paneNotifyMu.Unlock()
-			fmt.Fprintf(os.Stderr, "postman: notification: cooldown active for pane %s (last=%s, cooldown=%s)\n", paneID, last.Format(time.RFC3339), paneNotifyCooldown)
+	now := n.nowTime()
+	n.mu.Lock()
+	if n.lastNotified == nil {
+		n.lastNotified = make(map[string]time.Time)
+	}
+	cooldown := n.cooldown
+	if !bypassCooldown && cooldown > 0 {
+		if last, ok := n.lastNotified[paneID]; ok && now.Sub(last) < cooldown {
+			n.mu.Unlock()
+			fmt.Fprintf(n.stderrWriter(), "postman: notification: cooldown active for pane %s (last=%s, cooldown=%s)\n", paneID, last.Format(time.RFC3339), cooldown)
 			return nil
 		}
 	}
-	paneLastNotified[paneID] = time.Now()
-	paneNotifyMu.Unlock()
+	n.lastNotified[paneID] = now
+	n.mu.Unlock()
 	// Wrap with protocol sentinels so all pane output is clearly delimited.
 	message = "<!-- message start -->\n" + message + "\n<!-- end of message -->"
 	// Security: Sanitize message for tmux set-buffer (#301)
 	sanitized, err := sanitizeForTmux(message)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠️  postman: WARNING: sanitizeForTmux: %v\n", err)
+		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: sanitizeForTmux: %v\n", err)
 		return err
 	}
 
 	// 1-2. Set buffer + paste buffer (serialized via bufferMu to prevent
 	// global tmux paste-buffer race when deliveries run concurrently).
 	bufferMu.Lock()
-	cmd := exec.Command("tmux", "set-buffer", sanitized)
-	if err := cmd.Run(); err != nil {
+	if err := n.run("set-buffer", sanitized); err != nil {
 		bufferMu.Unlock()
-		fmt.Fprintf(os.Stderr, "⚠️  postman: WARNING: failed to set buffer for pane %s: %v\n", paneID, err)
+		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to set buffer for pane %s: %v\n", paneID, err)
 		return err
 	}
-	cmd = exec.Command("tmux", "paste-buffer", "-t", paneID)
-	if err := cmd.Run(); err != nil {
+	if err := n.run("paste-buffer", "-t", paneID); err != nil {
 		bufferMu.Unlock()
-		fmt.Fprintf(os.Stderr, "⚠️  postman: WARNING: failed to paste buffer to pane %s: %v\n", paneID, err)
+		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to paste buffer to pane %s: %v\n", paneID, err)
 		return err
 	}
 	bufferMu.Unlock()
 
 	// 3. Wait enter_delay (runs outside bufferMu — parallel across panes)
-	time.Sleep(enterDelay)
+	n.sleepFor(enterDelay)
 
 	// 4. Send C-m to submit. C-m (carriage return) submits reliably in both Codex CLI and claude-chill.
 	// "Enter" key name adds a newline in Codex CLI multi-line readline instead of submitting (#126).
-	cmd = exec.Command("tmux", "send-keys", "-t", paneID, "C-m")
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "⚠️  postman: WARNING: failed to send C-m to pane %s: %v\n", paneID, err)
+	if err := n.run("send-keys", "-t", paneID, "C-m"); err != nil {
+		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to send C-m to pane %s: %v\n", paneID, err)
 		return err
 	}
 
 	// 5. Send additional C-m keystrokes up to enterCount total
 	for i := 1; i < enterCount; i++ {
-		time.Sleep(enterDelay)
-		cmd = exec.Command("tmux", "send-keys", "-t", paneID, "C-m")
-		if err := cmd.Run(); err != nil {
+		n.sleepFor(enterDelay)
+		if err := n.run("send-keys", "-t", paneID, "C-m"); err != nil {
 			return fmt.Errorf("failed to send C-m %d to pane %s: %w", i+1, paneID, err)
 		}
 	}
@@ -119,13 +153,13 @@ func SendToPane(paneID string, message string, enterDelay time.Duration, tmuxTim
 	// 6. Post-Enter verify: capture-compare-retry to detect swallowed Enter
 	if verifyDelay > 0 && maxRetries > 0 {
 		for retry := 0; retry < maxRetries; retry++ {
-			time.Sleep(verifyDelay)
-			snapA, errA := paneutil.CaptureContent(paneID)
+			n.sleepFor(verifyDelay)
+			snapA, errA := n.capturePane(paneID)
 			if errA != nil {
 				break // cannot verify; skip
 			}
-			time.Sleep(verifyDelay)
-			snapB, errB := paneutil.CaptureContent(paneID)
+			n.sleepFor(verifyDelay)
+			snapB, errB := n.capturePane(paneID)
 			if errB != nil {
 				break
 			}
@@ -133,12 +167,47 @@ func SendToPane(paneID string, message string, enterDelay time.Duration, tmuxTim
 				break // pane content changed; Enter was accepted
 			}
 			// Pane unchanged — retry C-m silently so alt-screen TUI panes stay clean.
-			cmd = exec.Command("tmux", "send-keys", "-t", paneID, "C-m")
-			_ = cmd.Run()
+			_ = n.run("send-keys", "-t", paneID, "C-m")
 		}
 	}
 
 	return nil
+}
+
+func (n *PaneNotifier) nowTime() time.Time {
+	if n.now != nil {
+		return n.now()
+	}
+	return time.Now()
+}
+
+func (n *PaneNotifier) sleepFor(d time.Duration) {
+	if n.sleep != nil {
+		n.sleep(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+func (n *PaneNotifier) run(args ...string) error {
+	if n.runTmux != nil {
+		return n.runTmux(args...)
+	}
+	return exec.Command("tmux", args...).Run()
+}
+
+func (n *PaneNotifier) capturePane(paneID string) (string, error) {
+	if n.capture != nil {
+		return n.capture(paneID)
+	}
+	return paneutil.CaptureContent(paneID)
+}
+
+func (n *PaneNotifier) stderrWriter() io.Writer {
+	if n.stderr != nil {
+		return n.stderr
+	}
+	return os.Stderr
 }
 
 // ResolveEnterCount returns the effective enter count for pane delivery.

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -88,7 +88,7 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	}
 	if strings.TrimSpace(message) == "" {
 		err := fmt.Errorf("empty notification body for pane %s", paneID)
-		fmt.Fprintf(n.stderrWriter(), "postman: notification: %v\n", err)
+		n.warnf("postman: notification: %v\n", err)
 		return err
 	}
 	// Rate limit: skip if pane was notified within cooldown window (#273).
@@ -102,7 +102,7 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	if !bypassCooldown && cooldown > 0 {
 		if last, ok := n.lastNotified[paneID]; ok && now.Sub(last) < cooldown {
 			n.mu.Unlock()
-			fmt.Fprintf(n.stderrWriter(), "postman: notification: cooldown active for pane %s (last=%s, cooldown=%s)\n", paneID, last.Format(time.RFC3339), cooldown)
+			n.warnf("postman: notification: cooldown active for pane %s (last=%s, cooldown=%s)\n", paneID, last.Format(time.RFC3339), cooldown)
 			return nil
 		}
 	}
@@ -113,7 +113,7 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	// Security: Sanitize message for tmux set-buffer (#301)
 	sanitized, err := sanitizeForTmux(message)
 	if err != nil {
-		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: sanitizeForTmux: %v\n", err)
+		n.warnf("⚠️  postman: WARNING: sanitizeForTmux: %v\n", err)
 		return err
 	}
 
@@ -122,12 +122,12 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	bufferMu.Lock()
 	if err := n.run("set-buffer", sanitized); err != nil {
 		bufferMu.Unlock()
-		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to set buffer for pane %s: %v\n", paneID, err)
+		n.warnf("⚠️  postman: WARNING: failed to set buffer for pane %s: %v\n", paneID, err)
 		return err
 	}
 	if err := n.run("paste-buffer", "-t", paneID); err != nil {
 		bufferMu.Unlock()
-		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to paste buffer to pane %s: %v\n", paneID, err)
+		n.warnf("⚠️  postman: WARNING: failed to paste buffer to pane %s: %v\n", paneID, err)
 		return err
 	}
 	bufferMu.Unlock()
@@ -138,7 +138,7 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	// 4. Send C-m to submit. C-m (carriage return) submits reliably in both Codex CLI and claude-chill.
 	// "Enter" key name adds a newline in Codex CLI multi-line readline instead of submitting (#126).
 	if err := n.run("send-keys", "-t", paneID, "C-m"); err != nil {
-		fmt.Fprintf(n.stderrWriter(), "⚠️  postman: WARNING: failed to send C-m to pane %s: %v\n", paneID, err)
+		n.warnf("⚠️  postman: WARNING: failed to send C-m to pane %s: %v\n", paneID, err)
 		return err
 	}
 
@@ -208,6 +208,10 @@ func (n *PaneNotifier) stderrWriter() io.Writer {
 		return n.stderr
 	}
 	return os.Stderr
+}
+
+func (n *PaneNotifier) warnf(format string, args ...any) {
+	_, _ = fmt.Fprintf(n.stderrWriter(), format, args...)
 }
 
 // ResolveEnterCount returns the effective enter count for pane delivery.

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -423,6 +423,63 @@ func TestSendToPane_RejectsEmptyNotificationBody(t *testing.T) {
 	}
 }
 
+func TestPaneNotifierCooldownIsInstanceScoped(t *testing.T) {
+	now := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	notifierA, callsA := paneNotifierForTest(now, time.Minute)
+	if err := notifierA.SendToPane("%1", "hello", 0, 0, 1, false, 0, 0); err != nil {
+		t.Fatalf("notifierA first SendToPane: %v", err)
+	}
+	if err := notifierA.SendToPane("%1", "hello again", 0, 0, 1, false, 0, 0); err != nil {
+		t.Fatalf("notifierA second SendToPane: %v", err)
+	}
+	if *callsA != 3 {
+		t.Fatalf("notifierA tmux calls = %d, want 3 because second send is within cooldown", *callsA)
+	}
+
+	notifierB, callsB := paneNotifierForTest(now, time.Minute)
+	if err := notifierB.SendToPane("%1", "independent hello", 0, 0, 1, false, 0, 0); err != nil {
+		t.Fatalf("notifierB SendToPane: %v", err)
+	}
+	if *callsB != 3 {
+		t.Fatalf("notifierB tmux calls = %d, want 3 with independent cooldown state", *callsB)
+	}
+}
+
+func TestPaneNotifierBypassCooldown(t *testing.T) {
+	now := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	notifier, calls := paneNotifierForTest(now, time.Minute)
+	if err := notifier.SendToPane("%1", "hello", 0, 0, 1, true, 0, 0); err != nil {
+		t.Fatalf("first SendToPane: %v", err)
+	}
+	if err := notifier.SendToPane("%1", "hello again", 0, 0, 1, true, 0, 0); err != nil {
+		t.Fatalf("second SendToPane: %v", err)
+	}
+	if *calls != 6 {
+		t.Fatalf("tmux calls = %d, want 6 because bypass sends both notifications", *calls)
+	}
+}
+
+func TestPaneNotifierEnterVerifyRetryUsesInjectedDependencies(t *testing.T) {
+	now := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	notifier, _ := paneNotifierForTest(now, 0)
+	sendKeys := 0
+	notifier.runTmux = func(args ...string) error {
+		if len(args) > 0 && args[0] == "send-keys" {
+			sendKeys++
+		}
+		return nil
+	}
+	notifier.capture = func(paneID string) (string, error) {
+		return "unchanged", nil
+	}
+	if err := notifier.SendToPane("%1", "hello", 0, 0, 1, true, 1*time.Millisecond, 2); err != nil {
+		t.Fatalf("SendToPane: %v", err)
+	}
+	if sendKeys != 3 {
+		t.Fatalf("send-keys calls = %d, want initial send plus 2 verify retries", sendKeys)
+	}
+}
+
 func TestSendToPane_EnterCount2(t *testing.T) {
 	tmpDir := t.TempDir()
 	argsFile := filepath.Join(tmpDir, "args.txt")
@@ -653,4 +710,19 @@ esac
 	if strings.Contains(string(stderrBytes), "enter verify") {
 		t.Fatalf("SendToPane leaked enter-verify warning to stderr: %q", string(stderrBytes))
 	}
+}
+
+func paneNotifierForTest(now time.Time, cooldown time.Duration) (*PaneNotifier, *int) {
+	calls := 0
+	notifier := NewPaneNotifier(cooldown)
+	notifier.now = func() time.Time {
+		return now
+	}
+	notifier.sleep = func(time.Duration) {}
+	notifier.stderr = io.Discard
+	notifier.runTmux = func(args ...string) error {
+		calls++
+		return nil
+	}
+	return notifier, &calls
 }


### PR DESCRIPTION
## Summary

- Adds `notification.PaneNotifier` with instance-scoped per-pane cooldown state.
- Preserves the package-level `SendToPane` wrapper through a default notifier.
- Keeps tmux paste-buffer serialization process-wide while injecting runner, clock, sleep, capture, and stderr dependencies for deterministic tests.

## Scope

This is a partial slice of #480 focused on pane notifier state and test seams. It preserves existing delivery behavior and does not change retry policy or tmux runner ownership beyond this notification path.

## Verification

- `go test ./internal/notification`
- `go test ./...`
- `nix flake check`
- `nix build`

Refs #480
