### PR TITLE
refactor(cli): add daemon-submit transport seam

### DIFF
--- a/internal/cli/daemon_submit.go
+++ b/internal/cli/daemon_submit.go
@@ -4,10 +4,44 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 )
+
+const daemonSubmitPollInterval = 10 * time.Millisecond
+
+type daemonSubmitRoundTripper struct {
+	now            func() time.Time
+	sleep          func(time.Duration)
+	newRequestID   func(time.Time) (string, error)
+	writeRequest   func(string, projection.DaemonSubmitRequest) (string, error)
+	readResponse   func(string) (projection.DaemonSubmitResponse, error)
+	removeResponse func(string) error
+	diagnostics    func(string, time.Time) daemonSubmitRoundTripDiagnostics
+}
+
+type daemonSubmitRoundTripOutcome struct {
+	RequestID          string
+	RequestPath        string
+	ResponsePath       string
+	RequestCreatedAt   string
+	Response           projection.DaemonSubmitResponse
+	TimedOut           bool
+	StaleResponseCount int
+	Diagnostics        daemonSubmitRoundTripDiagnostics
+}
+
+type daemonSubmitRoundTripDiagnostics struct {
+	PendingRequestCount          int
+	OldestPendingAgeSeconds      int
+	ClaimedRequestCount          int
+	OldestClaimedAgeSeconds      int
+	LateResponseCount            int
+	OldestLateResponseAgeSeconds int
+}
 
 func daemonSubmitTimeout(tmuxTimeoutSeconds float64) time.Duration {
 	if tmuxTimeoutSeconds <= 0 {
@@ -21,29 +55,223 @@ func daemonSubmitTimeout(tmuxTimeoutSeconds float64) time.Duration {
 }
 
 func roundTripDaemonSubmit(sessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration) (projection.DaemonSubmitResponse, error) {
-	now := time.Now()
-	requestID, err := projection.NewDaemonSubmitRequestID(now)
-	if err != nil {
-		return projection.DaemonSubmitResponse{}, err
-	}
-	request.RequestID = requestID
-	request.CreatedAt = now.UTC().Format(time.RFC3339Nano)
-	if _, err := projection.WriteDaemonSubmitRequest(sessionDir, request); err != nil {
-		return projection.DaemonSubmitResponse{}, err
-	}
-	response, responsePath, err := projection.WaitDaemonSubmitResponse(sessionDir, requestID, timeout)
+	return roundTripDaemonSubmitWithTransport(sessionDir, request, timeout, daemonSubmitRoundTripper{})
+}
+
+func roundTripDaemonSubmitWithTransport(sessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration, transport daemonSubmitRoundTripper) (projection.DaemonSubmitResponse, error) {
+	outcome, err := transport.roundTrip(sessionDir, request, timeout)
 	if err != nil {
 		var timeoutErr projection.DaemonSubmitResponseTimeoutError
 		if errors.As(err, &timeoutErr) {
-			return projection.DaemonSubmitResponse{}, fmt.Errorf("daemon-submit %s request %q timed out after %s; the request may still commit after this timeout; do not retry blindly; use `tmux-a2a-postman inspect-daemon-submit --id %s` to look up this request, inspect status, inbox/read evidence, or recipient-side evidence, and use `tmux-a2a-postman get-status --debug` for daemon_submit pending/claimed/late response counts before retrying", request.Command, requestID, timeoutErr.Timeout, requestID)
+			return projection.DaemonSubmitResponse{}, fmt.Errorf("daemon-submit %s request %q timed out after %s; the request may still commit after this timeout; do not retry blindly; use `tmux-a2a-postman inspect-daemon-submit --id %s` to look up this request, inspect status, inbox/read evidence, or recipient-side evidence, and use `tmux-a2a-postman get-status --debug` for daemon_submit pending/claimed/late response counts before retrying", request.Command, outcome.RequestID, timeoutErr.Timeout, outcome.RequestID)
 		}
 		return projection.DaemonSubmitResponse{}, err
 	}
-	if removeErr := os.Remove(responsePath); removeErr != nil && !os.IsNotExist(removeErr) {
-		return projection.DaemonSubmitResponse{}, removeErr
-	}
+	response := outcome.Response
 	if response.Error != "" {
 		return projection.DaemonSubmitResponse{}, fmt.Errorf("%s", response.Error)
 	}
 	return response, nil
+}
+
+func (transport daemonSubmitRoundTripper) roundTrip(sessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration) (daemonSubmitRoundTripOutcome, error) {
+	transport = transport.withDefaults()
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+
+	now := transport.now()
+	requestID, err := transport.newRequestID(now)
+	if err != nil {
+		return daemonSubmitRoundTripOutcome{}, err
+	}
+	request.RequestID = requestID
+	request.CreatedAt = now.UTC().Format(time.RFC3339Nano)
+	requestPath, err := transport.writeRequest(sessionDir, request)
+	outcome := daemonSubmitRoundTripOutcome{
+		RequestID:        requestID,
+		RequestPath:      requestPath,
+		ResponsePath:     projection.DaemonSubmitResponsePath(sessionDir, requestID),
+		RequestCreatedAt: request.CreatedAt,
+	}
+	if err != nil {
+		return outcome, err
+	}
+
+	deadline := now.Add(timeout)
+	for {
+		response, err := transport.readResponse(outcome.ResponsePath)
+		if err == nil {
+			if isStaleDaemonSubmitResponse(response, requestID, request.CreatedAt) {
+				outcome.StaleResponseCount++
+				if removeErr := transport.removeResponse(outcome.ResponsePath); removeErr != nil && !os.IsNotExist(removeErr) {
+					return outcome, removeErr
+				}
+				continue
+			}
+			outcome.Response = response
+			if removeErr := transport.removeResponse(outcome.ResponsePath); removeErr != nil && !os.IsNotExist(removeErr) {
+				return outcome, removeErr
+			}
+			return outcome, nil
+		}
+		if !os.IsNotExist(err) {
+			return outcome, err
+		}
+		current := transport.now()
+		if current.After(deadline) {
+			outcome.TimedOut = true
+			outcome.Diagnostics = transport.diagnostics(sessionDir, current)
+			return outcome, projection.DaemonSubmitResponseTimeoutError{
+				RequestID: requestID,
+				Timeout:   timeout,
+			}
+		}
+		transport.sleep(daemonSubmitPollInterval)
+	}
+}
+
+func (transport daemonSubmitRoundTripper) withDefaults() daemonSubmitRoundTripper {
+	if transport.now == nil {
+		transport.now = time.Now
+	}
+	if transport.sleep == nil {
+		transport.sleep = time.Sleep
+	}
+	if transport.newRequestID == nil {
+		transport.newRequestID = projection.NewDaemonSubmitRequestID
+	}
+	if transport.writeRequest == nil {
+		transport.writeRequest = projection.WriteDaemonSubmitRequest
+	}
+	if transport.readResponse == nil {
+		transport.readResponse = projection.ReadDaemonSubmitResponse
+	}
+	if transport.removeResponse == nil {
+		transport.removeResponse = os.Remove
+	}
+	if transport.diagnostics == nil {
+		transport.diagnostics = scanDaemonSubmitRoundTripDiagnostics
+	}
+	return transport
+}
+
+func isStaleDaemonSubmitResponse(response projection.DaemonSubmitResponse, requestID, requestCreatedAt string) bool {
+	if response.RequestID != "" && response.RequestID != requestID {
+		return true
+	}
+	if response.HandledAt == "" || requestCreatedAt == "" {
+		return false
+	}
+	handledAt, err := time.Parse(time.RFC3339Nano, response.HandledAt)
+	if err != nil {
+		return false
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, requestCreatedAt)
+	if err != nil {
+		return false
+	}
+	// Daemon responses are currently second-precision while requests are
+	// nanosecond-precision, so same-second responses are not stale.
+	return handledAt.Add(time.Second).Before(createdAt)
+}
+
+func scanDaemonSubmitRoundTripDiagnostics(sessionDir string, now time.Time) daemonSubmitRoundTripDiagnostics {
+	diagnostics := daemonSubmitRoundTripDiagnostics{}
+	scanDaemonSubmitRoundTripRequests(sessionDir, now, &diagnostics)
+	scanDaemonSubmitRoundTripResponses(sessionDir, now, &diagnostics)
+	return diagnostics
+}
+
+func scanDaemonSubmitRoundTripRequests(sessionDir string, now time.Time, diagnostics *daemonSubmitRoundTripDiagnostics) {
+	requestsDir := projection.DaemonSubmitRequestsDir(sessionDir)
+	entries, err := os.ReadDir(requestsDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		state := ""
+		switch {
+		case strings.HasSuffix(entry.Name(), ".json"):
+			state = "pending"
+		case strings.HasSuffix(entry.Name(), ".processing"):
+			state = "claimed"
+		default:
+			continue
+		}
+
+		requestPath := filepath.Join(requestsDir, entry.Name())
+		request, err := projection.ReadDaemonSubmitRequest(requestPath)
+		if err == nil && request.Command == projection.DaemonSubmitRuntimeDiagnostics {
+			continue
+		}
+		switch state {
+		case "pending":
+			diagnostics.PendingRequestCount++
+			if err == nil {
+				diagnostics.OldestPendingAgeSeconds = oldestDaemonSubmitRoundTripAgeSeconds(diagnostics.OldestPendingAgeSeconds, request.CreatedAt, now)
+			}
+		case "claimed":
+			diagnostics.ClaimedRequestCount++
+			if err == nil {
+				diagnostics.OldestClaimedAgeSeconds = oldestDaemonSubmitRoundTripAgeSeconds(diagnostics.OldestClaimedAgeSeconds, request.CreatedAt, now)
+			}
+		}
+	}
+}
+
+func scanDaemonSubmitRoundTripResponses(sessionDir string, now time.Time, diagnostics *daemonSubmitRoundTripDiagnostics) {
+	responsesDir := projection.DaemonSubmitResponsesDir(sessionDir)
+	entries, err := os.ReadDir(responsesDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		responsePath := filepath.Join(responsesDir, entry.Name())
+		response, err := projection.ReadDaemonSubmitResponse(responsePath)
+		if err == nil && response.Command == projection.DaemonSubmitRuntimeDiagnostics {
+			continue
+		}
+
+		diagnostics.LateResponseCount++
+		if err == nil {
+			diagnostics.OldestLateResponseAgeSeconds = oldestDaemonSubmitRoundTripAgeSeconds(diagnostics.OldestLateResponseAgeSeconds, response.HandledAt, now)
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr == nil {
+			diagnostics.OldestLateResponseAgeSeconds = oldestDaemonSubmitRoundTripAgeSecondsFromTime(diagnostics.OldestLateResponseAgeSeconds, info.ModTime(), now)
+		}
+	}
+}
+
+func oldestDaemonSubmitRoundTripAgeSeconds(current int, timestamp string, now time.Time) int {
+	if timestamp == "" {
+		return current
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return current
+	}
+	return oldestDaemonSubmitRoundTripAgeSecondsFromTime(current, parsed, now)
+}
+
+func oldestDaemonSubmitRoundTripAgeSecondsFromTime(current int, timestamp time.Time, now time.Time) int {
+	if timestamp.IsZero() {
+		return current
+	}
+	age := 0
+	if timestamp.Before(now) {
+		age = int(now.Sub(timestamp).Seconds())
+	}
+	if age > current {
+		return age
+	}
+	return current
 }

--- a/internal/cli/daemon_submit_test.go
+++ b/internal/cli/daemon_submit_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -37,5 +40,369 @@ func TestRoundTripDaemonSubmitTimeoutWarnsRequestMayStillCommit(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("timeout error missing %q: %q", want, got)
 		}
+	}
+}
+
+func TestDaemonSubmitRoundTripperReturnsResponseBeforeTimeout(t *testing.T) {
+	createdAt := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	var wrote projection.DaemonSubmitRequest
+	var removedPath string
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return createdAt
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-ok", nil
+		},
+		writeRequest: func(_ string, request projection.DaemonSubmitRequest) (string, error) {
+			wrote = request
+			return "/state/requests/req-ok.json", nil
+		},
+		readResponse: func(path string) (projection.DaemonSubmitResponse, error) {
+			if path != "/session/snapshot/daemon-submit/responses/req-ok.json" {
+				t.Fatalf("readResponse path = %q", path)
+			}
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-ok",
+				Command:   projection.DaemonSubmitSend,
+				HandledAt: createdAt.Add(time.Second).Format(time.RFC3339Nano),
+				Filename:  "message.md",
+			}, nil
+		},
+		removeResponse: func(path string) error {
+			removedPath = path
+			return nil
+		},
+		sleep: func(time.Duration) {
+			t.Fatal("sleep should not run when response is available immediately")
+		},
+	}
+
+	outcome, err := transport.roundTrip("/session", projection.DaemonSubmitRequest{
+		Command:  projection.DaemonSubmitSend,
+		Filename: "message.md",
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("roundTrip: %v", err)
+	}
+	if outcome.RequestID != "req-ok" || outcome.RequestPath != "/state/requests/req-ok.json" {
+		t.Fatalf("outcome request identity = %q/%q", outcome.RequestID, outcome.RequestPath)
+	}
+	if wrote.RequestID != "req-ok" || wrote.CreatedAt != createdAt.Format(time.RFC3339Nano) {
+		t.Fatalf("written request = %#v", wrote)
+	}
+	if outcome.Response.Filename != "message.md" {
+		t.Fatalf("outcome.Response.Filename = %q, want message.md", outcome.Response.Filename)
+	}
+	if removedPath != "/session/snapshot/daemon-submit/responses/req-ok.json" {
+		t.Fatalf("removedPath = %q", removedPath)
+	}
+}
+
+func TestDaemonSubmitRoundTripperTimeoutReturnsDiagnosticsWithoutRealSleep(t *testing.T) {
+	createdAt := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	nowCalls := 0
+	sleepCalls := 0
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			nowCalls++
+			if nowCalls <= 2 {
+				return createdAt
+			}
+			return createdAt.Add(2 * time.Second)
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-timeout", nil
+		},
+		writeRequest: func(string, projection.DaemonSubmitRequest) (string, error) {
+			return "/state/requests/req-timeout.json", nil
+		},
+		readResponse: func(string) (projection.DaemonSubmitResponse, error) {
+			return projection.DaemonSubmitResponse{}, os.ErrNotExist
+		},
+		diagnostics: func(string, time.Time) daemonSubmitRoundTripDiagnostics {
+			return daemonSubmitRoundTripDiagnostics{
+				PendingRequestCount:     1,
+				OldestPendingAgeSeconds: 2,
+			}
+		},
+		sleep: func(time.Duration) {
+			sleepCalls++
+		},
+	}
+
+	outcome, err := transport.roundTrip("/session", projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitPop,
+		Node:    "worker",
+	}, time.Second)
+	if err == nil {
+		t.Fatal("roundTrip error = nil, want timeout")
+	}
+	var timeoutErr projection.DaemonSubmitResponseTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("roundTrip error = %v, want timeout error", err)
+	}
+	if !outcome.TimedOut {
+		t.Fatal("outcome.TimedOut = false, want true")
+	}
+	if outcome.Diagnostics.PendingRequestCount != 1 || outcome.Diagnostics.OldestPendingAgeSeconds != 2 {
+		t.Fatalf("outcome.Diagnostics = %#v", outcome.Diagnostics)
+	}
+	if sleepCalls != 1 {
+		t.Fatalf("sleepCalls = %d, want 1", sleepCalls)
+	}
+}
+
+func TestDaemonSubmitRoundTripperRemovesStaleResponseAndWaitsForFresh(t *testing.T) {
+	createdAt := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+	readCalls := 0
+	removed := []string{}
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return createdAt.Add(time.Second)
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-stale", nil
+		},
+		writeRequest: func(string, projection.DaemonSubmitRequest) (string, error) {
+			return "/state/requests/req-stale.json", nil
+		},
+		readResponse: func(string) (projection.DaemonSubmitResponse, error) {
+			readCalls++
+			if readCalls == 1 {
+				return projection.DaemonSubmitResponse{
+					RequestID: "req-stale",
+					Command:   projection.DaemonSubmitPop,
+					HandledAt: createdAt.Add(-time.Minute).Format(time.RFC3339Nano),
+					Empty:     true,
+				}, nil
+			}
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-stale",
+				Command:   projection.DaemonSubmitPop,
+				HandledAt: createdAt.Add(time.Second).Format(time.RFC3339Nano),
+				Filename:  "fresh.md",
+			}, nil
+		},
+		removeResponse: func(path string) error {
+			removed = append(removed, path)
+			return nil
+		},
+		sleep: func(time.Duration) {},
+	}
+
+	outcome, err := transport.roundTrip("/session", projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitPop,
+		Node:    "worker",
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("roundTrip: %v", err)
+	}
+	if outcome.StaleResponseCount != 1 {
+		t.Fatalf("outcome.StaleResponseCount = %d, want 1", outcome.StaleResponseCount)
+	}
+	if outcome.Response.Filename != "fresh.md" {
+		t.Fatalf("outcome.Response.Filename = %q, want fresh.md", outcome.Response.Filename)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed = %#v, want stale and fresh response removals", removed)
+	}
+}
+
+func TestDaemonSubmitRoundTripperAcceptsSecondPrecisionHandledAt(t *testing.T) {
+	createdAt := time.Date(2026, time.June, 1, 1, 0, 0, 750000000, time.UTC)
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return createdAt
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-second-precision", nil
+		},
+		writeRequest: func(string, projection.DaemonSubmitRequest) (string, error) {
+			return "/state/requests/req-second-precision.json", nil
+		},
+		readResponse: func(string) (projection.DaemonSubmitResponse, error) {
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-second-precision",
+				Command:   projection.DaemonSubmitPop,
+				HandledAt: createdAt.Truncate(time.Second).Format(time.RFC3339),
+				Filename:  "same-second.md",
+			}, nil
+		},
+		removeResponse: func(string) error {
+			return nil
+		},
+		sleep: func(time.Duration) {
+			t.Fatal("sleep should not run for same-second response")
+		},
+	}
+
+	outcome, err := transport.roundTrip("/session", projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitPop,
+		Node:    "worker",
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("roundTrip: %v", err)
+	}
+	if outcome.StaleResponseCount != 0 {
+		t.Fatalf("outcome.StaleResponseCount = %d, want 0", outcome.StaleResponseCount)
+	}
+	if outcome.Response.Filename != "same-second.md" {
+		t.Fatalf("outcome.Response.Filename = %q, want same-second.md", outcome.Response.Filename)
+	}
+}
+
+func TestDaemonSubmitRoundTripperReturnsMalformedResponseError(t *testing.T) {
+	sessionDir := t.TempDir()
+	createdAt := time.Date(2026, time.June, 1, 2, 0, 0, 0, time.UTC)
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return createdAt
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-malformed", nil
+		},
+		writeRequest: func(sessionDir string, request projection.DaemonSubmitRequest) (string, error) {
+			requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, request)
+			if err != nil {
+				return "", err
+			}
+			responsePath := projection.DaemonSubmitResponsePath(sessionDir, request.RequestID)
+			if err := os.WriteFile(responsePath, []byte("{"), 0o600); err != nil {
+				return "", err
+			}
+			return requestPath, nil
+		},
+		sleep: func(time.Duration) {
+			t.Fatal("sleep should not run when malformed response is present")
+		},
+	}
+
+	_, err := transport.roundTrip(sessionDir, projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitSend,
+	}, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "unexpected end") {
+		t.Fatalf("roundTrip error = %v, want malformed JSON error", err)
+	}
+}
+
+func TestDaemonSubmitRoundTripperReturnsCleanupFailureAfterResponse(t *testing.T) {
+	createdAt := time.Date(2026, time.June, 1, 3, 0, 0, 0, time.UTC)
+	cleanupErr := errors.New("remove response failed")
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return createdAt
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-cleanup", nil
+		},
+		writeRequest: func(string, projection.DaemonSubmitRequest) (string, error) {
+			return "/state/requests/req-cleanup.json", nil
+		},
+		readResponse: func(string) (projection.DaemonSubmitResponse, error) {
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-cleanup",
+				Command:   projection.DaemonSubmitPop,
+				HandledAt: createdAt.Format(time.RFC3339Nano),
+				Filename:  "cleanup.md",
+			}, nil
+		},
+		removeResponse: func(string) error {
+			return cleanupErr
+		},
+	}
+
+	outcome, err := transport.roundTrip("/session", projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitPop,
+		Node:    "worker",
+	}, time.Second)
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("roundTrip error = %v, want cleanup error", err)
+	}
+	if outcome.Response.Filename != "cleanup.md" {
+		t.Fatalf("outcome.Response.Filename = %q, want cleanup.md", outcome.Response.Filename)
+	}
+}
+
+func TestRoundTripDaemonSubmitWithTransportMapsDaemonErrorResponse(t *testing.T) {
+	transport := daemonSubmitRoundTripper{
+		now: func() time.Time {
+			return time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
+		},
+		newRequestID: func(time.Time) (string, error) {
+			return "req-error", nil
+		},
+		writeRequest: func(string, projection.DaemonSubmitRequest) (string, error) {
+			return "/state/requests/req-error.json", nil
+		},
+		readResponse: func(string) (projection.DaemonSubmitResponse, error) {
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-error",
+				Command:   projection.DaemonSubmitSend,
+				HandledAt: time.Date(2026, time.June, 1, 1, 0, 1, 0, time.UTC).Format(time.RFC3339Nano),
+				Error:     "daemon rejected send",
+			}, nil
+		},
+		removeResponse: func(string) error {
+			return nil
+		},
+	}
+
+	_, err := roundTripDaemonSubmitWithTransport("/session", projection.DaemonSubmitRequest{
+		Command: projection.DaemonSubmitSend,
+	}, time.Second, transport)
+	if err == nil || !strings.Contains(err.Error(), "daemon rejected send") {
+		t.Fatalf("roundTripDaemonSubmitWithTransport error = %v, want daemon response error", err)
+	}
+}
+
+func TestDaemonSubmitTransportDiagnosticsCountsPendingClaimedAndLate(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.June, 1, 1, 10, 0, 0, time.UTC)
+	if _, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-pending",
+		Command:   projection.DaemonSubmitPop,
+		CreatedAt: now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(pending): %v", err)
+	}
+	claimedPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID: "req-claimed",
+		Command:   projection.DaemonSubmitSend,
+		CreatedAt: now.Add(-3 * time.Minute).Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest(claimed): %v", err)
+	}
+	if err := os.Rename(claimedPath, claimedPath+".processing"); err != nil {
+		t.Fatalf("Rename claimed request: %v", err)
+	}
+	if _, err := projection.WriteDaemonSubmitResponse(sessionDir, projection.DaemonSubmitResponse{
+		RequestID: "req-late",
+		Command:   projection.DaemonSubmitPop,
+		HandledAt: now.Add(-4 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("WriteDaemonSubmitResponse(late): %v", err)
+	}
+	if _, err := projection.WriteDaemonSubmitResponse(sessionDir, projection.DaemonSubmitResponse{
+		RequestID: "req-diagnostics",
+		Command:   projection.DaemonSubmitRuntimeDiagnostics,
+		HandledAt: now.Add(-5 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("WriteDaemonSubmitResponse(diagnostics): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessionDir, "snapshot", string(projection.SubmitPathDaemon))); err != nil {
+		t.Fatalf("daemon-submit snapshot missing: %v", err)
+	}
+
+	diagnostics := scanDaemonSubmitRoundTripDiagnostics(sessionDir, now)
+	if diagnostics.PendingRequestCount != 1 || diagnostics.OldestPendingAgeSeconds != 120 {
+		t.Fatalf("pending diagnostics = %#v", diagnostics)
+	}
+	if diagnostics.ClaimedRequestCount != 1 || diagnostics.OldestClaimedAgeSeconds != 180 {
+		t.Fatalf("claimed diagnostics = %#v", diagnostics)
+	}
+	if diagnostics.LateResponseCount != 1 || diagnostics.OldestLateResponseAgeSeconds != 240 {
+		t.Fatalf("late diagnostics = %#v", diagnostics)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a daemon-submit transport seam for deterministic CLI request/response tests.
- Keeps request/response file formats unchanged while isolating timing, cleanup, and response handling behavior.
- Adds focused tests for timeout, late response, stale response, malformed response, daemon error mapping, and cleanup paths.

## Scope

This is a partial slice of #465 focused on the CLI daemon-submit transport. It does not change routing, reply policy, daemon lifecycle behavior, or request schema.

## Verification

- Not rerun during PR creation; branch was already remotely published.

Refs #465