### PR TITLE
fix(runtimecontext): handle add-dir summary close error (#537)

### DIFF
--- a/internal/runtimecontext/runtimecontext.go
+++ b/internal/runtimecontext/runtimecontext.go
@@ -540,7 +540,7 @@ func readAddDirSummary(addDir string) string {
 	if err != nil {
 		return ""
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	var paragraph []string


### PR DESCRIPTION
## Summary

- handle the deferred close in `readAddDirSummary` explicitly so `errcheck` passes
- keep the existing add-dir summary behavior unchanged

## Root Cause

`internal/runtimecontext/runtimecontext.go` used `defer file.Close()` inside `readAddDirSummary`, so CI failed `errcheck` on active PR merge builds.

## Verification

- `nix develop .#ci --command golangci-lint run ./...`
- `go test ./internal/runtimecontext`
- `nix flake check`
- `nix build`

Related: #537