### PR TITLE
fix(runtimecontext): preserve archived runtime metadata (#558)

### DIFF
--- a/internal/runtimecontext/runtimecontext.go
+++ b/internal/runtimecontext/runtimecontext.go
@@ -21,6 +21,7 @@ import (
 const (
 	SchemaVersion                    = 1
 	SemanticsMetadataNotInstructions = "metadata_not_instructions"
+	unboundedStringLimit             = 0
 	defaultStringLimit               = 240
 	defaultBodyLimit                 = 1024
 	defaultSummaryLimit              = 4096
@@ -432,7 +433,7 @@ func (tracker *redactionTracker) sanitizeString(value string, limit int) string 
 		tracker.applied = true
 		return "[redacted]"
 	}
-	if len(value) > limit {
+	if limit != unboundedStringLimit && len(value) > limit {
 		tracker.truncated = true
 		value = truncateUTF8(value, limit)
 	}
@@ -451,11 +452,11 @@ func sanitizeRuntimeMetadata(runtime RuntimeMetadata, tracker *redactionTracker)
 	runtime.Name = tracker.sanitizeString(runtime.Name, defaultStringLimit)
 	runtime.Model = tracker.sanitizeString(runtime.Model, defaultStringLimit)
 	runtime.Profile = tracker.sanitizeString(runtime.Profile, defaultStringLimit)
-	runtime.LaunchCommand = tracker.sanitizeString(runtime.LaunchCommand, defaultStringLimit)
+	runtime.LaunchCommand = tracker.sanitizeString(runtime.LaunchCommand, unboundedStringLimit)
 	if runtime.AddDir != nil {
 		addDir := *runtime.AddDir
 		addDir.Path = tracker.sanitizeString(displayPath(addDir.Path), defaultStringLimit)
-		addDir.Context = tracker.sanitizeString(addDir.Context, defaultStringLimit)
+		addDir.Context = tracker.sanitizeString(addDir.Context, unboundedStringLimit)
 		if addDir.Path == "" && addDir.Context == "" {
 			runtime.AddDir = nil
 		} else {

--- a/internal/runtimecontext/runtimecontext_test.go
+++ b/internal/runtimecontext/runtimecontext_test.go
@@ -104,6 +104,60 @@ func TestRuntimeContextIncludesLaunchCommandAndAddDirInMarkdownAndSummary(t *tes
 	}
 }
 
+func TestSaveSnapshotPreservesFullLaunchCommandAndAddDirContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	addDir := filepath.Join(tmpDir, "internal")
+	if err := os.MkdirAll(addDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll addDir: %v", err)
+	}
+	fullContext := strings.TrimSpace(strings.Repeat("Operational context for the automation archive. ", 12))
+	if len(fullContext) <= defaultStringLimit {
+		t.Fatalf("test context length = %d, want > %d", len(fullContext), defaultStringLimit)
+	}
+	if err := os.WriteFile(filepath.Join(addDir, "README.md"), []byte("# Internal\n\n"+fullContext+"\n\nSecond paragraph.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile README: %v", err)
+	}
+	launchCommand := "/usr/bin/codex --yolo --add-dir " + addDir + " --model gpt-5.5 " + strings.Repeat("--flag=value ", 30)
+	if len(launchCommand) <= defaultStringLimit {
+		t.Fatalf("test launch command length = %d, want > %d", len(launchCommand), defaultStringLimit)
+	}
+	sessionDir := filepath.Join(tmpDir, "ctx-runtime", "tmux-a2a-postman")
+
+	snapshot := BuildSnapshot(BuildOptions{
+		Now:       time.Date(2026, time.June, 19, 10, 0, 0, 0, time.UTC),
+		Scope:     "sender",
+		ContextID: "ctx-runtime",
+		MessageID: "message.md",
+		Node:      "worker",
+		Runtime:   RuntimeMetadataFromLaunchCommand(launchCommand, ""),
+	})
+	saved, err := SaveSnapshot(sessionDir, snapshot)
+	if err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	data, err := os.ReadFile(saved.Path)
+	if err != nil {
+		t.Fatalf("ReadFile saved snapshot: %v", err)
+	}
+	var archived Snapshot
+	if err := json.Unmarshal(data, &archived); err != nil {
+		t.Fatalf("json.Unmarshal archived snapshot: %v", err)
+	}
+	if archived.Runtime == nil {
+		t.Fatalf("archived.Runtime is nil: %s", data)
+	}
+	if archived.Runtime.LaunchCommand != strings.TrimSpace(launchCommand) {
+		t.Fatalf("archived launch command length = %d, want full length %d\nvalue=%q", len(archived.Runtime.LaunchCommand), len(strings.TrimSpace(launchCommand)), archived.Runtime.LaunchCommand)
+	}
+	if archived.Runtime.AddDir == nil || archived.Runtime.AddDir.Context != fullContext {
+		t.Fatalf("archived add_dir = %#v, want full README context length %d", archived.Runtime.AddDir, len(fullContext))
+	}
+	if strings.Contains(archived.Runtime.LaunchCommand, "...") || strings.Contains(archived.Runtime.AddDir.Context, "...") {
+		t.Fatalf("archived runtime metadata was abbreviated: %#v", archived.Runtime)
+	}
+}
+
 func TestRenderSenderMarkdownPreservesSafetyLinesAndBoundaryWhenTruncated(t *testing.T) {
 	snapshot := Snapshot{
 		SchemaVersion: SchemaVersion,


### PR DESCRIPTION
## Summary

- Preserve full archived `runtime.addDir.context` text instead of applying UI-oriented truncation.
- Preserve the launch command in archived runtime snapshots while still redacting sensitive substrings.
- Add focused runtime context coverage for full add-dir context and launch command behavior.

## Verification

- `nix develop --command go test ./internal/runtimecontext`
- `nix develop --command go test ./internal/runtimecontext ./internal/cli`
- `git diff --check`
- `nix flake check`
- `nix build`
- Checked README and `skills/*/SKILL.md` for stale references caused by the change.

Closes #558