### PR TITLE
fix(capture-profile): refuse overwrite by default (#573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,13 @@ retained objects; goroutine profiles help explain growing goroutine counts or
 stuck work. Captures are point-in-time and may briefly add CPU and memory
 pressure proportional to profile size, bounded by `--max-bytes`.
 
+By default, `capture-profile` refuses to overwrite an existing output file.
+Pass `--force` to allow overwriting:
+
+```sh
+tmux-a2a-postman capture-profile --type heap --output ./postman-heap.pprof --force
+```
+
 Inspect live session state:
 
 ```sh

--- a/internal/cli/capture_profile.go
+++ b/internal/cli/capture_profile.go
@@ -35,6 +35,7 @@ func runCaptureProfileWithContext(ctx commandContext, args []string) error {
 	profileType := fs.String("type", "", "Profile type: heap or goroutine")
 	output := fs.String("output", "", "Output destination: - for stdout or an explicit file path")
 	maxBytes := fs.Int64("max-bytes", runtimeprofile.DefaultMaxBytes, "Maximum profile bytes to return or write")
+	force := fs.Bool("force", false, "Overwrite an existing output file")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -77,6 +78,7 @@ func runCaptureProfileWithContext(ctx commandContext, args []string) error {
 		ProfileDestination: destination,
 		ProfileOutputPath:  outputPath,
 		ProfileMaxBytes:    *maxBytes,
+		ProfileForce:       *force,
 	}, daemonSubmitTimeout(target.cfg.TmuxTimeout))
 	if err != nil {
 		return fmt.Errorf("daemon submit runtime-profile: %w", err)

--- a/internal/cli/capture_profile_test.go
+++ b/internal/cli/capture_profile_test.go
@@ -138,3 +138,90 @@ func TestRunCaptureProfileFileOutputPrintsMetadataWithoutProfileContent(t *testi
 		t.Fatalf("stdout leaked profile content: %q", stdout.String())
 	}
 }
+
+func TestRunCaptureProfileFileForcePassesThroughRequest(t *testing.T) {
+	baseDir := t.TempDir()
+	installFakeTmuxForCLI(t, baseDir, "review", "worker")
+	outputPath := filepath.Join(t.TempDir(), "heap.pprof")
+
+	var gotRequest projection.DaemonSubmitRequest
+	ctx := commandContext{
+		stdout: &bytes.Buffer{},
+		loadConfig: func(string) (*config.Config, error) {
+			return &config.Config{BaseDir: baseDir, TmuxTimeout: 1}, nil
+		},
+		contextOwnsSession: func(baseDirArg, contextID, sessionName string) bool {
+			return baseDirArg == baseDir && contextID == "ctx-prof" && sessionName == "review"
+		},
+		roundTripDaemonSubmit: func(_ string, request projection.DaemonSubmitRequest, _ time.Duration) (projection.DaemonSubmitResponse, error) {
+			gotRequest = request
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-profile-force",
+				Command:   projection.DaemonSubmitRuntimeProfile,
+				HandledAt: time.Now().UTC().Format(time.RFC3339Nano),
+				RuntimeProfile: &projection.RuntimeProfileCapture{
+					Kind:        runtimeprofile.KindHeap,
+					Destination: "file",
+					Bytes:       10,
+					MaxBytes:    runtimeprofile.DefaultMaxBytes,
+					OutputPath:  outputPath,
+				},
+			}, nil
+		},
+	}
+
+	if err := runCaptureProfileWithContext(ctx, []string{
+		"--context-id", "ctx-prof",
+		"--type", "heap",
+		"--output", outputPath,
+		"--force",
+	}); err != nil {
+		t.Fatalf("runCaptureProfileWithContext(): %v", err)
+	}
+	if !gotRequest.ProfileForce {
+		t.Fatal("ProfileForce = false, want true when --force is passed")
+	}
+}
+
+func TestRunCaptureProfileFileNoForceByDefault(t *testing.T) {
+	baseDir := t.TempDir()
+	installFakeTmuxForCLI(t, baseDir, "review", "worker")
+	outputPath := filepath.Join(t.TempDir(), "heap.pprof")
+
+	var gotRequest projection.DaemonSubmitRequest
+	ctx := commandContext{
+		stdout: &bytes.Buffer{},
+		loadConfig: func(string) (*config.Config, error) {
+			return &config.Config{BaseDir: baseDir, TmuxTimeout: 1}, nil
+		},
+		contextOwnsSession: func(baseDirArg, contextID, sessionName string) bool {
+			return baseDirArg == baseDir && contextID == "ctx-prof" && sessionName == "review"
+		},
+		roundTripDaemonSubmit: func(_ string, request projection.DaemonSubmitRequest, _ time.Duration) (projection.DaemonSubmitResponse, error) {
+			gotRequest = request
+			return projection.DaemonSubmitResponse{
+				RequestID: "req-profile-no-force",
+				Command:   projection.DaemonSubmitRuntimeProfile,
+				HandledAt: time.Now().UTC().Format(time.RFC3339Nano),
+				RuntimeProfile: &projection.RuntimeProfileCapture{
+					Kind:        runtimeprofile.KindHeap,
+					Destination: "file",
+					Bytes:       10,
+					MaxBytes:    runtimeprofile.DefaultMaxBytes,
+					OutputPath:  outputPath,
+				},
+			}, nil
+		},
+	}
+
+	if err := runCaptureProfileWithContext(ctx, []string{
+		"--context-id", "ctx-prof",
+		"--type", "heap",
+		"--output", outputPath,
+	}); err != nil {
+		t.Fatalf("runCaptureProfileWithContext(): %v", err)
+	}
+	if gotRequest.ProfileForce {
+		t.Fatal("ProfileForce = true, want false when --force is not passed")
+	}
+}

--- a/internal/cli/helptext/capture-profile.txt
+++ b/internal/cli/helptext/capture-profile.txt
@@ -12,6 +12,7 @@ Usage:
   tmux-a2a-postman capture-profile --type heap --output ./postman-heap.pprof
   tmux-a2a-postman capture-profile --type goroutine --output ./postman-goroutine.pprof
   tmux-a2a-postman capture-profile --type goroutine --output - > goroutine.pprof
+  tmux-a2a-postman capture-profile --type heap --output ./postman-heap.pprof --force
 
 Flags:
   --type heap|goroutine   Profile type to capture (required)
@@ -19,10 +20,16 @@ Flags:
                           written by the daemon (required)
   --max-bytes N           Maximum profile bytes to return or write
                           (default: 16777216)
+  --force                 Overwrite an existing output file (default: refuse)
 
 Output:
   --output PATH prints JSON metadata after the daemon writes the profile.
   --output - writes raw profile bytes to stdout.
+
+Overwrite policy:
+  --output PATH refuses to overwrite an existing file by default. The daemon
+  returns an error if the destination already exists. Pass --force to allow
+  overwriting. New files are always written atomically regardless of --force.
 
 Operational notes:
   Heap profiles are useful when memory telemetry shows heap growth or retained

--- a/internal/cli/helptext/commands.txt
+++ b/internal/cli/helptext/commands.txt
@@ -32,6 +32,7 @@ capture-profile
   Capture one explicit Go runtime profile from the running daemon.
   Profiling has no default listener or background collector.
   Output: JSON for --output PATH; raw profile bytes for --output -
+  --output PATH refuses to overwrite an existing file; use --force to allow it.
   Usage:
     tmux-a2a-postman capture-profile --type heap --output ./postman-heap.pprof
     tmux-a2a-postman capture-profile --type goroutine --output -
@@ -39,6 +40,7 @@ capture-profile
     --type heap|goroutine   Profile type to capture (required)
     --output -|PATH         Explicit destination (required)
     --max-bytes N           Maximum profile bytes (default: 16777216)
+    --force                 Overwrite an existing output file (default: refuse)
 
 get-status
   Print canonical session status JSON for agents and scripts.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -282,7 +282,7 @@ func handleDaemonSubmitRuntimeProfile(_ string, request projection.DaemonSubmitR
 		if request.ProfileOutputPath == "" {
 			return response, fmt.Errorf("daemon submit runtime-profile file destination missing output path")
 		}
-		if err := writeRuntimeProfileFile(request.ProfileOutputPath, request.RequestID, data); err != nil {
+		if err := writeRuntimeProfileFile(request.ProfileOutputPath, request.RequestID, data, request.ProfileForce); err != nil {
 			return response, err
 		}
 		response.RuntimeProfile = &projection.RuntimeProfileCapture{
@@ -298,7 +298,7 @@ func handleDaemonSubmitRuntimeProfile(_ string, request projection.DaemonSubmitR
 	return response, nil
 }
 
-func writeRuntimeProfileFile(outputPath, requestID string, data []byte) error {
+func writeRuntimeProfileFile(outputPath, requestID string, data []byte, force bool) error {
 	if outputPath == "" {
 		return fmt.Errorf("profile output path is required")
 	}
@@ -314,6 +314,11 @@ func writeRuntimeProfileFile(outputPath, requestID string, data []byte) error {
 			return fmt.Errorf("profile output directory: %w", err)
 		} else if !info.IsDir() {
 			return fmt.Errorf("profile output directory is not a directory")
+		}
+	}
+	if !force {
+		if _, err := os.Stat(outputPath); err == nil {
+			return fmt.Errorf("profile output file already exists: %s (use --force to overwrite)", outputPath)
 		}
 	}
 	tmpPath := outputPath + "." + requestID + ".tmp"

--- a/internal/daemon/daemon_submit_test.go
+++ b/internal/daemon/daemon_submit_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -419,5 +420,93 @@ func TestProcessDaemonSubmitRequest_ConcurrentClaimsPopOnlyOnce(t *testing.T) {
 	}
 	if response.Filename != oldest {
 		t.Fatalf("response.Filename = %q, want %q", response.Filename, oldest)
+	}
+}
+
+func TestProcessDaemonSubmitRequest_RuntimeProfileFileRefusesOverwriteByDefault(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	outputPath := filepath.Join(t.TempDir(), "goroutine.pprof")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("WriteFile existing: %v", err)
+	}
+
+	requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID:          "req-profile-no-overwrite",
+		Command:            projection.DaemonSubmitRuntimeProfile,
+		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		ProfileKind:        runtimeprofile.KindGoroutine,
+		ProfileDestination: "file",
+		ProfileOutputPath:  outputPath,
+		ProfileMaxBytes:    runtimeprofile.DefaultMaxBytes,
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest: %v", err)
+	}
+
+	if _, err := processDaemonSubmitRequest(requestPath); err != nil {
+		t.Fatalf("processDaemonSubmitRequest: %v", err)
+	}
+	response, err := projection.ReadDaemonSubmitResponse(projection.DaemonSubmitResponsePath(sessionDir, "req-profile-no-overwrite"))
+	if err != nil {
+		t.Fatalf("ReadDaemonSubmitResponse: %v", err)
+	}
+	if response.Error == "" {
+		t.Fatal("response.Error = empty, want overwrite refusal error")
+	}
+	if !strings.Contains(response.Error, "already exists") {
+		t.Fatalf("response.Error = %q, want 'already exists'", response.Error)
+	}
+	got, _ := os.ReadFile(outputPath)
+	if string(got) != "existing" {
+		t.Fatalf("existing file was modified: %q", string(got))
+	}
+}
+
+func TestProcessDaemonSubmitRequest_RuntimeProfileFileForceOverwrites(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	outputPath := filepath.Join(t.TempDir(), "goroutine.pprof")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("WriteFile existing: %v", err)
+	}
+
+	requestPath, err := projection.WriteDaemonSubmitRequest(sessionDir, projection.DaemonSubmitRequest{
+		RequestID:          "req-profile-force",
+		Command:            projection.DaemonSubmitRuntimeProfile,
+		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		ProfileKind:        runtimeprofile.KindGoroutine,
+		ProfileDestination: "file",
+		ProfileOutputPath:  outputPath,
+		ProfileMaxBytes:    runtimeprofile.DefaultMaxBytes,
+		ProfileForce:       true,
+	})
+	if err != nil {
+		t.Fatalf("WriteDaemonSubmitRequest: %v", err)
+	}
+
+	if _, err := processDaemonSubmitRequest(requestPath); err != nil {
+		t.Fatalf("processDaemonSubmitRequest: %v", err)
+	}
+	response, err := projection.ReadDaemonSubmitResponse(projection.DaemonSubmitResponsePath(sessionDir, "req-profile-force"))
+	if err != nil {
+		t.Fatalf("ReadDaemonSubmitResponse: %v", err)
+	}
+	if response.Error != "" {
+		t.Fatalf("response.Error = %q, want empty (force overwrite succeeded)", response.Error)
+	}
+	written, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile profile output: %v", err)
+	}
+	if string(written) == "existing" {
+		t.Fatal("file was not overwritten by --force")
+	}
+	if len(written) == 0 {
+		t.Fatal("overwritten profile is empty")
 	}
 }

--- a/internal/projection/daemon_submit.go
+++ b/internal/projection/daemon_submit.go
@@ -41,6 +41,7 @@ type DaemonSubmitRequest struct {
 	ProfileDestination string              `json:"profile_destination,omitempty"`
 	ProfileOutputPath  string              `json:"profile_output_path,omitempty"`
 	ProfileMaxBytes    int64               `json:"profile_max_bytes,omitempty"`
+	ProfileForce       bool                `json:"profile_force,omitempty"`
 }
 
 type RuntimeProfileCapture struct {


### PR DESCRIPTION
## Summary
- Refuse to overwrite existing capture-profile outputs by default.
- Add `--force` behavior and help text for intentional overwrites.
- Cover the overwrite and force paths with tests.

## Verification
- `git status --short --branch` clean on the issue worktree.
- Remote head matches local branch head.
- `nix flake check` passed before publication.
- `nix build` passed before publication.

Closes #573