### PR TITLE
feat(daemon): include RSS in memory snapshots (#553)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,12 @@ The daemon writes passive runtime memory snapshots to `postman.log` at startup
 and every 10 minutes. These `component=daemon_runtime
 event=memory_snapshot source=passive_log` lines are intended for normal log
 analysis and require no operator action. They include only scalar Go memory,
-GC, goroutine, daemon cardinality, and daemon-submit queue counters; they omit
-mailbox body content, pane content, local absolute paths, message identifiers,
-node names, and unbounded lists.
+process RSS when supported by the host OS, GC, goroutine, daemon cardinality,
+and daemon-submit queue counters; they omit mailbox body content, pane content,
+local absolute paths, message identifiers, node names, and unbounded lists.
+Linux snapshots include `rss_bytes`; unsupported hosts or read failures mark
+`rss_supported=false` or `rss_available=false` instead of reporting a
+misleading zero value.
 
 For incident diagnostics, `capture-profile` can capture one heap or goroutine
 profile from the running daemon through an explicit daemon-submit request after

--- a/internal/cli/helptext/get-status.txt
+++ b/internal/cli/helptext/get-status.txt
@@ -49,4 +49,6 @@ Debug diagnostics:
   postman.log at startup and every 10 minutes as
   component=daemon_runtime event=memory_snapshot source=passive_log. Those
   passive log lines are the normal first signal for memory optimization
-  analysis; capture-profile remains an explicit follow-up diagnostic.
+  analysis. On supported hosts they include process RSS as rss_bytes; otherwise
+  rss_supported or rss_available marks RSS unavailable without a zero-value
+  placeholder. capture-profile remains an explicit follow-up diagnostic.

--- a/internal/cli/helptext/start.txt
+++ b/internal/cli/helptext/start.txt
@@ -8,5 +8,6 @@ Output:
   Starts the daemon with the default TUI surface and writes operational logs
   to postman.log.
   postman.log includes passive daemon runtime memory snapshots at startup and
-  every 10 minutes. The snapshots are scalar counters only and do not include
-  mailbox content, pane content, paths, message identifiers, or node names.
+  every 10 minutes. The snapshots are scalar counters only, include process RSS
+  when supported, and do not include mailbox content, pane content, paths,
+  message identifiers, or node names.

--- a/internal/daemon/process_rss.go
+++ b/internal/daemon/process_rss.go
@@ -1,0 +1,21 @@
+package daemon
+
+import "fmt"
+
+type processRSSSnapshot struct {
+	Supported bool
+	Available bool
+	Bytes     uint64
+}
+
+var currentProcessRSSSnapshot = readCurrentProcessRSSSnapshot
+
+func processRSSLogFields(snapshot processRSSSnapshot) string {
+	if !snapshot.Supported {
+		return "rss_supported=false rss_available=false"
+	}
+	if !snapshot.Available {
+		return "rss_supported=true rss_available=false"
+	}
+	return fmt.Sprintf("rss_supported=true rss_available=true rss_bytes=%d", snapshot.Bytes)
+}

--- a/internal/daemon/process_rss_linux.go
+++ b/internal/daemon/process_rss_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func readCurrentProcessRSSSnapshot() processRSSSnapshot {
+	bytes, err := readStatmRSSBytes("/proc/self/statm", os.Getpagesize())
+	if err != nil {
+		return processRSSSnapshot{Supported: true}
+	}
+	return processRSSSnapshot{Supported: true, Available: true, Bytes: bytes}
+}
+
+func readStatmRSSBytes(path string, pageSize int) (uint64, error) {
+	if pageSize <= 0 {
+		return 0, fmt.Errorf("invalid page size %d", pageSize)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(content))
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("statm missing resident page field")
+	}
+	residentPages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	pageSizeBytes := uint64(pageSize)
+	if residentPages > ^uint64(0)/pageSizeBytes {
+		return 0, fmt.Errorf("resident byte count overflow")
+	}
+	return residentPages * pageSizeBytes, nil
+}

--- a/internal/daemon/process_rss_linux_test.go
+++ b/internal/daemon/process_rss_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadStatmRSSBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "statm")
+	if err := os.WriteFile(path, []byte("100 7 0 0 0 0 0\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	bytes, err := readStatmRSSBytes(path, 4096)
+	if err != nil {
+		t.Fatalf("readStatmRSSBytes: %v", err)
+	}
+	if bytes != 7*4096 {
+		t.Fatalf("bytes = %d, want %d", bytes, 7*4096)
+	}
+}
+
+func TestReadStatmRSSBytesRejectsMissingResidentField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "statm")
+	if err := os.WriteFile(path, []byte("100\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := readStatmRSSBytes(path, 4096); err == nil {
+		t.Fatal("readStatmRSSBytes err = nil, want error")
+	}
+}

