### PR TITLE
fix(stop): wait on resolved daemon session (#566)

### DIFF
--- a/internal/cli/helptext/stop.txt
+++ b/internal/cli/helptext/stop.txt
@@ -8,8 +8,11 @@ Output:
   Always JSON.
   {"status":"not_running","session":"review"}
   {"status":"stopped","session":"review","context_id":"...","pid":12345}
+  {"status":"stopped","session":"review","daemon_session":"daemon","context_id":"...","pid":12345}
 
 Notes:
   stop resolves the daemon that owns the current tmux session and sends it
-  SIGTERM. In the daemon TUI, pressing q exits the same daemon directly; use q
-  as the manual shutdown path if stop cannot identify the owned daemon.
+  SIGTERM. When the daemon owner differs from the caller session, JSON output
+  includes daemon_session. In the daemon TUI, pressing q exits the same daemon
+  directly; use q as the manual shutdown path if stop cannot identify the owned
+  daemon.

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -18,10 +18,11 @@ import (
 const stopTimeoutSeconds = 10
 
 type stopOutput struct {
-	Status    string `json:"status"`
-	Session   string `json:"session,omitempty"`
-	ContextID string `json:"context_id,omitempty"`
-	PID       int    `json:"pid,omitempty"`
+	Status        string `json:"status"`
+	Session       string `json:"session,omitempty"`
+	DaemonSession string `json:"daemon_session,omitempty"`
+	ContextID     string `json:"context_id,omitempty"`
+	PID           int    `json:"pid,omitempty"`
 }
 
 // RunStop gracefully stops the running postman daemon for this tmux session.
@@ -61,11 +62,15 @@ func RunStop(stdout io.Writer, args []string) error {
 
 	daemonSessionName := config.FindContextSessionName(baseDir, contextID)
 	if daemonSessionName == "" || !config.IsSessionPIDOwnedByCurrentUser(baseDir, contextID, daemonSessionName) {
-		return json.NewEncoder(stdout).Encode(stopOutput{
+		output := stopOutput{
 			Status:    "not_owned",
 			Session:   sessionName,
 			ContextID: contextID,
-		})
+		}
+		if daemonSessionName != "" && daemonSessionName != sessionName {
+			output.DaemonSession = daemonSessionName
+		}
+		return json.NewEncoder(stdout).Encode(output)
 	}
 
 	pidPath := filepath.Join(baseDir, contextID, daemonSessionName, "postman.pid")
@@ -84,13 +89,17 @@ func RunStop(stdout io.Writer, args []string) error {
 
 	deadline := time.Now().Add(stopTimeoutSeconds * time.Second)
 	for time.Now().Before(deadline) {
-		if !config.IsSessionPIDAlive(baseDir, contextID, sessionName) {
-			return json.NewEncoder(stdout).Encode(stopOutput{
+		if !config.IsSessionPIDAlive(baseDir, contextID, daemonSessionName) {
+			output := stopOutput{
 				Status:    "stopped",
 				Session:   sessionName,
 				ContextID: contextID,
 				PID:       pid,
-			})
+			}
+			if daemonSessionName != sessionName {
+				output.DaemonSession = daemonSessionName
+			}
+			return json.NewEncoder(stdout).Encode(output)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,11 +102,86 @@ func TestRunStop_StopsDaemonOwningManagedSession(t *testing.T) {
 	if payload.Session != "managed-session" {
 		t.Fatalf("payload.Session = %q, want managed-session", payload.Session)
 	}
+	if payload.DaemonSession != "daemon-session" {
+		t.Fatalf("payload.DaemonSession = %q, want daemon-session", payload.DaemonSession)
+	}
 	if payload.ContextID != "ctx-owner" {
 		t.Fatalf("payload.ContextID = %q, want ctx-owner", payload.ContextID)
 	}
 	if payload.PID != child.Process.Pid {
 		t.Fatalf("payload.PID = %d, want %d", payload.PID, child.Process.Pid)
+	}
+}
+
+func TestRunStop_StopsDaemonOwnerSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	installFakeTmuxForStop(t, tmpDir, "daemon-session", map[string]string{
+		"daemon-session": "ctx-owner:12345",
+	})
+
+	pidDir := filepath.Join(tmpDir, "ctx-owner", "daemon-session")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll daemon session: %v", err)
+	}
+
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- child.Wait()
+	}()
+	t.Cleanup(func() {
+		if child.ProcessState == nil || !child.ProcessState.Exited() {
+			_ = child.Process.Kill()
+		}
+		select {
+		case <-waitCh:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	if err := config.WriteSessionPIDFile(filepath.Join(pidDir, "postman.pid"), child.Process.Pid); err != nil {
+		t.Fatalf("WriteFile postman.pid: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := RunStop(&stdout, nil); err != nil {
+		t.Fatalf("RunStop: %v", err)
+	}
+
+	var payload stopOutput
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if payload.Status != "stopped" {
+		t.Fatalf("payload.Status = %q, want stopped; full payload: %s", payload.Status, stdout.String())
+	}
+	if payload.Session != "daemon-session" {
+		t.Fatalf("payload.Session = %q, want daemon-session", payload.Session)
+	}
+	if payload.DaemonSession != "" {
+		t.Fatalf("payload.DaemonSession = %q, want empty for owner session", payload.DaemonSession)
+	}
+	if payload.ContextID != "ctx-owner" {
+		t.Fatalf("payload.ContextID = %q, want ctx-owner", payload.ContextID)
+	}
+	if payload.PID != child.Process.Pid {
+		t.Fatalf("payload.PID = %d, want %d", payload.PID, child.Process.Pid)
+	}
+}
+
+func TestRunStop_SourceContractWaitsOnResolvedDaemonSession(t *testing.T) {
+	source := readRepoFile(t, "internal/cli/stop.go")
+
+	if !strings.Contains(source, "config.IsSessionPIDAlive(baseDir, contextID, daemonSessionName)") {
+		t.Fatal("stop.go no longer waits on the resolved daemon owner session")
+	}
+	if strings.Contains(source, "config.IsSessionPIDAlive(baseDir, contextID, sessionName)") {
+		t.Fatal("stop.go still waits on the caller session instead of the resolved daemon owner session")
 	}
 }
 
@@ -119,6 +195,7 @@ func installFakeTmuxForStop(t *testing.T, postmanHome, sessionName string, owner
 		"case \"$*\" in\n" +
 		"  *\"#{session_name}\"*) printf '%s\\n' \"" + sessionName + "\" ;;\n" +
 		"  \"show-options -gqv @a2a_session_on_managed-session\") printf '%s\\n' '" + owners["managed-session"] + "' ;;\n" +
+		"  \"show-options -gqv @a2a_session_on_daemon-session\") printf '%s\\n' '" + owners["daemon-session"] + "' ;;\n" +
 		"  *) exit 1 ;;\n" +
 		"esac\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {


### PR DESCRIPTION
## Summary
- Resolve the daemon owner session before waiting during `stop`.
- Keep stop help text aligned with the corrected behavior.
- Add tests for the resolved-session wait path.

## Verification
- `git status --short --branch` clean on the issue worktree.
- Remote head matches local branch head.
- `nix flake check` passed before publication.
- `nix build` passed before publication.

Closes #566