### PR TITLE
Fix stale pid reuse daemon detection

### DIFF
--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -635,7 +634,7 @@ func TestRunPop_UsesDaemonSubmitWhenDaemonOwnsSession(t *testing.T) {
 	); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	if !config.ContextOwnsSession(tmpDir, contextID, "test-session") {

--- a/internal/cli/send_message_test.go
+++ b/internal/cli/send_message_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1632,7 +1631,7 @@ role = "worker"
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll sessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	now := time.Date(2026, time.May, 3, 9, 0, 0, 0, time.UTC)
@@ -2569,7 +2568,7 @@ role = "worker"
 	if err := os.MkdirAll(ownerSessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll ownerSessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(ownerSessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(ownerSessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 
@@ -2647,7 +2646,7 @@ role = "worker"
 	if err := os.MkdirAll(ownerSessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll ownerSessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(ownerSessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(ownerSessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 
@@ -2710,7 +2709,7 @@ role = "worker"
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll sessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	if !config.ContextOwnsSession(tmpDir, "ctx-send-submit", "test-session") {
@@ -2824,7 +2823,7 @@ role = "worker"
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll sessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	if !config.ContextOwnsSession(tmpDir, "ctx-send-submit-legacy", "test-session") {
@@ -2957,7 +2956,7 @@ role = "worker"
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll sessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	if !config.ContextOwnsSession(tmpDir, "ctx-send-submit-json", "test-session") {
@@ -3104,7 +3103,7 @@ role = "worker"
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll sessionDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 	if !config.ContextOwnsSession(tmpDir, "ctx-send-submit-marker-resolution", "test-session") {

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -253,7 +252,7 @@ func TestRunGetSessionStatus_DebugIncludesDaemonRuntimeDiagnostics(t *testing.T)
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
 		t.Fatalf("CreateSessionDirs: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 	t.Setenv("POSTMAN_HOME", tmpDir)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -214,7 +213,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string, noTUI bool) er
 	}
 
 	pidPath := filepath.Join(sessionDir, "postman.pid")
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(pidPath, os.Getpid()); err != nil {
 		return fmt.Errorf("writing PID file: %w", err)
 	}
 	defer func() { _ = os.Remove(pidPath) }()

--- a/internal/cli/start_ping_activation_test.go
+++ b/internal/cli/start_ping_activation_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -133,7 +132,7 @@ func TestActivateStartupSessions_DefaultMakesForeignSessionDiscoverableAndOwned(
 	if err := config.CreateMultiSessionDirs(contextDir, selfSession); err != nil {
 		t.Fatalf("CreateMultiSessionDirs(self): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(contextDir, selfSession, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(contextDir, selfSession, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 
@@ -317,7 +316,7 @@ func TestActivateSessionForPing_RejectsSameUserOwnedSession(t *testing.T) {
 	if err := os.MkdirAll(ownerDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(ownerDir): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(ownerDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(ownerDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 

--- a/internal/cli/start_status_relay_test.go
+++ b/internal/cli/start_status_relay_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -20,11 +19,7 @@ func writeLiveSessionPID(t *testing.T, baseDir, contextID, sessionName string) {
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q): %v", sessionDir, err)
 	}
-	if err := os.WriteFile(
-		filepath.Join(sessionDir, "postman.pid"),
-		[]byte(strconv.Itoa(os.Getpid())),
-		0o600,
-	); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(sessionDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 }

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -60,7 +59,7 @@ func TestRunStartWithFlags_RejectsDuplicateDaemonForSameSession(t *testing.T) {
 	if err := os.MkdirAll(pidDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(pidDir): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(pidDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(pidDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 
@@ -110,7 +109,7 @@ func TestRunStartWithFlags_RejectsCurrentUserDaemonInOtherSession(t *testing.T) 
 	if err := os.MkdirAll(pidDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(pidDir): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(pidDir, "postman.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(pidDir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 
@@ -564,7 +563,7 @@ func writeRuntimeSessionFixture(t *testing.T, baseDir, contextID, sessionName st
 	}
 	if livePID {
 		pidPath := filepath.Join(contextDir, sessionName, "postman.pid")
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		if err := config.WriteSessionPIDFile(pidPath, os.Getpid()); err != nil {
 			t.Fatalf("WriteFile(postman.pid): %v", err)
 		}
 	}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -70,13 +69,9 @@ func RunStop(stdout io.Writer, args []string) error {
 	}
 
 	pidPath := filepath.Join(baseDir, contextID, daemonSessionName, "postman.pid")
-	data, err := os.ReadFile(pidPath)
+	pid, err := config.ReadSessionPIDFile(pidPath)
 	if err != nil {
-		return fmt.Errorf("reading pid file %s: %w", pidPath, err)
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 {
-		return fmt.Errorf("invalid pid in %s", pidPath)
+		return err
 	}
 
 	proc, err := os.FindProcess(pid)

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 )
 
 func TestRunStop_NoActiveDaemonPrintsMessage(t *testing.T) {
@@ -81,7 +82,7 @@ func TestRunStop_StopsDaemonOwningManagedSession(t *testing.T) {
 		}
 	})
 
-	if err := os.WriteFile(filepath.Join(pidDir, "postman.pid"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(pidDir, "postman.pid"), child.Process.Pid); err != nil {
 		t.Fatalf("WriteFile postman.pid: %v", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -1321,7 +1320,7 @@ func writeLivePID(t *testing.T, baseDir, contextName, sessionName string) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	pidPath := filepath.Join(dir, "postman.pid")
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+	if err := WriteSessionPIDFile(pidPath, os.Getpid()); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 }

--- a/internal/config/process_probe.go
+++ b/internal/config/process_probe.go
@@ -1,36 +1,54 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 )
 
+const postmanProcessName = "tmux-a2a-postman"
+
 type signalProcess interface {
 	Signal(os.Signal) error
 }
 
+type sessionPIDRecord struct {
+	PID              int    `json:"pid"`
+	ProcessName      string `json:"process_name,omitempty"`
+	ProcessStartedAt string `json:"process_started_at,omitempty"`
+}
+
 type sessionPIDProbe struct {
-	readFile     func(string) ([]byte, error)
-	findProcess  func(int) (signalProcess, error)
-	stat         func(string) (os.FileInfo, error)
-	fileOwnerUID func(os.FileInfo) (int, bool)
-	currentUID   func() int
+	readFile         func(string) ([]byte, error)
+	writeFile        func(string, []byte, os.FileMode) error
+	findProcess      func(int) (signalProcess, error)
+	processCommand   func(int) (string, error)
+	processStartedAt func(int) (string, error)
+	stat             func(string) (os.FileInfo, error)
+	fileOwnerUID     func(os.FileInfo) (int, bool)
+	currentUID       func() int
 }
 
 var sessionPIDs = defaultSessionPIDProbe()
 
 func defaultSessionPIDProbe() sessionPIDProbe {
 	return sessionPIDProbe{
-		readFile: os.ReadFile,
+		readFile:  os.ReadFile,
+		writeFile: os.WriteFile,
 		findProcess: func(pid int) (signalProcess, error) {
 			return os.FindProcess(pid)
 		},
-		stat:         os.Stat,
-		fileOwnerUID: unixFileOwnerUID,
-		currentUID:   os.Getuid,
+		processCommand:   psProcessCommand,
+		processStartedAt: psProcessStartedAt,
+		stat:             os.Stat,
+		fileOwnerUID:     unixFileOwnerUID,
+		currentUID:       os.Getuid,
 	}
 }
 
@@ -39,8 +57,17 @@ func (p sessionPIDProbe) withDefaults() sessionPIDProbe {
 	if p.readFile == nil {
 		p.readFile = defaults.readFile
 	}
+	if p.writeFile == nil {
+		p.writeFile = defaults.writeFile
+	}
 	if p.findProcess == nil {
 		p.findProcess = defaults.findProcess
+	}
+	if p.processCommand == nil {
+		p.processCommand = defaults.processCommand
+	}
+	if p.processStartedAt == nil {
+		p.processStartedAt = defaults.processStartedAt
 	}
 	if p.stat == nil {
 		p.stat = defaults.stat
@@ -52,6 +79,18 @@ func (p sessionPIDProbe) withDefaults() sessionPIDProbe {
 		p.currentUID = defaults.currentUID
 	}
 	return p
+}
+
+func WriteSessionPIDFile(pidPath string, pid int) error {
+	return sessionPIDs.writeSessionPIDFile(pidPath, pid)
+}
+
+func ReadSessionPIDFile(pidPath string) (int, error) {
+	record, ok := sessionPIDs.readSessionPIDRecord(pidPath)
+	if !ok {
+		return 0, fmt.Errorf("invalid pid in %s", pidPath)
+	}
+	return record.PID, nil
 }
 
 func (p sessionPIDProbe) isPIDAlive(pidPath string) bool {
@@ -73,28 +112,111 @@ func (p sessionPIDProbe) isPIDOwnedByCurrentUser(pidPath string) bool {
 
 func (p sessionPIDProbe) signalPID(pidPath string) (error, bool) {
 	p = p.withDefaults()
-	pid, ok := p.readSessionPID(pidPath)
+	record, ok := p.readSessionPIDRecord(pidPath)
 	if !ok {
 		return nil, false
 	}
-	proc, err := p.findProcess(pid)
+	if !p.matchesSessionPIDRecord(record) {
+		return nil, false
+	}
+	proc, err := p.findProcess(record.PID)
 	if err != nil {
 		return nil, false
 	}
 	return proc.Signal(syscall.Signal(0)), true
 }
 
-func (p sessionPIDProbe) readSessionPID(pidPath string) (int, bool) {
+func (p sessionPIDProbe) readSessionPIDRecord(pidPath string) (sessionPIDRecord, bool) {
 	p = p.withDefaults()
 	data, err := p.readFile(pidPath)
 	if err != nil {
-		return 0, false
+		return sessionPIDRecord{}, false
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return sessionPIDRecord{}, false
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var record sessionPIDRecord
+		if err := json.Unmarshal([]byte(trimmed), &record); err != nil {
+			return sessionPIDRecord{}, false
+		}
+		if record.PID <= 0 {
+			return sessionPIDRecord{}, false
+		}
+		return record, true
+	}
+	pid, err := strconv.Atoi(trimmed)
 	if err != nil || pid <= 0 {
-		return 0, false
+		return sessionPIDRecord{}, false
 	}
-	return pid, true
+	return sessionPIDRecord{PID: pid}, true
+}
+
+func (p sessionPIDProbe) writeSessionPIDFile(pidPath string, pid int) error {
+	p = p.withDefaults()
+	record := sessionPIDRecord{
+		PID: pid,
+	}
+	record.ProcessName = p.processName(pid)
+	if record.ProcessName == "" {
+		record.ProcessName = postmanProcessName
+	}
+	if startedAt, err := p.processStartedAt(pid); err == nil {
+		record.ProcessStartedAt = strings.TrimSpace(startedAt)
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return p.writeFile(pidPath, data, 0o600)
+}
+
+func (p sessionPIDProbe) processName(pid int) string {
+	command, err := p.processCommand(pid)
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) == 0 {
+		return ""
+	}
+	return filepath.Base(fields[0])
+}
+
+func (p sessionPIDProbe) matchesSessionPIDRecord(record sessionPIDRecord) bool {
+	if record.ProcessStartedAt != "" {
+		startedAt, err := p.processStartedAt(record.PID)
+		if err != nil || strings.TrimSpace(startedAt) != record.ProcessStartedAt {
+			return false
+		}
+	}
+	expectedName := record.ProcessName
+	if expectedName == "" {
+		expectedName = postmanProcessName
+	}
+	if expectedName == "" {
+		return true
+	}
+	command, err := p.processCommand(record.PID)
+	if err != nil {
+		return false
+	}
+	return processCommandMatches(command, expectedName)
+}
+
+func processCommandMatches(command, expectedName string) bool {
+	command = strings.TrimSpace(command)
+	expectedName = strings.TrimSpace(expectedName)
+	if command == "" || expectedName == "" {
+		return false
+	}
+	fields := strings.Fields(command)
+	if len(fields) > 0 && filepath.Base(fields[0]) == expectedName {
+		return true
+	}
+	return strings.Contains(command, expectedName)
 }
 
 func (p sessionPIDProbe) pidFileOwnedByCurrentUser(pidPath string) bool {
@@ -118,4 +240,20 @@ func unixFileOwnerUID(info os.FileInfo) (int, bool) {
 		return 0, false
 	}
 	return int(stat.Uid), true
+}
+
+func psProcessCommand(pid int) (string, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func psProcessStartedAt(pid int) (string, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/config/process_probe.go
+++ b/internal/config/process_probe.go
@@ -44,8 +44,8 @@ func defaultSessionPIDProbe() sessionPIDProbe {
 		findProcess: func(pid int) (signalProcess, error) {
 			return os.FindProcess(pid)
 		},
-		processCommand:   psProcessCommand,
-		processStartedAt: psProcessStartedAt,
+		processCommand:   defaultProcessCommand,
+		processStartedAt: defaultProcessStartedAt,
 		stat:             os.Stat,
 		fileOwnerUID:     unixFileOwnerUID,
 		currentUID:       os.Getuid,
@@ -240,6 +240,55 @@ func unixFileOwnerUID(info os.FileInfo) (int, bool) {
 		return 0, false
 	}
 	return int(stat.Uid), true
+}
+
+func defaultProcessCommand(pid int) (string, error) {
+	if command, err := procProcessCommand(pid); err == nil {
+		return command, nil
+	}
+	if command, err := psProcessCommand(pid); err == nil {
+		return command, nil
+	}
+	return platformProcessCommand(pid)
+}
+
+func defaultProcessStartedAt(pid int) (string, error) {
+	if startedAt, err := procProcessStartedAt(pid); err == nil {
+		return startedAt, nil
+	}
+	if startedAt, err := psProcessStartedAt(pid); err == nil {
+		return startedAt, nil
+	}
+	return platformProcessStartedAt(pid)
+}
+
+func procProcessCommand(pid int) (string, error) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	command := strings.TrimSpace(strings.ReplaceAll(string(data), "\x00", " "))
+	if command == "" {
+		return "", fmt.Errorf("empty /proc cmdline for pid %d", pid)
+	}
+	return command, nil
+}
+
+func procProcessStartedAt(pid int) (string, error) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return "", err
+	}
+	stat := string(data)
+	closeParen := strings.LastIndex(stat, ")")
+	if closeParen < 0 || closeParen+2 >= len(stat) {
+		return "", fmt.Errorf("invalid /proc stat for pid %d", pid)
+	}
+	fields := strings.Fields(stat[closeParen+2:])
+	if len(fields) < 20 {
+		return "", fmt.Errorf("short /proc stat for pid %d", pid)
+	}
+	return fields[19], nil
 }
 
 func psProcessCommand(pid int) (string, error) {

--- a/internal/config/process_probe.go
+++ b/internal/config/process_probe.go
@@ -191,6 +191,7 @@ func (p sessionPIDProbe) matchesSessionPIDRecord(record sessionPIDRecord) bool {
 		if err != nil || strings.TrimSpace(startedAt) != record.ProcessStartedAt {
 			return false
 		}
+		return true
 	}
 	expectedName := record.ProcessName
 	if expectedName == "" {

--- a/internal/config/process_probe_darwin.go
+++ b/internal/config/process_probe_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func platformProcessCommand(pid int) (string, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(info.Proc.P_comm[:]), "\x00"), nil
+}
+
+func platformProcessStartedAt(pid int) (string, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d.%06d", info.Proc.P_starttime.Sec, info.Proc.P_starttime.Usec), nil
+}

--- a/internal/config/process_probe_other.go
+++ b/internal/config/process_probe_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package config
+
+import "fmt"
+
+func platformProcessCommand(pid int) (string, error) {
+	return "", fmt.Errorf("platform process command unavailable for pid %d", pid)
+}
+
+func platformProcessStartedAt(pid int) (string, error) {
+	return "", fmt.Errorf("platform process start time unavailable for pid %d", pid)
+}

--- a/internal/config/process_probe_test.go
+++ b/internal/config/process_probe_test.go
@@ -334,6 +334,34 @@ func TestSessionPIDProbeRejectsStructuredPIDWithDifferentStartTime(t *testing.T)
 	}
 }
 
+func TestSessionPIDProbeAcceptsStructuredPIDWithSameStartTime(t *testing.T) {
+	probe := sessionPIDProbe{
+		readFile: func(string) ([]byte, error) {
+			return []byte(`{"pid":2263,"process_name":"tmux-a2a-postman","process_started_at":"Mon Jun 15 11:22:00 2026"}`), nil
+		},
+		findProcess: func(int) (signalProcess, error) {
+			return fakeSignalProcess{t: t}, nil
+		},
+		processCommand: func(int) (string, error) {
+			return "/nix/store/example/bin/sleep 60", nil
+		},
+		processStartedAt: fakeProcessStartedAt,
+		stat: func(string) (os.FileInfo, error) {
+			return fakeFileInfo{uid: 501}, nil
+		},
+		fileOwnerUID: func(info os.FileInfo) (int, bool) {
+			return info.(fakeFileInfo).uid, true
+		},
+		currentUID: func() int {
+			return 501
+		},
+	}
+
+	if !probe.isPIDAlive(filepath.Join("ctx", "sess", "postman.pid")) {
+		t.Fatal("isPIDAlive() = false, want true when structured PID start time still matches")
+	}
+}
+
 func withSessionPIDProbe(t *testing.T, probe sessionPIDProbe) {
 	t.Helper()
 	orig := sessionPIDs

--- a/internal/config/process_probe_test.go
+++ b/internal/config/process_probe_test.go
@@ -21,6 +21,14 @@ func (p fakeSignalProcess) Signal(sig os.Signal) error {
 	return p.err
 }
 
+func fakePostmanCommand(int) (string, error) {
+	return "/nix/store/example/bin/tmux-a2a-postman start", nil
+}
+
+func fakeProcessStartedAt(int) (string, error) {
+	return "Mon Jun 15 11:22:00 2026", nil
+}
+
 type fakeFileInfo struct {
 	name string
 	uid  int
@@ -68,6 +76,8 @@ func TestSessionPIDProbeLivenessMatrix(t *testing.T) {
 					}
 					return fakeSignalProcess{t: t, err: tt.signalErr}, nil
 				},
+				processCommand:   fakePostmanCommand,
+				processStartedAt: fakeProcessStartedAt,
 				stat: func(string) (os.FileInfo, error) {
 					return fakeFileInfo{uid: 501}, nil
 				},
@@ -117,6 +127,8 @@ func TestSessionPIDProbeRejectsInvalidPIDFiles(t *testing.T) {
 					findCalled = true
 					return fakeSignalProcess{t: t}, nil
 				},
+				processCommand:   fakePostmanCommand,
+				processStartedAt: fakeProcessStartedAt,
 				stat: func(string) (os.FileInfo, error) {
 					return fakeFileInfo{uid: 501}, nil
 				},
@@ -179,6 +191,8 @@ func TestSessionPIDProbeOwnershipFallbacks(t *testing.T) {
 				findProcess: func(int) (signalProcess, error) {
 					return fakeSignalProcess{t: t}, nil
 				},
+				processCommand:   fakePostmanCommand,
+				processStartedAt: fakeProcessStartedAt,
 				stat: func(string) (os.FileInfo, error) {
 					return fakeFileInfo{uid: tt.ownerUID}, nil
 				},
@@ -211,6 +225,8 @@ func TestFindCurrentUserDaemonUsesPIDProbeAcrossMultipleContexts(t *testing.T) {
 		findProcess: func(int) (signalProcess, error) {
 			return fakeSignalProcess{t: t}, nil
 		},
+		processCommand:   fakePostmanCommand,
+		processStartedAt: fakeProcessStartedAt,
 		stat: func(path string) (os.FileInfo, error) {
 			switch path {
 			case foreignPID:
@@ -256,6 +272,66 @@ func writePIDFileForProbeTest(t *testing.T, baseDir, contextName, sessionName, p
 		t.Fatalf("WriteFile(%q): %v", pidPath, err)
 	}
 	return pidPath
+}
+
+func TestSessionPIDProbeRejectsReusedPIDWithDifferentCommand(t *testing.T) {
+	probe := sessionPIDProbe{
+		readFile: func(string) ([]byte, error) {
+			return []byte("2263"), nil
+		},
+		findProcess: func(int) (signalProcess, error) {
+			return fakeSignalProcess{t: t}, nil
+		},
+		processCommand: func(int) (string, error) {
+			return "/System/Library/PrivateFrameworks/DeviceCheckInternal.framework/devicecheckd", nil
+		},
+		processStartedAt: fakeProcessStartedAt,
+		stat: func(string) (os.FileInfo, error) {
+			return fakeFileInfo{uid: 501}, nil
+		},
+		fileOwnerUID: func(info os.FileInfo) (int, bool) {
+			return info.(fakeFileInfo).uid, true
+		},
+		currentUID: func() int {
+			return 501
+		},
+	}
+
+	pidPath := filepath.Join("ctx", "sess", "postman.pid")
+	if probe.isPIDAlive(pidPath) {
+		t.Fatal("isPIDAlive() = true, want false for reused PID with non-postman command")
+	}
+	if probe.isPIDOwnedByCurrentUser(pidPath) {
+		t.Fatal("isPIDOwnedByCurrentUser() = true, want false for reused PID with non-postman command")
+	}
+}
+
+func TestSessionPIDProbeRejectsStructuredPIDWithDifferentStartTime(t *testing.T) {
+	probe := sessionPIDProbe{
+		readFile: func(string) ([]byte, error) {
+			return []byte(`{"pid":2263,"process_name":"tmux-a2a-postman","process_started_at":"Mon Jun 15 10:00:00 2026"}`), nil
+		},
+		findProcess: func(int) (signalProcess, error) {
+			return fakeSignalProcess{t: t}, nil
+		},
+		processCommand: fakePostmanCommand,
+		processStartedAt: func(int) (string, error) {
+			return "Mon Jun 15 11:22:00 2026", nil
+		},
+		stat: func(string) (os.FileInfo, error) {
+			return fakeFileInfo{uid: 501}, nil
+		},
+		fileOwnerUID: func(info os.FileInfo) (int, bool) {
+			return info.(fakeFileInfo).uid, true
+		},
+		currentUID: func() int {
+			return 501
+		},
+	}
+
+	if probe.isPIDAlive(filepath.Join("ctx", "sess", "postman.pid")) {
+		t.Fatal("isPIDAlive() = true, want false for reused PID with different start time")
+	}
 }
 
 func withSessionPIDProbe(t *testing.T, probe sessionPIDProbe) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -359,7 +359,7 @@ func TestHandleSessionScanTick_AutoActivatesNewSessionWithConfiguredPanes(t *tes
 	if err := config.CreateMultiSessionDirs(contextDir, selfSession); err != nil {
 		t.Fatalf("CreateMultiSessionDirs(self): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(contextDir, selfSession, "postman.pid"), []byte(fmt.Sprint(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(contextDir, selfSession, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 
@@ -429,7 +429,7 @@ func TestHandleSessionScanTick_AutoActivatesNewSessionWithNodesOnlyConfiguredPan
 	if err := config.CreateMultiSessionDirs(contextDir, selfSession); err != nil {
 		t.Fatalf("CreateMultiSessionDirs(self): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(contextDir, selfSession, "postman.pid"), []byte(fmt.Sprint(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(contextDir, selfSession, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 
@@ -2283,7 +2283,7 @@ func writeRuntimeLivePID(t *testing.T, baseDir, contextName, sessionName string)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(pid dir): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "postman.pid"), []byte(fmt.Sprint(os.Getpid())), 0o600); err != nil {
+	if err := config.WriteSessionPIDFile(filepath.Join(dir, "postman.pid"), os.Getpid()); err != nil {
 		t.Fatalf("WriteFile(postman.pid): %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- write structured daemon pid metadata with process identity evidence
- verify pid-file process identity before treating a pid as a live daemon
- keep legacy numeric pid-file compatibility while rejecting reused non-postman PIDs
- update stop and tests to read both pid-file formats

Closes #548

## Verification

- `direnv exec . go test ./internal/config ./internal/cli ./internal/daemon`
- `direnv exec . go test ./...`
