### PR TITLE
feat(cli): add watch-status observation client (#488)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Inspect live session state:
 ```sh
 tmux-a2a-postman get-status
 tmux-a2a-postman get-status-oneline
+tmux-a2a-postman watch-status
 ```
 
 Use explicit subcommands. Running `tmux-a2a-postman` without a subcommand only

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -14,6 +14,7 @@ type Handlers struct {
 	Pop                     func(args []string) error
 	GetSessionStatus        func(args []string) error
 	GetSessionStatusOneline func(args []string) error
+	WatchStatus             func(args []string) error
 	InspectInput            func(args []string) error
 	InspectMessage          func(args []string) error
 	InspectDaemonSubmit     func(args []string) error
@@ -62,6 +63,11 @@ func Dispatch(command string, args []string, cfg Config, handlers Handlers) Resu
 		return Result{
 			Label: "postman get-status-oneline",
 			Err:   handlers.GetSessionStatusOneline(prependConfig(cfg.ConfigPath, prependContextID(cfg.ContextID, args))),
+		}
+	case "watch-status":
+		return Result{
+			Label: "postman watch-status",
+			Err:   handlers.WatchStatus(prependConfig(cfg.ConfigPath, prependContextID(cfg.ContextID, args))),
 		}
 	case "inspect-input":
 		return Result{

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -154,6 +154,33 @@ func TestDispatch_StatusCommandsArePublic(t *testing.T) {
 			t.Fatalf("get-status-oneline args = %#v, want %#v", gotArgs, wantArgs)
 		}
 	})
+
+	t.Run("watch-status", func(t *testing.T) {
+		var gotArgs []string
+
+		result := Dispatch(
+			"watch-status",
+			[]string{"--interval", "2s"},
+			Config{ContextID: "ctx-123", ConfigPath: "/tmp/postman.toml"},
+			Handlers{
+				WatchStatus: func(args []string) error {
+					gotArgs = append([]string(nil), args...)
+					return nil
+				},
+			},
+		)
+
+		if result.Err != nil {
+			t.Fatalf("Dispatch returned error: %v", result.Err)
+		}
+		if result.Label != "postman watch-status" {
+			t.Fatalf("label = %q, want %q", result.Label, "postman watch-status")
+		}
+		wantArgs := []string{"--config", "/tmp/postman.toml", "--context-id", "ctx-123", "--interval", "2s"}
+		if !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("watch-status args = %#v, want %#v", gotArgs, wantArgs)
+		}
+	})
 }
 
 func TestDispatch_InspectInputPrependsContextAndConfig(t *testing.T) {

--- a/internal/cli/doc_contract_test.go
+++ b/internal/cli/doc_contract_test.go
@@ -57,9 +57,11 @@ func TestReducedSurfaceDocContract_PopFileScopeAndCanonicalNames(t *testing.T) {
 	popHelp := readRepoFile(t, "internal/cli/helptext/pop.txt")
 	statusHelp := readRepoFile(t, "internal/cli/helptext/get-status.txt")
 	onelineHelp := readRepoFile(t, "internal/cli/helptext/get-status-oneline.txt")
+	watchHelp := readRepoFile(t, "internal/cli/helptext/watch-status.txt")
 	assertContainsNormalized(t, commandsHelp, "Use an explicit command. Bare `tmux-a2a-postman` prints usage; it does not start the daemon.")
 	assertContainsNormalized(t, commandsHelp, "get-status Print canonical session status JSON for agents and scripts.")
 	assertContainsNormalized(t, commandsHelp, "get-status-oneline Print compact all-session status for quick agent coordination.")
+	assertContainsNormalized(t, commandsHelp, "watch-status Watch live all-session status without starting a daemon or taking ownership.")
 	assertContainsNormalized(t, commandsHelp, "version Print the build version JSON.")
 	assertContainsNormalized(t, commandsHelp, "help [topic] Show help overview or detailed topic page.")
 	assertContainsNormalized(t, onelineHelp, "[0]🔷🟡:🟢 [1]⚫")
@@ -80,7 +82,10 @@ func TestReducedSurfaceDocContract_PopFileScopeAndCanonicalNames(t *testing.T) {
 	assertContainsNormalized(t, statusHelp, "daemon_submit includes worker_limit, active_worker_count, active_request_count, pending_request_count")
 	assertContainsNormalized(t, statusHelp, "late_response_count, oldest_late_response_age_seconds, saturation_count, and last_saturated_at")
 	assertContainsNormalized(t, statusHelp, "This is not a persisted time series.")
-	helpSurface := commandsHelp + "\n" + sendHelp + "\n" + popHelp + "\n" + statusHelp + "\n" + onelineHelp
+	assertContainsNormalized(t, watchHelp, "Repeatedly renders the existing all-session status contract without starting a daemon or taking daemon ownership.")
+	assertContainsNormalized(t, watchHelp, "jsonl One compact JSON all-session status snapshot per refresh.")
+	assertContainsNormalized(t, watchHelp, "It does not create daemon lock files, daemon PID files, enabled-session markers, mailbox messages, or PINGs.")
+	helpSurface := commandsHelp + "\n" + sendHelp + "\n" + popHelp + "\n" + statusHelp + "\n" + onelineHelp + "\n" + watchHelp
 	for _, hidden := range []string{
 		"`read`",
 		"`todo`",

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -19,6 +19,7 @@ var helpTopicFiles = map[string]string{
 	"get-status":            "helptext/get-status.txt",
 	"get-status-oneline":    "helptext/get-status-oneline.txt",
 	"help":                  "helptext/help.txt",
+	"watch-status":          "helptext/watch-status.txt",
 	"inspect-input":         "helptext/inspect-input.txt",
 	"inspect-daemon-submit": "helptext/inspect-daemon-submit.txt",
 	"inspect-message":       "helptext/inspect-message.txt",

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -37,6 +37,9 @@ func TestRunHelp_DefaultOverview(t *testing.T) {
 	if !strings.Contains(stdout.String(), "get-status-oneline         Print compact all-session status") {
 		t.Fatalf("stdout missing get-status-oneline overview line: %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "watch-status               Watch live all-session status") {
+		t.Fatalf("stdout missing watch-status overview line: %q", stdout.String())
+	}
 	if !strings.Contains(stdout.String(), "version                    Print the build version JSON") {
 		t.Fatalf("stdout missing version overview line: %q", stdout.String())
 	}
@@ -74,6 +77,9 @@ func TestRunHelp_CommandsShowsOperatorAndLifecycleSections(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "get-status-oneline") {
 		t.Fatalf("stdout missing get-status-oneline command: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "watch-status") {
+		t.Fatalf("stdout missing watch-status command: %q", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "version") {
 		t.Fatalf("stdout missing version command: %q", stdout.String())
@@ -115,6 +121,9 @@ func TestRunHelp_HelpTopicListsRegisteredTopics(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "\n  inspect-daemon-submit\n") {
 		t.Fatalf("stdout missing inspect-daemon-submit help topic: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "\n  watch-status\n") {
+		t.Fatalf("stdout missing watch-status help topic: %q", stdout.String())
 	}
 }
 

--- a/internal/cli/helptext/commands.txt
+++ b/internal/cli/helptext/commands.txt
@@ -37,6 +37,14 @@ get-status-oneline
   Shape: [0]🔷🟡:🟢 [1]🔴
   Window groups are colon-separated emoji runs with no literal window labels.
 
+watch-status
+  Watch live all-session status without starting a daemon or taking ownership.
+  Output: text snapshots by default, or JSON Lines with --format jsonl.
+  Usage:
+    tmux-a2a-postman watch-status
+    tmux-a2a-postman watch-status --interval 2s --severity
+    tmux-a2a-postman watch-status --format jsonl
+
 inspect-input
   Inspect open reply-required work by message_id or input_request_id.
   Output: JSON
@@ -77,4 +85,4 @@ stop
 
 help [topic]
   Show help overview or detailed topic page.
-  Topics: messaging, directories, config, commands, start, stop, send-heredoc, send, pop, get-status, get-status-oneline, inspect-input, inspect-daemon-submit, inspect-message, version, help
+  Topics: messaging, directories, config, commands, start, stop, send-heredoc, send, pop, get-status, get-status-oneline, watch-status, inspect-input, inspect-daemon-submit, inspect-message, version, help

--- a/internal/cli/helptext/help.txt
+++ b/internal/cli/helptext/help.txt
@@ -17,6 +17,7 @@ Topics:
   pop
   get-status
   get-status-oneline
+  watch-status
   inspect-input
   inspect-daemon-submit
   inspect-message

--- a/internal/cli/helptext/overview.txt
+++ b/internal/cli/helptext/overview.txt
@@ -28,6 +28,7 @@ Default operator surface:
   pop                        Claim and archive the oldest unread inbox message
   get-status                 Print canonical session status JSON
   get-status-oneline         Print compact all-session status
+  watch-status               Watch live all-session status
   inspect-input              Inspect open reply-required work by id
   inspect-daemon-submit      Inspect daemon-submit timeout state by id
   inspect-message            Inspect persisted message content by id
@@ -43,6 +44,7 @@ Messaging Protocol:
   pop                                        Claim and archive oldest message
   get-status                                Inspect agent-readable session status
   get-status-oneline                        Inspect compact all-session status
+  watch-status                              Watch live all-session status
   inspect-input --id <id>                   Inspect an open input request by id
   inspect-daemon-submit --id <request_id>   Inspect daemon-submit timeout state by id
   inspect-message --id <message_id>         Inspect persisted message content by id
@@ -60,6 +62,7 @@ Topics:
   pop                  tmux-a2a-postman help pop
   get-status           tmux-a2a-postman help get-status
   get-status-oneline   tmux-a2a-postman help get-status-oneline
+  watch-status         tmux-a2a-postman help watch-status
   inspect-input        tmux-a2a-postman help inspect-input
   inspect-daemon-submit tmux-a2a-postman help inspect-daemon-submit
   inspect-message      tmux-a2a-postman help inspect-message

--- a/internal/cli/helptext/watch-status.txt
+++ b/internal/cli/helptext/watch-status.txt
@@ -1,0 +1,35 @@
+watch-status — watch live all-session status
+
+Usage:
+  tmux-a2a-postman watch-status
+  tmux-a2a-postman watch-status --interval 2s
+  tmux-a2a-postman watch-status --format text
+  tmux-a2a-postman watch-status --format jsonl
+  tmux-a2a-postman watch-status --severity
+  tmux-a2a-postman watch-status --no-color
+  tmux-a2a-postman watch-status --no-clear
+  tmux-a2a-postman watch-status --help
+
+Output:
+  Repeatedly renders the existing all-session status contract without starting
+  a daemon or taking daemon ownership. The text view includes the daemon owner,
+  per-session compact token, worst severity, queue counts, delivery state,
+  oldest stuck post age when present, node counts, and short non-ok node
+  summaries.
+
+Formats:
+  text   Human-readable multi-line snapshots. TTY output clears between
+         refreshes unless --no-clear is set. Non-TTY output appends plain
+         snapshots and disables ANSI color and clearing automatically.
+  jsonl  One compact JSON all-session status snapshot per refresh.
+
+Flags:
+  --interval <duration>  Refresh interval (default: 2s)
+  --format text|jsonl    Output format (default: text)
+  --severity             Use compact severity tokens in text session lines
+  --no-color             Disable ANSI color
+  --no-clear             Append snapshots instead of clearing the terminal
+
+The command exits nonzero when no active daemon can be resolved. It does not
+create daemon lock files, daemon PID files, enabled-session markers, mailbox
+messages, or PINGs.

--- a/internal/cli/start_preflight.go
+++ b/internal/cli/start_preflight.go
@@ -60,7 +60,7 @@ func planStartPreflight(in startPreflightInput) startPreflightPlan {
 				OwnerSession:    ownerSession,
 			}},
 			Err: fmt.Errorf(
-				"a postman daemon is already running for this user in tmux session %q (context: %s); stop it first",
+				"a postman daemon is already running for this user in tmux session %q (context: %s); TUI and no-TUI daemon modes are exclusive; use `tmux-a2a-postman watch-status` to observe the running daemon or `tmux-a2a-postman stop` before switching modes",
 				ownerSession, ownerContext,
 			),
 		}
@@ -92,7 +92,7 @@ func planStartPreflight(in startPreflightInput) startPreflightPlan {
 				OwnerSession:    in.TmuxSessionName,
 			}},
 			Err: fmt.Errorf(
-				"a postman daemon is already running in tmux session %q (context: %s); stop it first",
+				"a postman daemon is already running in tmux session %q (context: %s); TUI and no-TUI daemon modes are exclusive; use `tmux-a2a-postman watch-status` to observe the running daemon or `tmux-a2a-postman stop` before switching modes",
 				in.TmuxSessionName, in.ContextID,
 			),
 		}

--- a/internal/cli/start_preflight_test.go
+++ b/internal/cli/start_preflight_test.go
@@ -28,6 +28,10 @@ func TestPlanStartPreflightRefusesCurrentUserDaemon(t *testing.T) {
 	if !strings.Contains(plan.Err.Error(), "already running for this user") {
 		t.Fatalf("plan.Err = %q, want current-user wording", plan.Err)
 	}
+	if !strings.Contains(plan.Err.Error(), "TUI and no-TUI daemon modes are exclusive") ||
+		!strings.Contains(plan.Err.Error(), "tmux-a2a-postman watch-status") {
+		t.Fatalf("plan.Err = %q, want exclusive-mode watch-status guidance", plan.Err)
+	}
 	if len(plan.Diagnostics) != 1 {
 		t.Fatalf("len(plan.Diagnostics) = %d, want 1", len(plan.Diagnostics))
 	}
@@ -68,6 +72,10 @@ func TestPlanStartPreflightRefusesCurrentUserSessionPID(t *testing.T) {
 	}
 	if !strings.Contains(plan.Err.Error(), `already running in tmux session "main"`) {
 		t.Fatalf("plan.Err = %q, want same-session wording", plan.Err)
+	}
+	if !strings.Contains(plan.Err.Error(), "TUI and no-TUI daemon modes are exclusive") ||
+		!strings.Contains(plan.Err.Error(), "tmux-a2a-postman watch-status") {
+		t.Fatalf("plan.Err = %q, want exclusive-mode watch-status guidance", plan.Err)
 	}
 	if len(plan.Diagnostics) != 1 {
 		t.Fatalf("len(plan.Diagnostics) = %d, want 1", len(plan.Diagnostics))

--- a/internal/cli/watch_status.go
+++ b/internal/cli/watch_status.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/cliutil"
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/status"
+)
+
+type watchStatusTarget struct {
+	contextID  string
+	baseDir    string
+	configPath string
+}
+
+type watchStatusRunOptions struct {
+	Interval      time.Duration
+	Format        string
+	Severity      bool
+	NoColor       bool
+	NoClear       bool
+	Collector     func() (status.AllSessionStatus, error)
+	Now           func() time.Time
+	IsTTY         func() bool
+	MaxIterations int
+}
+
+type watchStatusTextOptions struct {
+	Severity bool
+	Color    bool
+}
+
+// RunWatchStatus renders a live, read-only all-session status view.
+func RunWatchStatus(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("watch-status", flag.ContinueOnError)
+	cliutil.SetUsageWithoutContextID(fs)
+	contextID := fs.String("context-id", "", "Context ID (optional, auto-resolved from the active daemon)")
+	configPath := fs.String("config", "", "Config file path")
+	interval := fs.Duration("interval", 2*time.Second, "Refresh interval")
+	outputFormat := fs.String("format", "text", "Output format: text or jsonl")
+	severity := fs.Bool("severity", false, "Print compact contextual severity tokens in the text view")
+	noColor := fs.Bool("no-color", false, "Disable ANSI color")
+	noClear := fs.Bool("no-clear", false, "Append snapshots instead of clearing the terminal")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	target, err := resolveWatchStatusTarget(*contextID, *configPath)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return runWatchStatus(ctx, stdout, watchStatusRunOptions{
+		Interval: *interval,
+		Format:   *outputFormat,
+		Severity: *severity,
+		NoColor:  *noColor,
+		NoClear:  *noClear,
+		Collector: func() (status.AllSessionStatus, error) {
+			return target.collect()
+		},
+	})
+}
+
+func resolveWatchStatusTarget(contextIDFlag, configPath string) (watchStatusTarget, error) {
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		return watchStatusTarget{}, fmt.Errorf("loading config: %w", err)
+	}
+	baseDir := config.ResolveBaseDir(cfg.BaseDir)
+
+	if contextIDFlag != "" {
+		contextID, err := config.ResolveContextID(contextIDFlag)
+		if err != nil {
+			return watchStatusTarget{}, err
+		}
+		if ownerSession := config.FindContextSessionName(baseDir, contextID); ownerSession == "" {
+			return watchStatusTarget{}, fmt.Errorf("no active postman daemon found for context %q in %s", contextID, baseDir)
+		}
+		return watchStatusTarget{contextID: contextID, baseDir: baseDir, configPath: configPath}, nil
+	}
+
+	if contextID, _, ok := config.FindCurrentUserDaemon(baseDir); ok {
+		return watchStatusTarget{contextID: contextID, baseDir: baseDir, configPath: configPath}, nil
+	}
+
+	if sessionName := config.GetTmuxSessionName(); sessionName != "" {
+		contextID, err := config.ResolveContextIDFromSession(baseDir, sessionName)
+		if err == nil {
+			return watchStatusTarget{contextID: contextID, baseDir: baseDir, configPath: configPath}, nil
+		}
+	}
+
+	return watchStatusTarget{}, fmt.Errorf("no active postman daemon found in %s; start the daemon first", baseDir)
+}
+
+func (target watchStatusTarget) collect() (status.AllSessionStatus, error) {
+	if ownerSession := config.FindContextSessionName(target.baseDir, target.contextID); ownerSession == "" {
+		return status.AllSessionStatus{}, fmt.Errorf("no active postman daemon found for context %q in %s", target.contextID, target.baseDir)
+	}
+
+	snapshot, _, ok, err := collectAllSessionStatus(target.contextID, "", target.configPath)
+	if err != nil {
+		return status.AllSessionStatus{}, err
+	}
+	if !ok {
+		return status.AllSessionStatus{}, fmt.Errorf("no active postman daemon found for context %q in %s", target.contextID, target.baseDir)
+	}
+	if snapshot.DaemonOwner == nil {
+		return status.AllSessionStatus{}, fmt.Errorf("no active postman daemon found for context %q in %s", target.contextID, target.baseDir)
+	}
+	return snapshot, nil
+}
+
+func runWatchStatus(ctx context.Context, stdout io.Writer, opts watchStatusRunOptions) error {
+	if opts.Collector == nil {
+		return fmt.Errorf("watch-status collector is not configured")
+	}
+	if opts.Interval <= 0 {
+		return fmt.Errorf("--interval must be greater than zero")
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.IsTTY == nil {
+		opts.IsTTY = func() bool { return outputIsTTY(stdout) }
+	}
+	switch opts.Format {
+	case "text", "jsonl":
+	default:
+		return fmt.Errorf("--format must be text or jsonl")
+	}
+
+	isTTY := opts.IsTTY()
+	useClear := opts.Format == "text" && isTTY && !opts.NoClear
+	useColor := opts.Format == "text" && isTTY && !opts.NoColor
+
+	for iteration := 0; ; iteration++ {
+		snapshot, err := opts.Collector()
+		if err != nil {
+			return err
+		}
+		if opts.Format == "jsonl" {
+			if err := json.NewEncoder(stdout).Encode(snapshot); err != nil {
+				return err
+			}
+		} else {
+			if useClear {
+				if _, err := io.WriteString(stdout, "\033[H\033[2J"); err != nil {
+					return err
+				}
+			} else if iteration > 0 {
+				if _, err := io.WriteString(stdout, "\n"); err != nil {
+					return err
+				}
+			}
+			text := formatWatchStatusText(snapshot, opts.Now(), watchStatusTextOptions{
+				Severity: opts.Severity,
+				Color:    useColor,
+			})
+			if _, err := io.WriteString(stdout, text); err != nil {
+				return err
+			}
+		}
+
+		if opts.MaxIterations > 0 && iteration+1 >= opts.MaxIterations {
+			return nil
+		}
+
+		timer := time.NewTimer(opts.Interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+func outputIsTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func formatWatchStatusText(snapshot status.AllSessionStatus, now time.Time, opts watchStatusTextOptions) string {
+	var b strings.Builder
+	owner := "unknown"
+	if snapshot.DaemonOwner != nil {
+		owner = snapshot.DaemonOwner.ContextID + "/" + snapshot.DaemonOwner.SessionName
+	}
+	fmt.Fprintf(
+		&b,
+		"postman watch-status observed=%s context=%s daemon_owner=%s sessions=%d\n",
+		now.UTC().Format(time.RFC3339),
+		snapshot.ContextID,
+		owner,
+		len(snapshot.Sessions),
+	)
+
+	for idx, sessionStatus := range snapshot.Sessions {
+		token := sessionStatus.Compact
+		if opts.Severity && sessionStatus.CompactSeverity != "" {
+			token = sessionStatus.CompactSeverity
+		}
+		if token == "" {
+			token = "-"
+		}
+		severity := sessionStatus.Severity
+		if severity == "" {
+			severity = "ok"
+		}
+		token = colorizeWatchSeverity(token, severity, opts.Color)
+
+		fmt.Fprintf(
+			&b,
+			"[%d] %s token=%s state=%s severity=%s nodes=%d queues=post:%d inbox:%d dead_letter:%d",
+			idx,
+			sessionStatus.SessionName,
+			token,
+			emptyDash(sessionStatus.VisibleState),
+			severity,
+			sessionStatus.NodeCount,
+			sessionStatus.Queues.PostCount,
+			sessionStatus.Queues.InboxCount,
+			sessionStatus.Queues.DeadLetterCount,
+		)
+		if sessionStatus.Delivery != nil {
+			fmt.Fprintf(&b, " delivery=%s", emptyDash(sessionStatus.Delivery.State))
+			if sessionStatus.Delivery.OldestPostAgeSeconds > 0 {
+				fmt.Fprintf(&b, " oldest_post_age=%ds", sessionStatus.Delivery.OldestPostAgeSeconds)
+			}
+		}
+		b.WriteByte('\n')
+
+		nodeLines := watchStatusNodeLines(sessionStatus.Nodes)
+		if len(nodeLines) == 0 {
+			b.WriteString("  nodes ok\n")
+			continue
+		}
+		for _, line := range nodeLines {
+			fmt.Fprintf(&b, "  - %s\n", line)
+		}
+	}
+	return b.String()
+}
+
+func watchStatusNodeLines(nodes []status.NodeStatus) []string {
+	lines := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if !watchStatusShouldShowNode(node) {
+			continue
+		}
+		severity := node.Severity
+		if severity == "" {
+			severity = "ok"
+		}
+		blockedCount := 0
+		flowState := "-"
+		if node.Flow != nil {
+			flowState = emptyDash(node.Flow.State)
+			blockedCount = node.Flow.Blocked.OpenCount
+		}
+		localState := "-"
+		if node.NodeLocal != nil {
+			localState = emptyDash(node.NodeLocal.State)
+		}
+		screenState := "-"
+		if node.ScreenProgress != nil {
+			screenState = emptyDash(node.ScreenProgress.EvidenceState)
+		}
+		lines = append(lines, fmt.Sprintf(
+			"%s state=%s severity=%s inbox=%d input_required=%d waiting_on_input=%d blocked=%d flow=%s local=%s screen=%s",
+			node.Name,
+			emptyDash(node.VisibleState),
+			severity,
+			node.InboxCount,
+			node.InputRequiredCount,
+			node.WaitingOnInputCount,
+			blockedCount,
+			flowState,
+			localState,
+			screenState,
+		))
+	}
+	return lines
+}
+
+func watchStatusShouldShowNode(node status.NodeStatus) bool {
+	if node.InputRequiredCount > 0 || node.WaitingOnInputCount > 0 || node.InfoUnreadCount > 0 {
+		return true
+	}
+	if status.StateRank(node.VisibleState) > status.StateRank("ready") {
+		return true
+	}
+	if node.Severity != "" && status.SeverityRank(node.Severity) > status.SeverityRank("working") {
+		return true
+	}
+	if node.Flow != nil && (node.Flow.State != "" && node.Flow.State != "idle" || node.Flow.Blocked.OpenCount > 0) {
+		return true
+	}
+	if node.NodeLocal != nil && node.NodeLocal.State == "stale" {
+		return true
+	}
+	return node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "stale"
+}
+
+func colorizeWatchSeverity(text, severity string, color bool) string {
+	if !color {
+		return text
+	}
+	switch {
+	case status.SeverityRank(severity) >= status.SeverityRank("delivery_stuck"):
+		return "\033[31m" + text + "\033[0m"
+	case status.SeverityRank(severity) >= status.SeverityRank("needs_action"):
+		return "\033[33m" + text + "\033[0m"
+	case status.SeverityRank(severity) >= status.SeverityRank("working"):
+		return "\033[36m" + text + "\033[0m"
+	default:
+		return "\033[32m" + text + "\033[0m"
+	}
+}
+
+func emptyDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}

--- a/internal/cli/watch_status.go
+++ b/internal/cli/watch_status.go
@@ -64,14 +64,12 @@ func RunWatchStatus(stdout io.Writer, args []string) error {
 	defer stop()
 
 	return runWatchStatus(ctx, stdout, watchStatusRunOptions{
-		Interval: *interval,
-		Format:   *outputFormat,
-		Severity: *severity,
-		NoColor:  *noColor,
-		NoClear:  *noClear,
-		Collector: func() (status.AllSessionStatus, error) {
-			return target.collect()
-		},
+		Interval:  *interval,
+		Format:    *outputFormat,
+		Severity:  *severity,
+		NoColor:   *noColor,
+		NoClear:   *noClear,
+		Collector: target.collect,
 	})
 }
 

--- a/internal/cli/watch_status_test.go
+++ b/internal/cli/watch_status_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/status"
+)
+
+func TestRunWatchStatus_NoActiveDaemonReturnsClearErrorAndNoSideEffects(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("POSTMAN_HOME", tmpDir)
+
+	var stdout bytes.Buffer
+	err := RunWatchStatus(&stdout, []string{"--interval", "10ms"})
+	if err == nil {
+		t.Fatal("RunWatchStatus() error = nil, want no active daemon error")
+	}
+	if !strings.Contains(err.Error(), "no active postman daemon found") {
+		t.Fatalf("RunWatchStatus() error = %q, want no active daemon wording", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+
+	for _, path := range []string{
+		filepath.Join(tmpDir, "lock"),
+		filepath.Join(tmpDir, "postman.pid"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("unexpected side-effect path %s exists or stat failed: %v", path, statErr)
+		}
+	}
+}
+
+func TestRunWatchStatusTextAutoDisablesClearAndColorForNonTTY(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	snapshot := status.AllSessionStatus{
+		SchemaVersion: status.SchemaVersion,
+		ContextID:     "ctx-watch",
+		DaemonOwner: &status.DaemonOwner{
+			ContextID:   "ctx-watch",
+			SessionName: "daemon",
+		},
+		Sessions: []status.SessionStatus{
+			{
+				SessionName:     "main",
+				NodeCount:       2,
+				VisibleState:    "pending",
+				Severity:        "needs_action",
+				Compact:         "🔷🟢",
+				CompactSeverity: "needs_action:node=worker:input_required=1",
+				Queues: status.SessionQueues{
+					PostCount:       2,
+					InboxCount:      3,
+					DeadLetterCount: 1,
+				},
+				Delivery: &status.DeliveryStatus{
+					State:                "delivery_stuck",
+					Severity:             "delivery_stuck",
+					OldestPostAgeSeconds: 240,
+				},
+				Nodes: []status.NodeStatus{
+					{
+						Name:                "worker",
+						VisibleState:        "pending",
+						Severity:            "needs_action",
+						InboxCount:          2,
+						InputRequiredCount:  1,
+						WaitingOnInputCount: 0,
+						ScreenProgress:      &status.ScreenProgressEvidence{EvidenceState: "missing"},
+						NodeLocal:           &status.NodeLocalStatus{State: "unknown"},
+						Flow: &status.NodeFlowStatus{
+							State: "needs_action",
+							Blocked: status.BlockedState{
+								State:     "open",
+								OpenCount: 1,
+							},
+						},
+					},
+					{
+						Name:                "critic",
+						VisibleState:        "waiting",
+						Severity:            "expected_wait",
+						InboxCount:          0,
+						WaitingOnInputCount: 1,
+						ScreenProgress:      &status.ScreenProgressEvidence{EvidenceState: "unchanged"},
+						NodeLocal:           &status.NodeLocalStatus{State: "live"},
+						Flow:                &status.NodeFlowStatus{State: "waiting"},
+					},
+				},
+			},
+		},
+	}
+
+	var stdout bytes.Buffer
+	err := runWatchStatus(context.Background(), &stdout, watchStatusRunOptions{
+		Interval:      time.Hour,
+		Format:        "text",
+		Severity:      true,
+		Collector:     func() (status.AllSessionStatus, error) { return snapshot, nil },
+		Now:           func() time.Time { return fixedNow },
+		IsTTY:         func() bool { return false },
+		MaxIterations: 1,
+	})
+	if err != nil {
+		t.Fatalf("runWatchStatus: %v", err)
+	}
+
+	got := stdout.String()
+	if strings.Contains(got, "\x1b[") {
+		t.Fatalf("text output contains ANSI sequence for non-TTY: %q", got)
+	}
+	for _, want := range []string{
+		"postman watch-status observed=2026-06-01T12:00:00Z context=ctx-watch daemon_owner=ctx-watch/daemon sessions=1",
+		"[0] main token=needs_action:node=worker:input_required=1 state=pending severity=needs_action nodes=2 queues=post:2 inbox:3 dead_letter:1 delivery=delivery_stuck oldest_post_age=240s",
+		"worker state=pending severity=needs_action inbox=2 input_required=1 waiting_on_input=0 blocked=1 flow=needs_action local=unknown screen=missing",
+		"critic state=waiting severity=expected_wait inbox=0 input_required=0 waiting_on_input=1 blocked=0 flow=waiting local=live screen=unchanged",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("watch text missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunWatchStatusJSONLWritesOneStatusSnapshotPerRefresh(t *testing.T) {
+	snapshot := status.AllSessionStatus{
+		SchemaVersion: status.SchemaVersion,
+		ContextID:     "ctx-jsonl",
+		DaemonOwner:   &status.DaemonOwner{ContextID: "ctx-jsonl", SessionName: "daemon"},
+		Sessions: []status.SessionStatus{{
+			SessionName:  "main",
+			VisibleState: "ready",
+			Compact:      "🟢",
+			Nodes:        []status.NodeStatus{},
+			Windows:      []status.SessionWindow{},
+		}},
+	}
+
+	var stdout bytes.Buffer
+	err := runWatchStatus(context.Background(), &stdout, watchStatusRunOptions{
+		Interval:      time.Hour,
+		Format:        "jsonl",
+		Collector:     func() (status.AllSessionStatus, error) { return snapshot, nil },
+		IsTTY:         func() bool { return true },
+		MaxIterations: 1,
+	})
+	if err != nil {
+		t.Fatalf("runWatchStatus(jsonl): %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("jsonl line count = %d, want 1; output=%q", len(lines), stdout.String())
+	}
+	if strings.Contains(lines[0], "\x1b[") {
+		t.Fatalf("jsonl contains ANSI sequence: %q", lines[0])
+	}
+	var got status.AllSessionStatus
+	if err := json.Unmarshal([]byte(lines[0]), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", lines[0], err)
+	}
+	if got.ContextID != "ctx-jsonl" || len(got.Sessions) != 1 || got.Sessions[0].SessionName != "main" {
+		t.Fatalf("decoded jsonl snapshot = %#v", got)
+	}
+}
+
+func TestRunWatchStatusRejectsInvalidFormatAndInterval(t *testing.T) {
+	collector := func() (status.AllSessionStatus, error) {
+		return status.AllSessionStatus{}, nil
+	}
+
+	var stdout bytes.Buffer
+	if err := runWatchStatus(context.Background(), &stdout, watchStatusRunOptions{
+		Interval:  time.Second,
+		Format:    "yaml",
+		Collector: collector,
+	}); err == nil || !strings.Contains(err.Error(), "--format must be text or jsonl") {
+		t.Fatalf("invalid format error = %v, want format validation", err)
+	}
+
+	if err := runWatchStatus(context.Background(), &stdout, watchStatusRunOptions{
+		Interval:  0,
+		Format:    "text",
+		Collector: collector,
+	}); err == nil || !strings.Contains(err.Error(), "--interval must be greater than zero") {
+		t.Fatalf("invalid interval error = %v, want interval validation", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 			Pop:                     cli.RunPop,
 			GetSessionStatus:        cli.RunGetSessionStatus,
 			GetSessionStatusOneline: func(args []string) error { return cli.RunGetSessionStatusOneline(os.Stdout, args) },
+			WatchStatus:             func(args []string) error { return cli.RunWatchStatus(os.Stdout, args) },
 			InspectInput:            cli.RunInspectInput,
 			InspectMessage:          cli.RunInspectMessage,
 			InspectDaemonSubmit:     cli.RunInspectDaemonSubmit,

--- a/main_test.go
+++ b/main_test.go
@@ -125,6 +125,9 @@ func TestPrintUsage_ShowsReducedPublicSurface(t *testing.T) {
 	if !strings.Contains(got, "get-status-oneline         Print compact all-session status") {
 		t.Fatalf("usage missing get-status-oneline command: %q", got)
 	}
+	if !strings.Contains(got, "watch-status               Watch live all-session status") {
+		t.Fatalf("usage missing watch-status command: %q", got)
+	}
 	if !strings.Contains(got, "version                    Print the build version JSON") {
 		t.Fatalf("usage missing version command: %q", got)
 	}


### PR DESCRIPTION
## Summary
- Add a read-only watch-status observation client for no-TUI and systemd operation.
- Reuse existing status collection and formatting paths.
- Improve daemon-mode conflict text for TUI and no-TUI ownership.

## Verification
- go test ./internal/cli
- go test ./...
- nix flake check
- nix build
- nix run .#skill-check
- git diff --cached --check

Fixes #488