### PR TITLE
fix(retention): include snapshot dirs in stale cleanup (#571)

### DIFF
--- a/internal/cli/helptext/directories.txt
+++ b/internal/cli/helptext/directories.txt
@@ -15,4 +15,5 @@ Layout:
           ├── inbox/
           │   └── {node}/     # daemon delivers messages here
           ├── read/           # agent moves messages here after reading
+          ├── snapshot/       # internal: bounded daemon-submit/runtime snapshots
           └── dead-letter/    # unroutable messages land here

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -779,7 +779,7 @@ func isSessionRuntimeDir(path string) bool {
 
 func isKnownSessionRuntimeSubdir(name string) bool {
 	switch name {
-	case "inbox", "post", "draft", "read", "dead-letter":
+	case "inbox", "post", "draft", "read", "dead-letter", "snapshot":
 		return true
 	default:
 		return false

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -487,19 +487,24 @@ func TestCleanupExpiredRuntimeState_PreservesLiveAndDurablePaths(t *testing.T) {
 	liveContext := "ctx-live"
 	liveSession := "20240101-review"
 	liveContextDir := writeRuntimeSessionFixture(t, baseDir, liveContext, liveSession, true)
+	liveSnapshotDir := filepath.Join(liveContextDir, liveSession, "snapshot")
+	writeRuntimeSnapshotFixture(t, liveSnapshotDir)
 	liveLog := filepath.Join(liveContextDir, "postman.log")
 	writeRuntimeFileFixture(t, liveLog, "live log")
 	markOldRuntimePath(t, filepath.Join(liveContextDir, liveSession), staleWhen)
+	markOldRuntimePath(t, liveSnapshotDir, staleWhen)
 	markOldRuntimePath(t, liveLog, staleWhen)
 
 	staleContext := "ctx-stale"
 	staleSession := "main"
 	staleContextDir := writeRuntimeSessionFixture(t, baseDir, staleContext, staleSession, false)
 	staleSessionDir := filepath.Join(staleContextDir, staleSession)
+	staleSnapshotDir := filepath.Join(staleSessionDir, "snapshot")
 	staleLog := filepath.Join(staleContextDir, "postman.log")
 	stalePaneActivity := filepath.Join(staleContextDir, "pane-activity.json")
 	staleUnknown := filepath.Join(staleContextDir, "scratch-cache")
 
+	writeRuntimeSnapshotFixture(t, staleSnapshotDir)
 	writeRuntimeFileFixture(t, staleLog, "old log")
 	writeRuntimeFileFixture(t, stalePaneActivity, "{}")
 	if err := os.MkdirAll(staleUnknown, 0o700); err != nil {
@@ -520,8 +525,10 @@ func TestCleanupExpiredRuntimeState_PreservesLiveAndDurablePaths(t *testing.T) {
 
 	assertPathExists(t, lockDir)
 	assertPathExists(t, filepath.Join(liveContextDir, liveSession))
+	assertPathExists(t, liveSnapshotDir)
 	assertPathExists(t, liveLog)
 	assertPathMissing(t, staleSessionDir)
+	assertPathMissing(t, staleSnapshotDir)
 	assertPathMissing(t, staleLog)
 	assertPathMissing(t, stalePaneActivity)
 	assertPathExists(t, staleUnknown)
@@ -579,6 +586,23 @@ func writeRuntimeFileFixture(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile(%q): %v", path, err)
 	}
+}
+
+func writeRuntimeSnapshotFixture(t *testing.T, snapshotDir string) {
+	t.Helper()
+
+	for _, dir := range []string{
+		filepath.Join(snapshotDir, "runtime-context"),
+		filepath.Join(snapshotDir, "daemon-submit", "requests"),
+		filepath.Join(snapshotDir, "daemon-submit", "responses"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+	writeRuntimeFileFixture(t, filepath.Join(snapshotDir, "runtime-context", "rctx_test.json"), "{}")
+	writeRuntimeFileFixture(t, filepath.Join(snapshotDir, "daemon-submit", "requests", "req-test.json"), "{}")
+	writeRuntimeFileFixture(t, filepath.Join(snapshotDir, "daemon-submit", "responses", "req-test.json"), "{}")
 }
 
 func markOldRuntimePath(t *testing.T, path string, when time.Time) {


### PR DESCRIPTION
## Summary
- Include runtime snapshot directories in stale session cleanup.
- Update directory help text for the retained snapshot paths.
- Add tests for snapshot directory cleanup classification.

## Verification
- `git status --short --branch` clean on the issue worktree.
- Remote head matches local branch head.
- `nix flake check` passed before publication.
- `nix build` passed before publication.

Closes #571