### PR TITLE
perf: bound daemon memory retention surfaces (#501)

### DIFF
--- a/docs/design/memory-retention-audit.md
+++ b/docs/design/memory-retention-audit.md
@@ -1,0 +1,64 @@
+# Memory retention audit
+
+This is the issue #501 audit of long-lived daemon and projection retention
+surfaces after the runtime diagnostics and loaded-session fixtures were added.
+
+## 1. Evidence
+
+The count-only mailbox state path was measured with:
+
+```sh
+go test ./internal/projection -run '^$' -bench BenchmarkProjectMailboxState_LoadedSession10000MailboxEvents500ReadArchives -benchmem -benchtime=1x -count=3
+```
+
+Fixture shape:
+
+- 10,000 mailbox events
+- 500 read archives
+- 128 daemon-submit responses
+- 8 status snapshots
+- 512 byte message bodies
+
+Before the streaming projection change:
+
+| run | ns/op       | B/op       | allocs/op |
+| --- | ----------: | ---------: | --------: |
+| 1   | 217,748,480 | 59,269,016 | 394,488   |
+| 2   | 205,472,858 | 59,268,888 | 394,487   |
+| 3   | 207,912,273 | 59,268,888 | 394,487   |
+
+After the streaming projection change:
+
+| run | ns/op       | B/op       | allocs/op |
+| --- | ----------: | ---------: | --------: |
+| 1   | 220,743,996 | 52,880,088 | 375,747   |
+| 2   | 198,839,537 | 52,878,088 | 375,720   |
+| 3   | 209,489,590 | 52,878,120 | 375,720   |
+
+The after result reduces per-projection allocation from about 59.27 MB/op to
+52.88 MB/op and allocation count from about 394.5k allocs/op to 375.7k
+allocs/op. Runtime is noise-level equivalent for the 1x fixture.
+
+## 2. Audited surfaces
+
+| Surface                                          | Conclusion                                                                                                                                                                                                                                         | Evidence                                                                                                                                                           |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `journal.Replay` returning all raw events        | Changed. `journal.ReplayEach` streams validated events through a callback; `Replay` keeps the old slice-returning API by appending streamed events.                                                                                                | `internal/journal/journal.go`; `TestReplayEach_StreamsValidatedEventsAndStopsOnCallbackError`; existing replay validation tests still pass.                        |
+| `MailboxEventPayload.Content` in replay payloads | Bounded by use case. Full content is still required by `ProjectMailboxProjection` and `SyncMailboxProjection` to reconstruct mailbox files from the journal. The count-only path no longer unmarshals content into a long-lived payload value.     | `internal/projection/mailbox_projection.go` still owns file reconstruction; `ProjectMailboxState` now decodes only `message_id`, `to`, and `path`.                 |
+| `ProjectMailboxState` full replay state          | Changed. It streams journal records and keeps only maps needed for unread counts. It no longer retains the full event slice or payload content for count projection.                                                                               | Benchmark above; `TestProjectMailboxState_UsesMailboxMetadataWithoutContent`; existing mailbox state tests pass.                                                   |
+| Runtime node maps                                | Bounded by scan snapshots. `nodes` is replaced from discovery, `knownNodes` is pruned against the fresh snapshot, and `claimedPanes` is pruned against live pane IDs.                                                                              | `internal/daemon/runtime.go`; runtime tests cover known-node and claimed-pane cleanup behavior.                                                                    |
+| Runtime watcher directory map                    | Changed. `watchedDirs` now removes directories that are no longer desired by the fresh node snapshot and calls watcher `Remove` before deleting the map entry.                                                                                     | `internal/daemon/runtime.go`; `TestPruneWatchedDirsRemovesDirsForDisappearedNodes`.                                                                                |
+| Active post delivery map                         | Bounded by path guard lifetime. Accepted deliveries call `finishPostEvent` on normal completion, retry completion, missing file, or goroutine defer.                                                                                               | `beginPostEvent`, `finishPostEvent`, and delivery defer in `internal/daemon/runtime.go`; `TestPostEventGuard_DedupesByPathUntilFinished`.                          |
+| Active auto-ping map                             | Bounded by per-node goroutine lifetime. `beginAutoPing` suppresses duplicate in-flight pings and `finishAutoPing` deletes the key when the send path returns.                                                                                      | `internal/daemon/runtime.go`; auto-ping tests wait for active keys to clear.                                                                                       |
+| Active daemon-submit map                         | Bounded by worker result handling. `activeDaemonSubmitKeys` is keyed by operation, capped by `daemonSubmitWorkerLimit`, and deleted in `handleDaemonSubmitResult`. Runtime diagnostics expose only counts and ages.                                | `internal/daemon/runtime.go`; daemon-submit runtime tests cover active, pending, claimed, late response, and saturation counts.                                    |
+| Mailbox projection sync maps                     | Bounded by session directory and coalescing. Only one active sync per session runs; duplicate requests become a pending bit and both active and pending maps are cleared in `runMailboxProjectionSync`.                                            | `scheduleMailboxProjectionSync` and `runMailboxProjectionSync` in `internal/daemon/runtime.go`.                                                                    |
+| Idle pane capture state                          | Changed. Pane state keeps hashes, timestamps, counts, trigger identity, marker count, and prefix hash/line count. It no longer retains captured pane text through `LastCompactionPrefix`; stale pane entries are deleted after `NodeStaleSeconds`. | `internal/idle/idle.go`; compaction-marker tests cover repeated marker behavior after replacing text with hash state; stale cleanup remains in `checkPaneCapture`. |
+| Late daemon-submit responses                     | Bounded in memory and reported in diagnostics. Response files may remain on disk for inspection after client timeout, but daemon status scans keep only counts and oldest ages; responses are not accumulated in a daemon heap slice.              | `scanDaemonSubmitResponses` in `internal/daemon/runtime.go`; README timeout guidance points operators to `inspect-daemon-submit` and `get-status --debug`.         |
+
+## 3. Operator surface
+
+No command behavior or help text changed. Existing `get-status --debug`
+diagnostics already expose bounded daemon cardinality and daemon-submit queue
+health, and existing timeout guidance already points operators at late-response
+inspection. The changes here reduce internal retention without adding new
+operator-facing diagnostics.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -37,6 +37,7 @@ const (
 
 type filesystemWatcher interface {
 	Add(string, fswatcher.Op) error
+	Remove(string) error
 }
 
 func sessionScanInterval(cfg *config.Config) time.Duration {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -815,6 +815,7 @@ func (rt *daemonRuntime) processActivePostEvent(eventPath, filename string) {
 
 	freshNodes, _, err := rt.discoverNodes()
 	if err == nil {
+		rt.pruneWatchedDirs(freshNodes)
 		rt.claimNewPanes(freshNodes)
 		rt.pruneKnownNodes(freshNodes)
 		newNodes := rt.detectNewNodes(freshNodes)
@@ -1085,6 +1086,7 @@ func (rt *daemonRuntime) handleScanTick() {
 	}
 
 	rt.pruneClaimedPanes(freshNodes)
+	rt.pruneWatchedDirs(freshNodes)
 	rt.claimNewPanes(freshNodes)
 	for _, collision := range scanCollisions {
 		rt.events <- tui.DaemonEvent{
@@ -1273,6 +1275,7 @@ func (rt *daemonRuntime) refreshNodesAfterSessionActivation(allSessions []string
 	}
 
 	rt.pruneClaimedPanes(freshNodes)
+	rt.pruneWatchedDirs(freshNodes)
 	rt.claimNewPanes(freshNodes)
 	for _, collision := range scanCollisions {
 		rt.events <- tui.DaemonEvent{
@@ -1383,6 +1386,46 @@ func (rt *daemonRuntime) ensureNodeWatchDirs(nodeName string, nodeInfo discovery
 		if err := rt.watcher.Add(submitRequestsDir, fswatcher.All); err == nil {
 			rt.watchedDirs[submitRequestsDir] = true
 		}
+	}
+}
+
+func nodeWatchDirs(nodeInfo discovery.NodeInfo) []string {
+	if nodeInfo.SessionDir == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(nodeInfo.SessionDir, "post"),
+		filepath.Join(nodeInfo.SessionDir, "inbox"),
+		filepath.Join(nodeInfo.SessionDir, "read"),
+		projection.DaemonSubmitRequestsDir(nodeInfo.SessionDir),
+	}
+}
+
+func desiredWatchDirsForNodes(nodes map[string]discovery.NodeInfo) map[string]bool {
+	desired := make(map[string]bool, len(nodes)*4)
+	for _, nodeInfo := range nodes {
+		for _, dir := range nodeWatchDirs(nodeInfo) {
+			if dir != "" {
+				desired[dir] = true
+			}
+		}
+	}
+	return desired
+}
+
+func (rt *daemonRuntime) pruneWatchedDirs(freshNodes map[string]discovery.NodeInfo) {
+	desired := desiredWatchDirsForNodes(freshNodes)
+	for dir := range rt.watchedDirs {
+		if desired[dir] {
+			continue
+		}
+		if rt.watcher != nil {
+			if err := rt.watcher.Remove(dir); err != nil {
+				log.Printf("postman: WARNING: failed to remove watcher dir %s: %v\n", dir, err)
+				continue
+			}
+		}
+		delete(rt.watchedDirs, dir)
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -25,6 +25,19 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
 )
 
+type recordingFilesystemWatcher struct {
+	removed []string
+}
+
+func (w *recordingFilesystemWatcher) Add(string, fswatcher.Op) error {
+	return nil
+}
+
+func (w *recordingFilesystemWatcher) Remove(path string) error {
+	w.removed = append(w.removed, path)
+	return nil
+}
+
 func waitForInboxEntries(t *testing.T, sessionDir, nodeName string, want int) {
 	t.Helper()
 	inboxDir := filepath.Join(sessionDir, "inbox", nodeName)
@@ -1795,6 +1808,40 @@ func TestPruneKnownNodes_AllowsReturnedNodeToReceiveAutoPingAgain(t *testing.T) 
 
 	if got, want := newNodes, []string{"review:worker"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("detectNewNodes() after pruneKnownNodes() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPruneWatchedDirsRemovesDirsForDisappearedNodes(t *testing.T) {
+	liveSessionDir := filepath.Join(t.TempDir(), "live")
+	staleSessionDir := filepath.Join(t.TempDir(), "stale")
+	livePostDir := filepath.Join(liveSessionDir, "post")
+	stalePostDir := filepath.Join(staleSessionDir, "post")
+	staleSubmitDir := projection.DaemonSubmitRequestsDir(staleSessionDir)
+	watcher := &recordingFilesystemWatcher{}
+	rt := &daemonRuntime{
+		watcher: watcher,
+		watchedDirs: map[string]bool{
+			livePostDir:    true,
+			stalePostDir:   true,
+			staleSubmitDir: true,
+		},
+	}
+
+	rt.pruneWatchedDirs(map[string]discovery.NodeInfo{
+		"review:worker": {SessionDir: liveSessionDir},
+	})
+
+	if !rt.watchedDirs[livePostDir] {
+		t.Fatalf("pruneWatchedDirs() removed live dir %q", livePostDir)
+	}
+	if rt.watchedDirs[stalePostDir] || rt.watchedDirs[staleSubmitDir] {
+		t.Fatalf("pruneWatchedDirs() kept stale dirs: %#v", rt.watchedDirs)
+	}
+	sort.Strings(watcher.removed)
+	wantRemoved := []string{stalePostDir, staleSubmitDir}
+	sort.Strings(wantRemoved)
+	if !reflect.DeepEqual(watcher.removed, wantRemoved) {
+		t.Fatalf("removed dirs = %#v, want %#v", watcher.removed, wantRemoved)
 	}
 }
 

--- a/internal/daemon/watcher_event_test.go
+++ b/internal/daemon/watcher_event_test.go
@@ -25,6 +25,10 @@ func (testFilesystemWatcher) Add(string, fswatcher.Op) error {
 	return nil
 }
 
+func (testFilesystemWatcher) Remove(string) error {
+	return nil
+}
+
 func TestClassifyRuntimeWatcherEvent(t *testing.T) {
 	sessionDir := filepath.Join(t.TempDir(), "review-session")
 	daemonRequestPath := filepath.Join(sessionDir, string(projection.SubmitPathDaemon), "requests", "req.json")

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -51,15 +51,16 @@ type CompactionPingTarget struct {
 
 // PaneCaptureState holds pane capture state for hybrid idle detection.
 type PaneCaptureState struct {
-	LastHash              uint32    // CRC32 hash of pane content
-	LastChangeAt          time.Time // Last time content change was detected
-	ChangeCount           int       // Consecutive change count (2 = active)
-	LastCaptureAt         time.Time // Last capture time
-	LastCompactionPingAt  time.Time // Last compaction-triggered PING for this pane
-	LastCompactionTrigger string    // Non-empty while a compaction marker remains in scanned content
-	LastCompactionHash    uint32    // Scanned compaction content hash for the most recent compaction marker state
-	LastCompactionMarkers int       // Marker occurrences in scanned content for the most recent compaction state
-	LastCompactionPrefix  string    // Bounded scanned content suffix through the latest marker occurrence
+	LastHash                  uint32    // CRC32 hash of pane content
+	LastChangeAt              time.Time // Last time content change was detected
+	ChangeCount               int       // Consecutive change count (2 = active)
+	LastCaptureAt             time.Time // Last capture time
+	LastCompactionPingAt      time.Time // Last compaction-triggered PING for this pane
+	LastCompactionTrigger     string    // Non-empty while a compaction marker remains in scanned content
+	LastCompactionHash        uint32    // Scanned compaction content hash for the most recent compaction marker state
+	LastCompactionMarkers     int       // Marker occurrences in scanned content for the most recent compaction state
+	LastCompactionPrefixHash  uint32    // Hash of scanned content through the latest marker occurrence
+	LastCompactionPrefixLines int       // Line count through the latest marker occurrence
 }
 
 // IdleTracker manages idle detection state (Issue #71).
@@ -215,6 +216,8 @@ type compactionMarkerScan struct {
 	Trigger            string
 	MarkerCount        int
 	LatestMarkerPrefix string
+	MarkerPrefixHash   uint32
+	MarkerPrefixLines  int
 }
 
 func compactionTrigger(runtime, content string) string {
@@ -249,6 +252,8 @@ func codexCompactionTriggerScan(content string) compactionMarkerScan {
 func scanCompactionMarkers(content, trigger string, isMarker func(string) bool) compactionMarkerScan {
 	markers := 0
 	latestMarkerEnd := -1
+	latestMarkerLine := 0
+	lineNumber := 0
 	for lineStart := 0; lineStart <= len(content); {
 		lineEnd := strings.IndexByte(content[lineStart:], '\n')
 		nextLineStart := len(content) + 1
@@ -263,8 +268,10 @@ func scanCompactionMarkers(content, trigger string, isMarker func(string) bool) 
 		if isMarker(line) {
 			markers++
 			latestMarkerEnd = lineEnd
+			latestMarkerLine = lineNumber
 		}
 
+		lineNumber++
 		lineStart = nextLineStart
 	}
 	if markers == 0 {
@@ -274,6 +281,8 @@ func scanCompactionMarkers(content, trigger string, isMarker func(string) bool) 
 		Trigger:            trigger,
 		MarkerCount:        markers,
 		LatestMarkerPrefix: compactionPrefixTail(content, latestMarkerEnd),
+		MarkerPrefixHash:   hashContentCRC32(content[:latestMarkerEnd]),
+		MarkerPrefixLines:  latestMarkerLine + 1,
 	}
 }
 
@@ -326,19 +335,16 @@ func sameCompactionMarker(state PaneCaptureState, scan compactionMarkerScan, com
 	if state.LastCompactionTrigger == "" || scan.Trigger != state.LastCompactionTrigger {
 		return false
 	}
-	if state.LastCompactionPrefix == "" {
+	if state.LastCompactionPrefixLines <= 0 {
 		return scan.MarkerCount <= state.LastCompactionMarkers
 	}
-	if state.LastCompactionPrefix == scan.LatestMarkerPrefix {
-		if !strings.Contains(scan.LatestMarkerPrefix, "\n") {
+	if state.LastCompactionPrefixHash == scan.MarkerPrefixHash {
+		if scan.MarkerPrefixLines <= 1 {
 			return state.LastCompactionHash == compactionHash
 		}
 		return true
 	}
-	if !strings.Contains(scan.LatestMarkerPrefix, "\n") {
-		return false
-	}
-	return strings.HasSuffix(state.LastCompactionPrefix, scan.LatestMarkerPrefix)
+	return false
 }
 
 func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, compactionHash uint32, now time.Time) bool {
@@ -357,13 +363,15 @@ func recordCompactionPing(state *PaneCaptureState, scan compactionMarkerScan, co
 	state.LastCompactionPingAt = now
 	state.LastCompactionHash = compactionHash
 	state.LastCompactionMarkers = scan.MarkerCount
-	state.LastCompactionPrefix = scan.LatestMarkerPrefix
+	state.LastCompactionPrefixHash = scan.MarkerPrefixHash
+	state.LastCompactionPrefixLines = scan.MarkerPrefixLines
 }
 
 func refreshSameCompactionMarker(state *PaneCaptureState, scan compactionMarkerScan, compactionHash uint32) {
 	if sameCompactionMarker(*state, scan, compactionHash) {
 		state.LastCompactionMarkers = scan.MarkerCount
-		state.LastCompactionPrefix = scan.LatestMarkerPrefix
+		state.LastCompactionPrefixHash = scan.MarkerPrefixHash
+		state.LastCompactionPrefixLines = scan.MarkerPrefixLines
 	}
 }
 
@@ -446,7 +454,8 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 					state.LastCompactionTrigger = scan.Trigger
 					state.LastCompactionHash = compactionHash
 					state.LastCompactionMarkers = scan.MarkerCount
-					state.LastCompactionPrefix = scan.LatestMarkerPrefix
+					state.LastCompactionPrefixHash = scan.MarkerPrefixHash
+					state.LastCompactionPrefixLines = scan.MarkerPrefixLines
 				}
 			}
 			t.paneCaptureState[paneID] = state
@@ -472,7 +481,8 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 			} else {
 				state.LastCompactionTrigger = ""
 				state.LastCompactionMarkers = 0
-				state.LastCompactionPrefix = ""
+				state.LastCompactionPrefixHash = 0
+				state.LastCompactionPrefixLines = 0
 			}
 		}
 

--- a/internal/idle/idle_benchmark_test.go
+++ b/internal/idle/idle_benchmark_test.go
@@ -71,15 +71,16 @@ func newLoadedPaneCaptureTracker(panes int) *IdleTracker {
 	for i := 0; i < panes; i++ {
 		paneID := fmt.Sprintf("%%%d", 1000+i)
 		tracker.paneCaptureState[paneID] = PaneCaptureState{
-			LastHash:              uint32(i + 1),
-			LastChangeAt:          now.Add(-time.Duration(i%120) * time.Second),
-			ChangeCount:           i % 3,
-			LastCaptureAt:         now.Add(-time.Duration(i%30) * time.Second),
-			LastCompactionPingAt:  now.Add(-time.Duration(i%300) * time.Second),
-			LastCompactionTrigger: "codex:context-compaction",
-			LastCompactionHash:    uint32(10000 + i),
-			LastCompactionMarkers: i % 5,
-			LastCompactionPrefix:  "Context compacted",
+			LastHash:                  uint32(i + 1),
+			LastChangeAt:              now.Add(-time.Duration(i%120) * time.Second),
+			ChangeCount:               i % 3,
+			LastCaptureAt:             now.Add(-time.Duration(i%30) * time.Second),
+			LastCompactionPingAt:      now.Add(-time.Duration(i%300) * time.Second),
+			LastCompactionTrigger:     "codex:context-compaction",
+			LastCompactionHash:        uint32(10000 + i),
+			LastCompactionMarkers:     i % 5,
+			LastCompactionPrefixHash:  hashContentCRC32("Context compacted"),
+			LastCompactionPrefixLines: 1,
 		}
 	}
 	return tracker

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1041,8 +1041,11 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenMarkerOnlyHistoryReplacesO
 	if state.LastCompactionMarkers != 1 {
 		t.Fatalf("checkPaneCapture() recorded %d compaction markers, want 1", state.LastCompactionMarkers)
 	}
-	if state.LastCompactionPrefix != "• Context compacted" {
-		t.Fatalf("checkPaneCapture() recorded compaction prefix %q, want marker-only prefix", state.LastCompactionPrefix)
+	if state.LastCompactionPrefixLines != 1 {
+		t.Fatalf("checkPaneCapture() recorded %d compaction prefix lines, want marker-only prefix", state.LastCompactionPrefixLines)
+	}
+	if state.LastCompactionPrefixHash != hashContentCRC32("• Context compacted") {
+		t.Fatal("checkPaneCapture() did not record the marker-only prefix hash")
 	}
 
 	state.LastCompactionPingAt = time.Now().Add(-compactionPingCooldown - time.Second)
@@ -1078,8 +1081,11 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenMarkerOnlyHistoryReplacesO
 	if state.LastCompactionMarkers != 1 {
 		t.Fatalf("checkPaneCapture() recorded %d compaction markers after third poll, want 1", state.LastCompactionMarkers)
 	}
-	if state.LastCompactionPrefix != "• Context compacted" {
-		t.Fatalf("checkPaneCapture() recorded third compaction prefix %q, want marker-only prefix", state.LastCompactionPrefix)
+	if state.LastCompactionPrefixLines != 1 {
+		t.Fatalf("checkPaneCapture() recorded %d third compaction prefix lines, want marker-only prefix", state.LastCompactionPrefixLines)
+	}
+	if state.LastCompactionPrefixHash != hashContentCRC32("• Context compacted") {
+		t.Fatal("checkPaneCapture() did not record the third marker-only prefix hash")
 	}
 }
 

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -432,12 +433,23 @@ func (w *Writer) ensureActiveLease() error {
 }
 
 func Replay(sessionDir string) ([]Event, error) {
+	events := make([]Event, 0)
+	if err := ReplayEach(sessionDir, func(event Event) error {
+		events = append(events, event)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func ReplayEach(sessionDir string, fn func(Event) error) error {
 	entries, err := os.ReadDir(recordsDir(sessionDir))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil
 		}
-		return nil, fmt.Errorf("reading records dir: %w", err)
+		return fmt.Errorf("reading records dir: %w", err)
 	}
 
 	type committedRecord struct {
@@ -465,57 +477,60 @@ func Replay(sessionDir string) ([]Event, error) {
 	expectedSequence := 1
 	currentLeaseID := ""
 	currentLeaseEpoch := 0
-	events := make([]Event, 0, len(records))
 	for _, record := range records {
 		if record.sequence < expectedSequence {
-			return nil, fmt.Errorf("replay: duplicate sequence %d", record.sequence)
+			return fmt.Errorf("replay: duplicate sequence %d", record.sequence)
 		}
 		if record.sequence > expectedSequence {
-			return nil, fmt.Errorf("replay: sequence gap at %d", expectedSequence)
+			return fmt.Errorf("replay: sequence gap at %d", expectedSequence)
 		}
 
 		var event Event
-		if err := readJSONFile(filepath.Join(recordsDir(sessionDir), record.name), &event); err != nil {
-			return nil, fmt.Errorf("replay: reading %s: %w", record.name, err)
+		if err := readJSONRecord(filepath.Join(recordsDir(sessionDir), record.name), &event); err != nil {
+			return fmt.Errorf("replay: reading %s: %w", record.name, err)
 		}
 		if event.Sequence != record.sequence {
-			return nil, fmt.Errorf("replay: record %s encoded sequence %d, want %d", record.name, event.Sequence, record.sequence)
+			return fmt.Errorf("replay: record %s encoded sequence %d, want %d", record.name, event.Sequence, record.sequence)
 		}
 		if event.SessionKey == "" {
-			return nil, fmt.Errorf("replay: record %s missing session_key", record.name)
+			return fmt.Errorf("replay: record %s missing session_key", record.name)
 		}
 		if event.Generation < 1 {
-			return nil, fmt.Errorf("replay: record %s has invalid generation %d", record.name, event.Generation)
+			return fmt.Errorf("replay: record %s has invalid generation %d", record.name, event.Generation)
 		}
 		if err := validateThreadBinding(event.Type, strings.TrimSpace(event.ThreadID)); err != nil {
-			return nil, fmt.Errorf("replay: record %s: %w", record.name, err)
+			return fmt.Errorf("replay: record %s: %w", record.name, err)
 		}
 
 		if event.Type == leaseAcquiredEventType {
 			if event.LeaseID == "" {
-				return nil, fmt.Errorf("replay: record %s missing lease_id", record.name)
+				return fmt.Errorf("replay: record %s missing lease_id", record.name)
 			}
 			if event.LeaseEpoch < 1 {
-				return nil, fmt.Errorf("replay: record %s has invalid lease_epoch %d", record.name, event.LeaseEpoch)
+				return fmt.Errorf("replay: record %s has invalid lease_epoch %d", record.name, event.LeaseEpoch)
 			}
 			if currentLeaseEpoch != 0 && event.LeaseEpoch <= currentLeaseEpoch {
-				return nil, fmt.Errorf("replay: non-monotonic lease epoch %d", event.LeaseEpoch)
+				return fmt.Errorf("replay: non-monotonic lease epoch %d", event.LeaseEpoch)
 			}
 			currentLeaseID = event.LeaseID
 			currentLeaseEpoch = event.LeaseEpoch
 		} else {
 			if currentLeaseID == "" {
-				return nil, fmt.Errorf("replay: record %s appeared before lease acquisition", record.name)
+				return fmt.Errorf("replay: record %s appeared before lease acquisition", record.name)
 			}
 			if event.LeaseID != currentLeaseID || event.LeaseEpoch != currentLeaseEpoch {
-				return nil, fmt.Errorf("replay: lease mismatch at sequence %d", event.Sequence)
+				return fmt.Errorf("replay: lease mismatch at sequence %d", event.Sequence)
 			}
 		}
 
-		events = append(events, event)
+		if fn != nil {
+			if err := fn(event); err != nil {
+				return fmt.Errorf("replay: callback sequence %d: %w", event.Sequence, err)
+			}
+		}
 		expectedSequence++
 	}
-	return events, nil
+	return nil
 }
 
 func SessionStatePath(sessionDir string) string {
@@ -712,6 +727,21 @@ func readJSONFile(path string, target interface{}) error {
 		return err
 	}
 	return json.Unmarshal(data, target)
+}
+
+func readJSONRecord(path string, target interface{}) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if err := json.NewDecoder(file).Decode(target); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			return fmt.Errorf("unexpected end of JSON input")
+		}
+		return err
+	}
+	return nil
 }
 
 func randomHex(byteCount int) string {

--- a/internal/journal/journal_test.go
+++ b/internal/journal/journal_test.go
@@ -404,6 +404,42 @@ func TestReplay_FailsClosedOnSequenceAndLeaseDefects(t *testing.T) {
 	})
 }
 
+func TestReplayEach_StreamsValidatedEventsAndStopsOnCallbackError(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.April, 14, 17, 25, 0, 0, time.UTC)
+	writer, err := OpenShadowWriter(sessionDir, "ctx-main", "main", 111, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+	if _, err := writer.AppendEvent("mailbox_projection_posted", VisibilityMailboxProjection, map[string]string{"path": "post/test.md"}, now.Add(time.Second)); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	wantErr := errors.New("stop streaming")
+	var sequences []int
+	err = ReplayEach(sessionDir, func(event Event) error {
+		sequences = append(sequences, event.Sequence)
+		if event.Sequence == 2 {
+			return wantErr
+		}
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ReplayEach() error = %v, want callback error", err)
+	}
+	if len(sequences) != 2 || sequences[0] != 1 || sequences[1] != 2 {
+		t.Fatalf("ReplayEach() streamed sequences %#v, want [1 2]", sequences)
+	}
+
+	events, err := Replay(sessionDir)
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("Replay() returned %d events, want 3", len(events))
+	}
+}
+
 func assertOwnerOnlyMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 

--- a/internal/projection/mailbox_state.go
+++ b/internal/projection/mailbox_state.go
@@ -2,12 +2,15 @@ package projection
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr"
 )
+
+var errInvalidMailboxStateProjection = errors.New("invalid mailbox state projection")
 
 type MailboxState struct {
 	InboxCounts map[string]int
@@ -19,11 +22,6 @@ func ProjectMailboxState(sessionDir, sessionName string) (MailboxState, bool, er
 		return MailboxState{}, false, nil
 	}
 
-	events, err := journal.Replay(sessionDir)
-	if err != nil || len(events) == 0 {
-		return MailboxState{}, false, nil
-	}
-
 	projected := MailboxState{
 		InboxCounts: make(map[string]int),
 	}
@@ -31,12 +29,14 @@ func ProjectMailboxState(sessionDir, sessionName string) (MailboxState, bool, er
 	deliveredMessages := make(map[string]bool)
 	readMessages := make(map[string]bool)
 	sawDelivery := false
+	sawEvent := false
 	sawLease := false
 	sawResolution := false
 
-	for _, event := range events {
+	err := journal.ReplayEach(sessionDir, func(event journal.Event) error {
+		sawEvent = true
 		if event.SessionKey != state.SessionKey || event.Generation != state.Generation {
-			continue
+			return nil
 		}
 
 		switch event.Type {
@@ -45,54 +45,58 @@ func ProjectMailboxState(sessionDir, sessionName string) (MailboxState, bool, er
 		case "session_resolved":
 			sawResolution = true
 		case MailboxProjectionDeliveredEventType:
-			payload, ok := projectedMailboxPayload(event.Payload)
+			payload, ok := projectedMailboxStatePayload(event.Payload)
 			if !ok {
-				return MailboxState{}, false, nil
+				return errInvalidMailboxStateProjection
 			}
 			recipient, ok := projectedRecipientName(payload, sessionName)
 			if !ok {
-				return MailboxState{}, false, nil
+				return errInvalidMailboxStateProjection
 			}
 			messageID, ok := projectedMessageIdentity(payload)
 			if !ok {
-				return MailboxState{}, false, nil
+				return errInvalidMailboxStateProjection
 			}
 			sawDelivery = true
 			deliveredMessages[messageID] = true
 			if readMessages[messageID] {
-				continue
+				return nil
 			}
 			if _, alreadyUnread := unreadMessages[messageID]; alreadyUnread {
-				continue
+				return nil
 			}
 			unreadMessages[messageID] = recipient
 			projected.InboxCounts[recipient]++
 		case MailboxProjectionReadEventType:
-			payload, ok := projectedMailboxPayload(event.Payload)
+			payload, ok := projectedMailboxStatePayload(event.Payload)
 			if !ok {
-				return MailboxState{}, false, nil
+				return errInvalidMailboxStateProjection
 			}
 			messageID, ok := projectedMessageIdentity(payload)
 			if !ok {
 				if sawDelivery {
-					continue
+					return nil
 				}
-				return MailboxState{}, false, nil
+				return errInvalidMailboxStateProjection
 			}
 			recipient, unread := unreadMessages[messageID]
 			if !unread {
 				if !sawDelivery {
-					return MailboxState{}, false, nil
+					return errInvalidMailboxStateProjection
 				}
 				if deliveredMessages[messageID] {
 					readMessages[messageID] = true
 				}
-				continue
+				return nil
 			}
 			projected.InboxCounts[recipient]--
 			delete(unreadMessages, messageID)
 			readMessages[messageID] = true
 		}
+		return nil
+	})
+	if err != nil || !sawEvent {
+		return MailboxState{}, false, nil
 	}
 
 	if !sawLease || !sawResolution {
@@ -100,6 +104,12 @@ func ProjectMailboxState(sessionDir, sessionName string) (MailboxState, bool, er
 	}
 
 	return projected, true, nil
+}
+
+type mailboxStatePayload struct {
+	MessageID string `json:"message_id,omitempty"`
+	To        string `json:"to,omitempty"`
+	Path      string `json:"path,omitempty"`
 }
 
 func loadCurrentSessionState(sessionDir string) (journal.SessionState, bool) {
@@ -118,15 +128,18 @@ func loadCurrentSessionState(sessionDir string) (journal.SessionState, bool) {
 	return state, true
 }
 
-func projectedMailboxPayload(raw json.RawMessage) (journal.MailboxEventPayload, bool) {
-	payload, ok := decodeMailboxEventPayload(raw)
-	if !ok {
-		return journal.MailboxEventPayload{}, false
+func projectedMailboxStatePayload(raw json.RawMessage) (mailboxStatePayload, bool) {
+	var payload mailboxStatePayload
+	if len(raw) == 0 {
+		return payload, true
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return mailboxStatePayload{}, false
 	}
 	return payload, true
 }
 
-func projectedRecipientName(payload journal.MailboxEventPayload, sessionName string) (string, bool) {
+func projectedRecipientName(payload mailboxStatePayload, sessionName string) (string, bool) {
 	if payload.To == "" {
 		return "", false
 	}
@@ -140,7 +153,7 @@ func projectedRecipientName(payload journal.MailboxEventPayload, sessionName str
 	return recipientName, true
 }
 
-func projectedMessageIdentity(payload journal.MailboxEventPayload) (string, bool) {
+func projectedMessageIdentity(payload mailboxStatePayload) (string, bool) {
 	if payload.MessageID != "" {
 		return payload.MessageID, true
 	}

--- a/internal/projection/mailbox_state_test.go
+++ b/internal/projection/mailbox_state_test.go
@@ -2,6 +2,7 @@ package projection
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,36 @@ func TestProjectMailboxState_ReplaysUnreadCountsForCurrentGeneration(t *testing.
 	}
 	if got.InboxCounts["critic"] != 1 {
 		t.Fatalf("critic unread = %d, want 1", got.InboxCounts["critic"])
+	}
+}
+
+func TestProjectMailboxState_UsesMailboxMetadataWithoutContent(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.April, 14, 3, 15, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+	messageID := "20260414-031501-r1111-from-orchestrator-to-worker.md"
+	if _, err := writer.AppendEvent(MailboxProjectionDeliveredEventType, journal.VisibilityMailboxProjection, journal.MailboxEventPayload{
+		MessageID: messageID,
+		To:        "worker",
+		Path:      filepath.Join("inbox", "worker", messageID),
+		Content:   strings.Repeat("payload\n", 4096),
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("AppendEvent(delivered) error = %v", err)
+	}
+
+	got, ok, err := ProjectMailboxState(sessionDir, "review")
+	if err != nil {
+		t.Fatalf("ProjectMailboxState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectMailboxState() ok = false, want true")
+	}
+	if got.InboxCounts["worker"] != 1 {
+		t.Fatalf("worker unread = %d, want 1", got.InboxCounts["worker"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces #529 with a clean branch based on current `main` after the old #529 head remained conflicting.
- Add an evidence-backed daemon memory retention audit covering long-lived state and replay/projection surfaces.
- Stream journal replay for mailbox state projection and avoid decoding retained mailbox content when only counts are needed.
- Add cleanup and bounded-state coverage for watcher dirs, daemon node snapshots, and idle compaction marker tracking.

## Evidence

- Baseline projection benchmark: about 59.27 MB/op and 394.5k allocs/op.
- After-change projection benchmark: about 52.88 MB/op and 375.7k allocs/op.

## Verification

- `nix develop .#ci --command go test ./...`
- `git diff --check origin/main...HEAD`
- `nix flake check`
- `nix build`
- `nix run '.#skill-check'`
- README.md and `skills/*/SKILL.md` deprecated-reference scan

Replaces #529.
Closes #501.
