### PR TITLE
feat(daemon): add headless auto-ping reconciliation (#487)

### DIFF
--- a/docs/ping-events.md
+++ b/docs/ping-events.md
@@ -15,20 +15,27 @@ sends the normal pane notification when inbox delivery succeeds.
 
 - Trigger: daemon bootstrap sees already discovered nodes.
 - Timing: queued at startup, due after `auto_ping_delay_seconds` (default
-  `20`), then delivered on the next full scan.
+  `20`), then delivered on the next full scan. `start --no-tui` caps this
+  delay to `1s` unless `auto_ping_delay_seconds = 0` makes it immediate, so a
+  headless daemon normally wakes discovered nodes on the first full scan after
+  readiness.
 - Source: daemon startup.
 - Recipients: all discovered nodes unless `ui_node` is explicitly set.
   Explicit `ui_node` limits startup auto-PING to matching roles discovered in
   enabled sessions.
 - Notes: journal reason is `startup`. The embedded default
-  `ui_node = "messenger"` does not narrow by itself.
+  `ui_node = "messenger"` does not narrow by itself. Rapid restart suppresses
+  duplicate startup PINGs for the same context/session/node/pane for a short
+  cooldown after a successful delivery; a new context, new pane ID, or pane
+  restart can still queue a fresh PING.
 
 ### 1.2. New Node Auto-PING
 
 - Trigger: a daemon scan, post wake-up, or session activation discovers a node
   that was not in the known-node set.
 - Timing: queued when discovered, due after `auto_ping_delay_seconds`, then
-  delivered on the next full scan.
+  delivered on the next full scan. Under `start --no-tui`, the same `1s`
+  headless cap applies to newly discovered nodes.
 - Source: daemon discovery.
 - Recipients: the newly discovered node.
 - Notes: journal reason is `discovered`. A node that disappeared and later
@@ -72,6 +79,15 @@ normally delivered on the next full scan. If delivery is retryable, for example
 because the target inbox queue is full, the pending auto-PING remains in the
 journal and the daemon tries again on later scans. One in-flight auto-PING per
 node is allowed at a time.
+
+The auto-PING journal records distinguishable states for operator diagnosis:
+`auto_ping_pending`, `auto_ping_delivered`, `auto_ping_suppressed`,
+`auto_ping_blocked`, and `auto_ping_retrying`. Daemon logs include matching
+`auto-PING pending`, `auto-PING delivered`, `auto-PING suppressed`,
+`auto-PING blocked`, and `auto-PING retrying` lines. `tmux-a2a-postman
+get-status --debug` includes point-in-time `runtime_diagnostics.auto_ping`
+counts for pending, delivered, cooldown-suppressed, ownership-blocked, and
+retrying-full-inbox nodes.
 
 ## 2. Contact Hints
 
@@ -144,3 +160,9 @@ Repeated PING mail that has no startup, discovery, pane restart, operator
 keypress, compaction marker, or retryable-delivery explanation is unexpected
 and should be investigated with `tmux-a2a-postman get-status` and the archived
 message IDs.
+
+If a no-TUI daemon appears ready but a node has no PING, first check
+`tmux-a2a-postman get-status --debug` and `postman.log`. A due PING may still
+be pending until the next full scan, suppressed by the recent-delivery
+cooldown, blocked because another daemon owns the session, or retrying because
+the recipient inbox is full.

--- a/internal/cli/helptext/start.txt
+++ b/internal/cli/helptext/start.txt
@@ -2,8 +2,21 @@ start — start the daemon
 
 Usage:
   tmux-a2a-postman start
+  tmux-a2a-postman start --no-tui
   tmux-a2a-postman start --help
 
 Output:
   Starts the daemon with the default TUI surface and writes operational logs
   to postman.log.