--- a/internal/daemon/process_rss_unsupported.go
+++ b/internal/daemon/process_rss_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package daemon
+
+func readCurrentProcessRSSSnapshot() processRSSSnapshot {
+	return processRSSSnapshot{}
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -477,11 +477,13 @@ func runtimeDiagnosticsLogLine(reason string, diagnostics *status.RuntimeDiagnos
 	gc := diagnostics.GoRuntime.GC
 	daemon := diagnostics.Daemon
 	submit := diagnostics.DaemonSubmit
+	rss := currentProcessRSSSnapshot()
 
 	return fmt.Sprintf(
-		"postman: component=daemon_runtime event=memory_snapshot source=passive_log reason=%s observed_at=%s heap_alloc_bytes=%d heap_sys_bytes=%d heap_objects=%d stack_inuse_bytes=%d total_alloc_bytes=%d memory_sys_bytes=%d memory_frees_count=%d gc_count=%d gc_next_bytes=%d gc_pause_total_ns=%d gc_last_pause_ns=%d goroutine_count=%d daemon_session_count=%d daemon_node_count=%d daemon_watched_dir_count=%d daemon_claimed_pane_count=%d daemon_active_post_event_count=%d daemon_active_auto_ping_count=%d daemon_active_daemon_submit_count=%d daemon_submit_worker_limit=%d daemon_submit_active_worker_count=%d daemon_submit_active_request_count=%d daemon_submit_pending_request_count=%d daemon_submit_oldest_pending_age_seconds=%d daemon_submit_claimed_request_count=%d daemon_submit_oldest_claimed_age_seconds=%d daemon_submit_late_response_count=%d daemon_submit_oldest_late_response_age_seconds=%d daemon_submit_saturation_count=%d daemon_submit_last_saturated_at=%s",
+		"postman: component=daemon_runtime event=memory_snapshot source=passive_log reason=%s observed_at=%s %s heap_alloc_bytes=%d heap_sys_bytes=%d heap_objects=%d stack_inuse_bytes=%d total_alloc_bytes=%d memory_sys_bytes=%d memory_frees_count=%d gc_count=%d gc_next_bytes=%d gc_pause_total_ns=%d gc_last_pause_ns=%d goroutine_count=%d daemon_session_count=%d daemon_node_count=%d daemon_watched_dir_count=%d daemon_claimed_pane_count=%d daemon_active_post_event_count=%d daemon_active_auto_ping_count=%d daemon_active_daemon_submit_count=%d daemon_submit_worker_limit=%d daemon_submit_active_worker_count=%d daemon_submit_active_request_count=%d daemon_submit_pending_request_count=%d daemon_submit_oldest_pending_age_seconds=%d daemon_submit_claimed_request_count=%d daemon_submit_oldest_claimed_age_seconds=%d daemon_submit_late_response_count=%d daemon_submit_oldest_late_response_age_seconds=%d daemon_submit_saturation_count=%d daemon_submit_last_saturated_at=%s",
 		reason,
 		diagnostics.ObservedAt,
+		processRSSLogFields(rss),
 		mem.HeapAllocBytes,
 		mem.HeapSysBytes,
 		mem.HeapObjects,

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -358,12 +358,22 @@ func TestLogRuntimeDiagnosticsSnapshotWritesPassiveScalarLine(t *testing.T) {
 		log.SetOutput(originalOutput)
 		log.SetFlags(originalFlags)
 	})
+	originalRSS := currentProcessRSSSnapshot
+	currentProcessRSSSnapshot = func() processRSSSnapshot {
+		return processRSSSnapshot{Supported: true, Available: true, Bytes: 123456}
+	}
+	t.Cleanup(func() {
+		currentProcessRSSSnapshot = originalRSS
+	})
 
 	rt.logRuntimeDiagnosticsSnapshot("startup", now)
 	line := buf.String()
 	for _, want := range []string{
 		"postman: component=daemon_runtime event=memory_snapshot source=passive_log reason=startup",
 		"observed_at=2026-06-02T00:00:00Z",
+		"rss_supported=true",
+		"rss_available=true",
+		"rss_bytes=123456",
 		"heap_alloc_bytes=",
 		"heap_sys_bytes=",
 		"heap_objects=",
@@ -395,6 +405,36 @@ func TestLogRuntimeDiagnosticsSnapshotWritesPassiveScalarLine(t *testing.T) {
 		if strings.Contains(line, forbidden) {
 			t.Fatalf("runtime diagnostics log leaked %q in %q", forbidden, line)
 		}
+	}
+}
+
+func TestRuntimeDiagnosticsLogLineMarksUnsupportedRSSExplicitly(t *testing.T) {
+	originalRSS := currentProcessRSSSnapshot
+	currentProcessRSSSnapshot = func() processRSSSnapshot {
+		return processRSSSnapshot{}
+	}
+	t.Cleanup(func() {
+		currentProcessRSSSnapshot = originalRSS
+	})
+
+	diagnostics := status.NewRuntimeDiagnostics(
+		"daemon_runtime",
+		status.DaemonRuntimeCardinality{},
+		status.DaemonSubmitRuntimeDiagnostics{},
+		time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+	)
+
+	line := runtimeDiagnosticsLogLine("interval", &diagnostics)
+	for _, want := range []string{
+		"rss_supported=false",
+		"rss_available=false",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("runtime diagnostics log missing %q in %q", want, line)
+		}
+	}
+	if strings.Contains(line, "rss_bytes=") {
+		t.Fatalf("unsupported RSS log included rss_bytes in %q", line)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add daemon RSS sampling for memory snapshot diagnostics.
- Report unsupported platforms without misleading zero values.
- Document the new memory snapshot field in README and help text.

## Verification
- `git status --short --branch` clean on the issue worktree.
- Remote head matches local branch head.
- `nix flake check` passed before publication.
- `nix build` passed before publication.

Closes #553