+
+No-TUI operation:
+  `start --no-tui` runs the same daemon loop without the TUI. Startup and
+  newly discovered auto-PINGs use a short headless delay cap so discovered
+  nodes can wake without pressing `p`; `auto_ping_delay_seconds = 0` still
+  makes them immediate.
+
+Diagnostics:
+  If daemon PING mail is absent, delayed, or stale, inspect `postman.log` and
+  `tmux-a2a-postman get-status --debug`. Auto-PING evidence distinguishes
+  pending, delivered, cooldown-suppressed, ownership-blocked, and retrying
+  full-inbox cases.

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -127,6 +127,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string, noTUI bool) er
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	if noTUI {
+		daemon.ApplyHeadlessAutoPingDelay(cfg)
+	}
 
 	// Parse edge definitions for routing
 	adjacency, err := config.ParseEdges(cfg.Edges)

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -78,6 +78,22 @@ type daemonRuntime struct {
 
 const daemonSubmitWorkerLimit = 4
 
+const HeadlessAutoPingDelaySeconds = 1.0
+
+const autoPingDuplicateCooldown = 30 * time.Second
+
+func ApplyHeadlessAutoPingDelay(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	if cfg.AutoPingDelaySeconds == 0 {
+		return
+	}
+	if cfg.AutoPingDelaySeconds < 0 || cfg.AutoPingDelaySeconds > HeadlessAutoPingDelaySeconds {
+		cfg.AutoPingDelaySeconds = HeadlessAutoPingDelaySeconds
+	}
+}
+
 type daemonSubmitProcessor func(requestPath string) (daemonSubmitProcessResult, error)
 
 type daemonSubmitRuntimeResult struct {
@@ -418,6 +434,8 @@ func (rt *daemonRuntime) processRuntimeDiagnosticsSubmitRequest(requestPath stri
 
 func (rt *daemonRuntime) runtimeDiagnostics(now time.Time) *status.RuntimeDiagnostics {
 	diag := status.NewRuntimeDiagnostics("daemon_runtime", rt.runtimeCardinality(), rt.daemonSubmitRuntimeDiagnostics(now), now)
+	autoPing := rt.autoPingRuntimeDiagnostics(now)
+	diag.AutoPing = &autoPing
 	return &diag
 }
 
@@ -483,6 +501,34 @@ func (rt *daemonRuntime) daemonSubmitRuntimeDiagnostics(now time.Time) status.Da
 	for _, sessionDir := range runtimeSessionDirs(rt.sessionDir, rt.nodes) {
 		scanDaemonSubmitRequests(sessionDir, now, &diagnostics)
 		scanDaemonSubmitResponses(sessionDir, now, &diagnostics)
+	}
+	return diagnostics
+}
+
+func (rt *daemonRuntime) autoPingRuntimeDiagnostics(now time.Time) status.AutoPingRuntimeDiagnostics {
+	diagnostics := status.AutoPingRuntimeDiagnostics{}
+	for _, sessionDir := range runtimeSessionDirs(rt.sessionDir, rt.nodes) {
+		state, ok, err := projection.ProjectAutoPingState(sessionDir)
+		if err != nil || !ok {
+			continue
+		}
+		for _, node := range state.Nodes {
+			switch node.Status {
+			case projection.AutoPingStatusDelivered:
+				diagnostics.DeliveredCount++
+			case projection.AutoPingStatusSuppressed:
+				diagnostics.SuppressedCount++
+			case projection.AutoPingStatusOwnershipBlocked:
+				diagnostics.OwnershipBlockedCount++
+			case projection.AutoPingStatusRetryingFullInbox:
+				diagnostics.RetryingFullInboxCount++
+				diagnostics.OldestRetryAgeSeconds = oldestDaemonSubmitAgeSeconds(diagnostics.OldestRetryAgeSeconds, node.RetryAt, now)
+			}
+			if node.Pending {
+				diagnostics.PendingCount++
+				diagnostics.OldestPendingAgeSeconds = oldestDaemonSubmitAgeSeconds(diagnostics.OldestPendingAgeSeconds, node.TriggeredAt, now)
+			}
+		}
 	}
 	return diagnostics
 }
@@ -1390,7 +1436,7 @@ func (rt *daemonRuntime) recordPendingAutoPing(nodeKey string, nodeInfo discover
 
 	triggeredAt := now
 	notBeforeAt := now.Add(time.Duration(delaySeconds * float64(time.Second)))
-	if state, ok, err := projection.ProjectAutoPingState(nodeInfo.SessionDir); err != nil {
+	if state, ok, err := projection.ProjectAutoPingHistory(nodeInfo.SessionDir); err != nil {
 		log.Printf("postman: WARNING: auto-PING replay failed for %s: %v\n", nodeKey, err)
 	} else if ok {
 		if existing, exists := state.Nodes[nodeKey]; exists && existing.Pending {
@@ -1406,6 +1452,11 @@ func (rt *daemonRuntime) recordPendingAutoPing(nodeKey string, nodeInfo discover
 			if reason == "" {
 				reason = existing.Reason
 			}
+		} else if exists {
+			if suppressUntil, suppressed := rt.autoPingSuppressionUntil(nodeKey, nodeInfo, existing, reason, now); suppressed {
+				rt.recordSuppressedAutoPing(nodeKey, nodeInfo, existing, reason, now, suppressUntil)
+				return
+			}
 		}
 	}
 	if reason == "" {
@@ -1414,6 +1465,7 @@ func (rt *daemonRuntime) recordPendingAutoPing(nodeKey string, nodeInfo discover
 
 	payload := projection.AutoPingEventPayload{
 		NodeKey:      nodeKey,
+		ContextID:    rt.contextID,
 		SessionName:  nodeInfo.SessionName,
 		NodeName:     ping.ExtractSimpleName(nodeKey),
 		PaneID:       nodeInfo.PaneID,
@@ -1424,12 +1476,65 @@ func (rt *daemonRuntime) recordPendingAutoPing(nodeKey string, nodeInfo discover
 	}
 	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingPendingEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
 		log.Printf("postman: WARNING: auto-PING pending append failed for %s: %v\n", nodeKey, err)
+		return
 	}
+	log.Printf("postman: auto-PING pending node=%s pane=%s reason=%s not_before=%s\n", nodeKey, nodeInfo.PaneID, reason, payload.NotBeforeAt)
+}
+
+func (rt *daemonRuntime) autoPingSuppressionUntil(nodeKey string, nodeInfo discovery.NodeInfo, existing projection.AutoPingNodeState, reason string, now time.Time) (time.Time, bool) {
+	if reason == "pane_restart" {
+		return time.Time{}, false
+	}
+	if rt.contextID == "" || existing.ContextID != rt.contextID {
+		return time.Time{}, false
+	}
+	if nodeInfo.PaneID == "" || existing.PaneID != nodeInfo.PaneID {
+		return time.Time{}, false
+	}
+	if existing.DeliveredAt == "" {
+		return time.Time{}, false
+	}
+	deliveredAt, err := time.Parse(time.RFC3339Nano, existing.DeliveredAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	suppressUntil := deliveredAt.Add(autoPingDuplicateCooldown)
+	if !now.Before(suppressUntil) {
+		return time.Time{}, false
+	}
+	return suppressUntil, true
+}
+
+func (rt *daemonRuntime) recordSuppressedAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, existing projection.AutoPingNodeState, reason string, now, suppressUntil time.Time) {
+	if reason == "" {
+		reason = "startup"
+	}
+	payload := projection.AutoPingEventPayload{
+		NodeKey:           nodeKey,
+		ContextID:         rt.contextID,
+		SessionName:       nodeInfo.SessionName,
+		NodeName:          ping.ExtractSimpleName(nodeKey),
+		PaneID:            nodeInfo.PaneID,
+		Reason:            reason,
+		TriggeredAt:       now.Format(time.RFC3339Nano),
+		DelaySeconds:      existing.DelaySeconds,
+		NotBeforeAt:       existing.NotBeforeAt,
+		DeliveredAt:       existing.DeliveredAt,
+		SuppressedAt:      now.Format(time.RFC3339Nano),
+		SuppressUntilAt:   suppressUntil.Format(time.RFC3339Nano),
+		SuppressionReason: "recent_delivered_cooldown",
+	}
+	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingSuppressedEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
+		log.Printf("postman: WARNING: auto-PING suppressed append failed for %s: %v\n", nodeKey, err)
+		return
+	}
+	log.Printf("postman: auto-PING suppressed node=%s pane=%s reason=%s suppression=recent_delivered_cooldown until=%s\n", nodeKey, nodeInfo.PaneID, reason, payload.SuppressUntilAt)
 }
 
 func (rt *daemonRuntime) recordDeliveredAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, now time.Time) {
 	payload := projection.AutoPingEventPayload{
 		NodeKey:      nodeKey,
+		ContextID:    rt.contextID,
 		SessionName:  nodeInfo.SessionName,
 		NodeName:     ping.ExtractSimpleName(nodeKey),
 		PaneID:       nodeInfo.PaneID,
@@ -1444,6 +1549,49 @@ func (rt *daemonRuntime) recordDeliveredAutoPing(nodeKey string, nodeInfo discov
 	}
 	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
 		log.Printf("postman: WARNING: auto-PING delivered append failed for %s: %v\n", nodeKey, err)
+		return
+	}
+	log.Printf("postman: auto-PING delivered node=%s pane=%s reason=%s delivered_at=%s\n", nodeKey, nodeInfo.PaneID, payload.Reason, payload.DeliveredAt)
+}
+
+func (rt *daemonRuntime) recordBlockedAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, now time.Time, blockedReason string) {
+	payload := autoPingPayloadFromPending(rt.contextID, nodeKey, nodeInfo, pending)
+	payload.BlockedAt = now.Format(time.RFC3339Nano)
+	payload.BlockedReason = blockedReason
+	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingBlockedEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
+		log.Printf("postman: WARNING: auto-PING blocked append failed for %s: %v\n", nodeKey, err)
+		return
+	}
+	log.Printf("postman: auto-PING blocked node=%s pane=%s reason=%s blocked_reason=%s\n", nodeKey, nodeInfo.PaneID, payload.Reason, blockedReason)
+}
+
+func (rt *daemonRuntime) recordRetryingAutoPing(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, now time.Time, retryReason string) {
+	payload := autoPingPayloadFromPending(rt.contextID, nodeKey, nodeInfo, pending)
+	payload.RetryAt = now.Format(time.RFC3339Nano)
+	payload.RetryReason = retryReason
+	if err := journal.RecordProcessEvent(nodeInfo.SessionDir, nodeInfo.SessionName, projection.AutoPingRetryingEventType, journal.VisibilityOperatorVisible, payload, now); err != nil {
+		log.Printf("postman: WARNING: auto-PING retry append failed for %s: %v\n", nodeKey, err)
+		return
+	}
+	log.Printf("postman: auto-PING retrying node=%s pane=%s reason=%s retry_reason=%s\n", nodeKey, nodeInfo.PaneID, payload.Reason, retryReason)
+}
+
+func autoPingPayloadFromPending(contextID, nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState) projection.AutoPingEventPayload {
+	reason := pending.Reason
+	if reason == "" {
+		reason = "discovered"
+	}
+	return projection.AutoPingEventPayload{
+		NodeKey:      nodeKey,
+		ContextID:    contextID,
+		SessionName:  nodeInfo.SessionName,
+		NodeName:     ping.ExtractSimpleName(nodeKey),
+		PaneID:       nodeInfo.PaneID,
+		Reason:       reason,
+		TriggeredAt:  pending.TriggeredAt,
+		DelaySeconds: pending.DelaySeconds,
+		NotBeforeAt:  pending.NotBeforeAt,
+		DeliveredAt:  pending.DeliveredAt,
 	}
 }
 
@@ -1493,6 +1641,9 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 			}
 		}
 		if owner := config.FindSessionOwner(rt.baseDir, nodeInfo.SessionName, rt.contextID); owner != "" {
+			if pending.Status != projection.AutoPingStatusOwnershipBlocked {
+				rt.recordBlockedAutoPing(nodeKey, nodeInfo, pending, now, "foreign_session_owner")
+			}
 			continue
 		}
 
@@ -1530,6 +1681,9 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 				return
 			}
 			if !result.Delivered {
+				if dispatchPending.Status != projection.AutoPingStatusRetryingFullInbox {
+					rt.recordRetryingAutoPing(dispatchNodeKey, dispatchNodeInfo, dispatchPending, rt.now(), "full_inbox")
+				}
 				return
 			}
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -77,6 +77,27 @@ func waitForAutoPingPending(t *testing.T, sessionDir, nodeKey string, want bool)
 	}
 }
 
+func waitForAutoPingStatus(t *testing.T, sessionDir, nodeKey, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		state, ok, err := projection.ProjectAutoPingState(sessionDir)
+		if err != nil {
+			t.Fatalf("ProjectAutoPingState() error = %v", err)
+		}
+		if ok {
+			if node, exists := state.Nodes[nodeKey]; exists && node.Status == want {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			state, _, _ := projection.ProjectAutoPingState(sessionDir)
+			t.Fatalf("auto-PING status[%s] did not become %q; state=%#v", nodeKey, want, state.Nodes[nodeKey])
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestDispatchRuntimeDiagnosticsSubmitRequestWritesBoundedCounts(t *testing.T) {
 	sessionDir := filepath.Join(t.TempDir(), "review")
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
@@ -1673,6 +1694,9 @@ func TestDispatchPendingAutoPings_ForeignOwnedSessionStaysPendingAndDisabled(t *
 	if !state.Nodes["foreign:worker"].Pending {
 		t.Fatal("pending auto-PING was cleared even though the session is foreign-owned")
 	}
+	if state.Nodes["foreign:worker"].Status != projection.AutoPingStatusOwnershipBlocked {
+		t.Fatalf("auto-PING status = %q, want %q", state.Nodes["foreign:worker"].Status, projection.AutoPingStatusOwnershipBlocked)
+	}
 }
 
 func TestDispatchPendingAutoPings_DeliversDuePendingPingAndClearsDebt(t *testing.T) {
@@ -2085,6 +2109,7 @@ func TestDispatchPendingAutoPings_QueueFullLeavesPendingWithoutDeadLetter(t *tes
 	if !state.Nodes["review:worker"].Pending {
 		t.Fatal("pending auto-PING debt was cleared even though delivery was blocked by a full inbox")
 	}
+	waitForAutoPingStatus(t, sessionDir, "review:worker", projection.AutoPingStatusRetryingFullInbox)
 }
 
 func TestDispatchPendingAutoPings_RespectsNotBeforeAt(t *testing.T) {
@@ -2194,6 +2219,81 @@ func TestRecordPendingAutoPing_UsesConfiguredAutoPingDelay(t *testing.T) {
 	}
 }
 
+func TestApplyHeadlessAutoPingDelayCapsConfiguredDelay(t *testing.T) {
+	cfg := &config.Config{AutoPingDelaySeconds: 20}
+
+	ApplyHeadlessAutoPingDelay(cfg)
+
+	if cfg.AutoPingDelaySeconds != HeadlessAutoPingDelaySeconds {
+		t.Fatalf("AutoPingDelaySeconds = %v, want %v", cfg.AutoPingDelaySeconds, HeadlessAutoPingDelaySeconds)
+	}
+}
+
+func TestApplyHeadlessAutoPingDelayPreservesImmediateDelay(t *testing.T) {
+	cfg := &config.Config{AutoPingDelaySeconds: 0}
+
+	ApplyHeadlessAutoPingDelay(cfg)
+
+	if cfg.AutoPingDelaySeconds != 0 {
+		t.Fatalf("AutoPingDelaySeconds = %v, want 0", cfg.AutoPingDelaySeconds)
+	}
+}
+
+func TestAutoPingRuntimeDiagnosticsCountsProjectedStates(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.May, 4, 14, 25, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	events := []projection.AutoPingEventPayload{
+		{NodeKey: "review:pending", ContextID: "ctx-self", SessionName: "review", NodeName: "pending", PaneID: "%1", Reason: "startup", TriggeredAt: now.Add(-10 * time.Second).Format(time.RFC3339Nano), NotBeforeAt: now.Add(-9 * time.Second).Format(time.RFC3339Nano)},
+		{NodeKey: "review:delivered", ContextID: "ctx-self", SessionName: "review", NodeName: "delivered", PaneID: "%2", Reason: "startup", TriggeredAt: now.Add(-8 * time.Second).Format(time.RFC3339Nano), DeliveredAt: now.Add(-7 * time.Second).Format(time.RFC3339Nano)},
+		{NodeKey: "review:suppressed", ContextID: "ctx-self", SessionName: "review", NodeName: "suppressed", PaneID: "%3", Reason: "startup", DeliveredAt: now.Add(-6 * time.Second).Format(time.RFC3339Nano), SuppressedAt: now.Add(-5 * time.Second).Format(time.RFC3339Nano), SuppressionReason: "recent_delivered_cooldown"},
+		{NodeKey: "review:blocked", ContextID: "ctx-self", SessionName: "review", NodeName: "blocked", PaneID: "%4", Reason: "discovered", TriggeredAt: now.Add(-4 * time.Second).Format(time.RFC3339Nano), BlockedAt: now.Add(-3 * time.Second).Format(time.RFC3339Nano), BlockedReason: "foreign_session_owner"},
+		{NodeKey: "review:retry", ContextID: "ctx-self", SessionName: "review", NodeName: "retry", PaneID: "%5", Reason: "discovered", TriggeredAt: now.Add(-4 * time.Second).Format(time.RFC3339Nano), RetryAt: now.Add(-2 * time.Second).Format(time.RFC3339Nano), RetryReason: "full_inbox"},
+	}
+	eventTypes := []string{
+		projection.AutoPingPendingEventType,
+		projection.AutoPingDeliveredEventType,
+		projection.AutoPingSuppressedEventType,
+		projection.AutoPingBlockedEventType,
+		projection.AutoPingRetryingEventType,
+	}
+	for i, payload := range events {
+		if err := journal.RecordProcessEvent(sessionDir, "review", eventTypes[i], journal.VisibilityOperatorVisible, payload, now.Add(time.Duration(i)*time.Millisecond)); err != nil {
+			t.Fatalf("RecordProcessEvent(%s): %v", eventTypes[i], err)
+		}
+	}
+
+	rt := &daemonRuntime{
+		sessionDir: sessionDir,
+		nodes: map[string]discovery.NodeInfo{
+			"review:pending":    {SessionName: "review", SessionDir: sessionDir},
+			"review:delivered":  {SessionName: "review", SessionDir: sessionDir},
+			"review:suppressed": {SessionName: "review", SessionDir: sessionDir},
+			"review:blocked":    {SessionName: "review", SessionDir: sessionDir},
+			"review:retry":      {SessionName: "review", SessionDir: sessionDir},
+		},
+	}
+
+	got := rt.autoPingRuntimeDiagnostics(now)
+
+	if got.PendingCount != 3 ||
+		got.DeliveredCount != 1 ||
+		got.SuppressedCount != 1 ||
+		got.OwnershipBlockedCount != 1 ||
+		got.RetryingFullInboxCount != 1 {
+		t.Fatalf("auto-PING diagnostics = %#v", got)
+	}
+	if got.OldestPendingAgeSeconds <= 0 || got.OldestRetryAgeSeconds <= 0 {
+		t.Fatalf("auto-PING age diagnostics = %#v", got)
+	}
+}
+
 func TestRecordPendingAutoPing_UsesDefaultAutoPingDelay(t *testing.T) {
 	baseDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(baseDir, "xdg-config"))
@@ -2239,6 +2339,113 @@ func TestRecordPendingAutoPing_UsesDefaultAutoPingDelay(t *testing.T) {
 	}
 	if got, want := pending.NotBeforeAt, now.Add(20*time.Second).Format(time.RFC3339Nano); got != want {
 		t.Fatalf("NotBeforeAt: got %q, want %q", got, want)
+	}
+}
+
+func TestRecordPendingAutoPing_SuppressesRecentDeliveredForSameContextPane(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.May, 4, 14, 30, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		ContextID:    "ctx-self",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%88",
+		Reason:       "startup",
+		TriggeredAt:  now.Add(-5 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 1,
+		NotBeforeAt:  now.Add(-4 * time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(-3 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-3*time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(delivered): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg:       &config.Config{AutoPingDelaySeconds: 1},
+	}
+	rt.recordPendingAutoPing("review:worker", discovery.NodeInfo{
+		PaneID:      "%88",
+		SessionName: "review",
+		SessionDir:  sessionDir,
+	}, "startup", now)
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	got := state.Nodes["review:worker"]
+	if got.Pending {
+		t.Fatal("suppressed auto-PING is still pending")
+	}
+	if got.Status != projection.AutoPingStatusSuppressed {
+		t.Fatalf("Status = %q, want %q", got.Status, projection.AutoPingStatusSuppressed)
+	}
+	if got.SuppressionReason != "recent_delivered_cooldown" {
+		t.Fatalf("SuppressionReason = %q", got.SuppressionReason)
+	}
+}
+
+func TestRecordPendingAutoPing_AllowsNewPaneAfterRecentDelivered(t *testing.T) {
+	baseDir := t.TempDir()
+	sessionDir := filepath.Join(baseDir, "ctx-self", "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs(): %v", err)
+	}
+
+	now := time.Date(2026, time.May, 4, 14, 35, 0, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-self", "review", now)
+	t.Cleanup(journal.ClearProcessManager)
+	if err := journal.RecordProcessEvent(sessionDir, "review", projection.AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, projection.AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		ContextID:    "ctx-self",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%88",
+		Reason:       "startup",
+		TriggeredAt:  now.Add(-5 * time.Second).Format(time.RFC3339Nano),
+		DelaySeconds: 1,
+		NotBeforeAt:  now.Add(-4 * time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(-3 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(-3*time.Second)); err != nil {
+		t.Fatalf("RecordProcessEvent(delivered): %v", err)
+	}
+
+	rt := &daemonRuntime{
+		baseDir:   baseDir,
+		contextID: "ctx-self",
+		cfg:       &config.Config{AutoPingDelaySeconds: 1},
+	}
+	rt.recordPendingAutoPing("review:worker", discovery.NodeInfo{
+		PaneID:      "%89",
+		SessionName: "review",
+		SessionDir:  sessionDir,
+	}, "startup", now)
+
+	state, ok, err := projection.ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	got := state.Nodes["review:worker"]
+	if !got.Pending {
+		t.Fatal("new pane auto-PING was not queued")
+	}
+	if got.PaneID != "%89" {
+		t.Fatalf("PaneID = %q, want %%89", got.PaneID)
 	}
 }
 

--- a/internal/projection/auto_ping_state.go
+++ b/internal/projection/auto_ping_state.go
@@ -7,33 +7,61 @@ import (
 )
 
 const (
-	AutoPingPendingEventType   = "auto_ping_pending"
-	AutoPingDeliveredEventType = "auto_ping_delivered"
+	AutoPingPendingEventType    = "auto_ping_pending"
+	AutoPingDeliveredEventType  = "auto_ping_delivered"
+	AutoPingSuppressedEventType = "auto_ping_suppressed"
+	AutoPingBlockedEventType    = "auto_ping_blocked"
+	AutoPingRetryingEventType   = "auto_ping_retrying"
+)
+
+const (
+	AutoPingStatusPending           = "pending"
+	AutoPingStatusDelivered         = "delivered"
+	AutoPingStatusSuppressed        = "suppressed"
+	AutoPingStatusOwnershipBlocked  = "ownership_blocked"
+	AutoPingStatusRetryingFullInbox = "retrying_full_inbox"
 )
 
 type AutoPingEventPayload struct {
-	NodeKey      string  `json:"node_key"`
-	SessionName  string  `json:"session_name,omitempty"`
-	NodeName     string  `json:"node_name,omitempty"`
-	PaneID       string  `json:"pane_id,omitempty"`
-	Reason       string  `json:"reason,omitempty"`
-	TriggeredAt  string  `json:"triggered_at,omitempty"`
-	DelaySeconds float64 `json:"delay_seconds,omitempty"`
-	NotBeforeAt  string  `json:"not_before_at,omitempty"`
-	DeliveredAt  string  `json:"delivered_at,omitempty"`
+	NodeKey           string  `json:"node_key"`
+	ContextID         string  `json:"context_id,omitempty"`
+	SessionName       string  `json:"session_name,omitempty"`
+	NodeName          string  `json:"node_name,omitempty"`
+	PaneID            string  `json:"pane_id,omitempty"`
+	Reason            string  `json:"reason,omitempty"`
+	TriggeredAt       string  `json:"triggered_at,omitempty"`
+	DelaySeconds      float64 `json:"delay_seconds,omitempty"`
+	NotBeforeAt       string  `json:"not_before_at,omitempty"`
+	DeliveredAt       string  `json:"delivered_at,omitempty"`
+	SuppressedAt      string  `json:"suppressed_at,omitempty"`
+	SuppressUntilAt   string  `json:"suppress_until_at,omitempty"`
+	SuppressionReason string  `json:"suppression_reason,omitempty"`
+	BlockedAt         string  `json:"blocked_at,omitempty"`
+	BlockedReason     string  `json:"blocked_reason,omitempty"`
+	RetryAt           string  `json:"retry_at,omitempty"`
+	RetryReason       string  `json:"retry_reason,omitempty"`
 }
 
 type AutoPingNodeState struct {
-	NodeKey      string
-	SessionName  string
-	NodeName     string
-	PaneID       string
-	Reason       string
-	TriggeredAt  string
-	DelaySeconds float64
-	NotBeforeAt  string
-	DeliveredAt  string
-	Pending      bool
+	NodeKey           string
+	ContextID         string
+	SessionName       string
+	NodeName          string
+	PaneID            string
+	Reason            string
+	TriggeredAt       string
+	DelaySeconds      float64
+	NotBeforeAt       string
+	DeliveredAt       string
+	SuppressedAt      string
+	SuppressUntilAt   string
+	SuppressionReason string
+	BlockedAt         string
+	BlockedReason     string
+	RetryAt           string
+	RetryReason       string
+	Status            string
+	Pending           bool
 }
 
 type AutoPingState struct {
@@ -41,6 +69,14 @@ type AutoPingState struct {
 }
 
 func ProjectAutoPingState(sessionDir string) (AutoPingState, bool, error) {
+	return projectAutoPingState(sessionDir, true)
+}
+
+func ProjectAutoPingHistory(sessionDir string) (AutoPingState, bool, error) {
+	return projectAutoPingState(sessionDir, false)
+}
+
+func projectAutoPingState(sessionDir string, currentGenerationOnly bool) (AutoPingState, bool, error) {
 	state, ok := loadCurrentSessionState(sessionDir)
 	if !ok {
 		return AutoPingState{}, false, nil
@@ -58,18 +94,29 @@ func ProjectAutoPingState(sessionDir string) (AutoPingState, bool, error) {
 	sawResolution := false
 
 	for _, event := range events {
-		if event.SessionKey != state.SessionKey || event.Generation != state.Generation {
+		if event.SessionKey != state.SessionKey {
+			continue
+		}
+		currentGeneration := event.Generation == state.Generation
+
+		switch event.Type {
+		case "lease_acquired":
+			if currentGeneration {
+				sawLease = true
+			}
+			continue
+		case "session_resolved":
+			if currentGeneration {
+				sawResolution = true
+			}
+			continue
+		}
+		if currentGenerationOnly && !currentGeneration {
 			continue
 		}
 
 		switch event.Type {
-		case "lease_acquired":
-			sawLease = true
-			continue
-		case "session_resolved":
-			sawResolution = true
-			continue
-		case AutoPingPendingEventType, AutoPingDeliveredEventType:
+		case AutoPingPendingEventType, AutoPingDeliveredEventType, AutoPingSuppressedEventType, AutoPingBlockedEventType, AutoPingRetryingEventType:
 		default:
 			continue
 		}
@@ -82,17 +129,45 @@ func ProjectAutoPingState(sessionDir string) (AutoPingState, bool, error) {
 			return AutoPingState{}, false, nil
 		}
 
+		previous := projected.Nodes[payload.NodeKey]
 		nodeState := AutoPingNodeState{
-			NodeKey:      payload.NodeKey,
-			SessionName:  payload.SessionName,
-			NodeName:     payload.NodeName,
-			PaneID:       payload.PaneID,
-			Reason:       payload.Reason,
-			TriggeredAt:  payload.TriggeredAt,
-			DelaySeconds: payload.DelaySeconds,
-			NotBeforeAt:  payload.NotBeforeAt,
-			DeliveredAt:  payload.DeliveredAt,
-			Pending:      event.Type == AutoPingPendingEventType,
+			NodeKey:           payload.NodeKey,
+			ContextID:         payload.ContextID,
+			SessionName:       payload.SessionName,
+			NodeName:          payload.NodeName,
+			PaneID:            payload.PaneID,
+			Reason:            payload.Reason,
+			TriggeredAt:       payload.TriggeredAt,
+			DelaySeconds:      payload.DelaySeconds,
+			NotBeforeAt:       payload.NotBeforeAt,
+			DeliveredAt:       payload.DeliveredAt,
+			SuppressedAt:      payload.SuppressedAt,
+			SuppressUntilAt:   payload.SuppressUntilAt,
+			SuppressionReason: payload.SuppressionReason,
+			BlockedAt:         payload.BlockedAt,
+			BlockedReason:     payload.BlockedReason,
+			RetryAt:           payload.RetryAt,
+			RetryReason:       payload.RetryReason,
+		}
+		if nodeState.DeliveredAt == "" {
+			nodeState.DeliveredAt = previous.DeliveredAt
+		}
+		switch event.Type {
+		case AutoPingPendingEventType:
+			nodeState.Status = AutoPingStatusPending
+			nodeState.Pending = true
+		case AutoPingDeliveredEventType:
+			nodeState.Status = AutoPingStatusDelivered
+			nodeState.Pending = false
+		case AutoPingSuppressedEventType:
+			nodeState.Status = AutoPingStatusSuppressed
+			nodeState.Pending = false
+		case AutoPingBlockedEventType:
+			nodeState.Status = AutoPingStatusOwnershipBlocked
+			nodeState.Pending = true
+		case AutoPingRetryingEventType:
+			nodeState.Status = AutoPingStatusRetryingFullInbox
+			nodeState.Pending = true
 		}
 		projected.Nodes[payload.NodeKey] = nodeState
 	}

--- a/internal/projection/auto_ping_state_test.go
+++ b/internal/projection/auto_ping_state_test.go
@@ -160,3 +160,116 @@ func TestProjectAutoPingState_ReplaysAcrossLeaseResume(t *testing.T) {
 		t.Fatalf("worker PaneID = %q, want %q", worker.PaneID, "%21")
 	}
 }
+
+func TestProjectAutoPingHistory_ReplaysDeliveredAcrossGenerations(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.May, 22, 9, 0, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter(first) error = %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		ContextID:    "ctx-main",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%30",
+		Reason:       "startup",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 1,
+		NotBeforeAt:  now.Add(time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(first delivered): %v", err)
+	}
+
+	if _, _, err := journal.ResolveSession(sessionDir, "review", journal.ResolutionExplicitRebind, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("ResolveSession(rebind): %v", err)
+	}
+	if _, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 202, now.Add(4*time.Second)); err != nil {
+		t.Fatalf("OpenShadowWriter(second): %v", err)
+	}
+
+	current, ok, err := ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	if _, exists := current.Nodes["review:worker"]; exists {
+		t.Fatalf("ProjectAutoPingState() unexpectedly replayed previous generation: %#v", current.Nodes["review:worker"])
+	}
+
+	history, ok, err := ProjectAutoPingHistory(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingHistory() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingHistory() ok = false, want true")
+	}
+	got := history.Nodes["review:worker"]
+	if got.Status != AutoPingStatusDelivered {
+		t.Fatalf("history Status = %q, want %q", got.Status, AutoPingStatusDelivered)
+	}
+	if got.ContextID != "ctx-main" || got.PaneID != "%30" {
+		t.Fatalf("history identity = context %q pane %q", got.ContextID, got.PaneID)
+	}
+}
+
+func TestProjectAutoPingState_ReplaysSuppressedStatus(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.May, 22, 9, 5, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingDeliveredEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:      "review:worker",
+		ContextID:    "ctx-main",
+		SessionName:  "review",
+		NodeName:     "worker",
+		PaneID:       "%30",
+		Reason:       "startup",
+		TriggeredAt:  now.Format(time.RFC3339Nano),
+		DelaySeconds: 1,
+		NotBeforeAt:  now.Add(time.Second).Format(time.RFC3339Nano),
+		DeliveredAt:  now.Add(2 * time.Second).Format(time.RFC3339Nano),
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(delivered): %v", err)
+	}
+	if _, err := writer.AppendEvent(AutoPingSuppressedEventType, journal.VisibilityOperatorVisible, AutoPingEventPayload{
+		NodeKey:           "review:worker",
+		ContextID:         "ctx-main",
+		SessionName:       "review",
+		NodeName:          "worker",
+		PaneID:            "%30",
+		Reason:            "startup",
+		DeliveredAt:       now.Add(2 * time.Second).Format(time.RFC3339Nano),
+		SuppressedAt:      now.Add(3 * time.Second).Format(time.RFC3339Nano),
+		SuppressUntilAt:   now.Add(32 * time.Second).Format(time.RFC3339Nano),
+		SuppressionReason: "recent_delivered_cooldown",
+	}, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(suppressed): %v", err)
+	}
+
+	got, ok, err := ProjectAutoPingState(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectAutoPingState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectAutoPingState() ok = false, want true")
+	}
+	worker := got.Nodes["review:worker"]
+	if worker.Pending {
+		t.Fatal("suppressed worker pending = true, want false")
+	}
+	if worker.Status != AutoPingStatusSuppressed {
+		t.Fatalf("Status = %q, want %q", worker.Status, AutoPingStatusSuppressed)
+	}
+	if worker.DeliveredAt == "" {
+		t.Fatal("suppressed state lost DeliveredAt")
+	}
+}

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -203,6 +203,16 @@ type DaemonSubmitRuntimeDiagnostics struct {
 	LastSaturatedAt              string `json:"last_saturated_at,omitempty"`
 }
 
+type AutoPingRuntimeDiagnostics struct {
+	PendingCount            int `json:"pending_count"`
+	DeliveredCount          int `json:"delivered_count"`
+	SuppressedCount         int `json:"suppressed_count"`
+	OwnershipBlockedCount   int `json:"ownership_blocked_count"`
+	RetryingFullInboxCount  int `json:"retrying_full_inbox_count"`
+	OldestPendingAgeSeconds int `json:"oldest_pending_age_seconds,omitempty"`
+	OldestRetryAgeSeconds   int `json:"oldest_retry_age_seconds,omitempty"`
+}
+
 type RuntimeDiagnostics struct {
 	Source       string                         `json:"source"`
 	PointInTime  bool                           `json:"point_in_time"`
@@ -210,6 +220,7 @@ type RuntimeDiagnostics struct {
 	GoRuntime    GoRuntimeDiagnostics           `json:"go_runtime"`
 	Daemon       DaemonRuntimeCardinality       `json:"daemon"`
 	DaemonSubmit DaemonSubmitRuntimeDiagnostics `json:"daemon_submit"`
+	AutoPing     *AutoPingRuntimeDiagnostics    `json:"auto_ping,omitempty"`
 }
 
 type AllSessionStatus struct {


### PR DESCRIPTION
## Summary
- Add no-TUI startup auto-PING reconciliation for discovered nodes.
- Suppress duplicate startup PING floods across rapid daemon restarts.
- Surface headless auto-PING state through diagnostics and docs.

## Verification
- go test ./internal/projection ./internal/daemon ./internal/status ./internal/cli
- go test ./...
- nix flake check
- nix build
- nix run .#skill-check
- git diff --check
- git diff --cached --check
- commit hooks

Fixes #487