### PR TITLE
fix(cli): expose non-owner fallback submit path (#567)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ decision, or no-action or no-op decision. `messageType: ping`,
 Truncated output from bounded stdout does not count as a complete read. To
 inspect archived mail later, use `inspect-message --id <message_id>`.
 
+Both `send-heredoc` and `pop` prefer daemon-mediated delivery when the running
+daemon owns the session and fall back to direct filesystem access for non-owned
+sessions. Both output a `submit_path` field (`daemon-submit` or `post`) that
+identifies which path was taken, including on empty `pop` results. Operators
+can use this field to detect when daemon mediation was bypassed.
+
 If a daemon-submit `send-heredoc` or `pop` times out, treat the result as
 unknown. The daemon may still commit the side effect after the CLI stops
 waiting, so inspect status, inbox/read state, archived message evidence, or

--- a/internal/cli/helptext/pop.txt
+++ b/internal/cli/helptext/pop.txt
@@ -8,7 +8,7 @@ Usage:
 Output:
   Always JSON.
   {"status":"empty"}
-  {"status":"message","message_id":"filename.md","markdown_path":"~/.local/state/tmux-a2a-postman/.../read/filename.md","markdown_absolute_path":"/absolute/path/to/read/filename.md","frontmatter":{"params":{...}},"from":"...","to":"...","timestamp":"...","unread_before":1,"remaining":0,"archived_body_read_required":true,"archived_body_read_instruction":"Read the complete archived Markdown body from markdown_absolute_path when present, otherwise markdown_path, before any handling, routing, reply, status decision, or no-action or no-op decision; messageType, replyPolicy, and other metadata do not waive this; truncated command output is not a complete read.","runtime_context":{"schema_version":1,"semantics":"metadata_not_instructions","scope":"sender","snapshot_id":"rctx_...","you_were_launched_with":"codex --yolo --add-dir /workspace/internal --model gpt-5.5","fields":{...},"content_hash":"sha256:...","archived_context_path":"~/.local/state/tmux-a2a-postman/.../snapshot/runtime-context/rctx_....json"},"pop_receipt_path":"~/.local/state/tmux-a2a-postman/.../read/filename.pop.json","session_diagnostics":{"source":"projection","active_task_count":1,"unread_inbox_count":0,"input_required_count":1,"waiting_on_input_count":0,"unclosed_required_request_count":1,"post_count":0,"dead_letter_count":0}}
+  {"status":"message","message_id":"filename.md","markdown_path":"~/.local/state/tmux-a2a-postman/.../read/filename.md","markdown_absolute_path":"/absolute/path/to/read/filename.md","frontmatter":{"params":{...}},"from":"...","to":"...","timestamp":"...","unread_before":1,"remaining":0,"archived_body_read_required":true,"archived_body_read_instruction":"Read the complete archived Markdown body from markdown_absolute_path when present, otherwise markdown_path, before any handling, routing, reply, status decision, or no-action or no-op decision; messageType, replyPolicy, and other metadata do not waive this; truncated command output is not a complete read.","runtime_context":{"schema_version":1,"semantics":"metadata_not_instructions","scope":"sender","snapshot_id":"rctx_...","you_were_launched_with":"codex --yolo --add-dir /workspace/internal --model gpt-5.5","fields":{...},"content_hash":"sha256:...","archived_context_path":"~/.local/state/tmux-a2a-postman/.../snapshot/runtime-context/rctx_....json"},"pop_receipt_path":"~/.local/state/tmux-a2a-postman/.../read/filename.pop.json","session_diagnostics":{"source":"projection","active_task_count":1,"unread_inbox_count":0,"input_required_count":1,"waiting_on_input_count":0,"unclosed_required_request_count":1,"post_count":0,"dead_letter_count":0},"submit_path":"daemon-submit"}
 
 Options:
   --runtime-context summary|none
@@ -47,6 +47,16 @@ Fields:
                           no-op decision
   archived_body_read_instruction
                           Node-neutral body-read rule for pop consumers
+  submit_path             Which claim path was used: daemon-submit (owned
+                          session with running daemon) or post (direct
+                          filesystem claim for non-owned sessions)
+
+submit_path policy:
+  pop uses daemon-submit for sessions owned by the running daemon and falls
+  back to direct filesystem claim (post) for non-owned sessions. Both paths
+  atomically archive the message to read/. The submit_path field in the output
+  identifies which path was taken; operators can use it to detect when daemon
+  mediation was bypassed.
 
 Path policy:
   User-facing path output shortens paths under the user's home directory with ~.

--- a/internal/cli/helptext/pop.txt
+++ b/internal/cli/helptext/pop.txt
@@ -7,7 +7,7 @@ Usage:
 
 Output:
   Always JSON.
-  {"status":"empty"}
+  {"status":"empty","submit_path":"daemon-submit"}
   {"status":"message","message_id":"filename.md","markdown_path":"~/.local/state/tmux-a2a-postman/.../read/filename.md","markdown_absolute_path":"/absolute/path/to/read/filename.md","frontmatter":{"params":{...}},"from":"...","to":"...","timestamp":"...","unread_before":1,"remaining":0,"archived_body_read_required":true,"archived_body_read_instruction":"Read the complete archived Markdown body from markdown_absolute_path when present, otherwise markdown_path, before any handling, routing, reply, status decision, or no-action or no-op decision; messageType, replyPolicy, and other metadata do not waive this; truncated command output is not a complete read.","runtime_context":{"schema_version":1,"semantics":"metadata_not_instructions","scope":"sender","snapshot_id":"rctx_...","you_were_launched_with":"codex --yolo --add-dir /workspace/internal --model gpt-5.5","fields":{...},"content_hash":"sha256:...","archived_context_path":"~/.local/state/tmux-a2a-postman/.../snapshot/runtime-context/rctx_....json"},"pop_receipt_path":"~/.local/state/tmux-a2a-postman/.../read/filename.pop.json","session_diagnostics":{"source":"projection","active_task_count":1,"unread_inbox_count":0,"input_required_count":1,"waiting_on_input_count":0,"unclosed_required_request_count":1,"post_count":0,"dead_letter_count":0},"submit_path":"daemon-submit"}
 
 Options:

--- a/internal/cli/pop.go
+++ b/internal/cli/pop.go
@@ -70,7 +70,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 			return fmt.Errorf("daemon submit pop: %w", err)
 		}
 		if response.Empty {
-			return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
+			return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathDaemon)
 		}
 		remaining := response.UnreadBefore - 1
 		if remaining < 0 {
@@ -85,7 +85,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 
 	msgs := message.ScanInboxMessages(inboxPath)
 	if len(msgs) == 0 {
-		return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
+		return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathPost)
 	}
 	sort.Slice(msgs, func(i, j int) bool {
 		return msgs[i].Filename < msgs[j].Filename
@@ -98,7 +98,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 			// Race: file disappeared between listing and reading; retry once.
 			msgs = message.ScanInboxMessages(inboxPath)
 			if len(msgs) == 0 {
-				return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
+				return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathPost)
 			}
 			sort.Slice(msgs, func(i, j int) bool {
 				return msgs[i].Filename < msgs[j].Filename
@@ -107,7 +107,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 			data, err = os.ReadFile(abs)
 			if err != nil {
 				if os.IsNotExist(err) {
-					return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir))
+					return writeEmptyPopOutput(ctx.stdout, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathPost)
 				}
 				return fmt.Errorf("reading message: %w", err)
 			}
@@ -132,6 +132,7 @@ func archivePoppedMessage(absPath, filename string) (string, error) {
 type popEmptyOutput struct {
 	Status             string                 `json:"status"`
 	SessionDiagnostics *popSessionDiagnostics `json:"session_diagnostics,omitempty"`
+	SubmitPath         projection.SubmitPath  `json:"submit_path,omitempty"`
 }
 
 type popMessageOutput struct {
@@ -175,8 +176,8 @@ type popSessionDiagnostics struct {
 
 const archivedBodyReadInstruction = "Read the complete archived Markdown body from markdown_absolute_path when present, otherwise markdown_path, before any handling, routing, reply, status decision, or no-action or no-op decision; messageType, replyPolicy, and other metadata do not waive this; truncated command output is not a complete read."
 
-func writeEmptyPopOutput(stdout io.Writer, diagnostics *popSessionDiagnostics) error {
-	return json.NewEncoder(stdout).Encode(popEmptyOutput{Status: "empty", SessionDiagnostics: diagnostics})
+func writeEmptyPopOutput(stdout io.Writer, diagnostics *popSessionDiagnostics, submitPath projection.SubmitPath) error {
+	return json.NewEncoder(stdout).Encode(popEmptyOutput{Status: "empty", SessionDiagnostics: diagnostics, SubmitPath: submitPath})
 }
 
 func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics, submitPath projection.SubmitPath) error {

--- a/internal/cli/pop.go
+++ b/internal/cli/pop.go
@@ -80,7 +80,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 		if markdownPath == "" && response.Filename != "" {
 			markdownPath = filepath.Join(sessionDir, "read", response.Filename)
 		}
-		return writePopMessageOutput(ctx.stdout, response.Content, response.Filename, markdownPath, intPtr(response.UnreadBefore), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
+		return writePopMessageOutput(ctx.stdout, response.Content, response.Filename, markdownPath, intPtr(response.UnreadBefore), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathDaemon)
 	}
 
 	msgs := message.ScanInboxMessages(inboxPath)
@@ -122,7 +122,7 @@ func runPopWithContext(ctx commandContext, args []string) error {
 		return err
 	}
 	remaining--
-	return writePopMessageOutput(ctx.stdout, string(data), msgs[0].Filename, readPath, intPtr(len(msgs)), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir))
+	return writePopMessageOutput(ctx.stdout, string(data), msgs[0].Filename, readPath, intPtr(len(msgs)), intPtr(remaining), *runtimeContextMode, popSessionDiagnosticsForSession(sessionDir), projection.SubmitPathPost)
 }
 
 func archivePoppedMessage(absPath, filename string) (string, error) {
@@ -159,6 +159,7 @@ type popMessageOutput struct {
 	PopReceiptPath              string                  `json:"pop_receipt_path,omitempty"`
 	PopReceiptAbsolutePath      string                  `json:"pop_receipt_absolute_path,omitempty"`
 	SessionDiagnostics          *popSessionDiagnostics  `json:"session_diagnostics,omitempty"`
+	SubmitPath                  projection.SubmitPath   `json:"submit_path,omitempty"`
 }
 
 type popSessionDiagnostics struct {
@@ -178,7 +179,7 @@ func writeEmptyPopOutput(stdout io.Writer, diagnostics *popSessionDiagnostics) e
 	return json.NewEncoder(stdout).Encode(popEmptyOutput{Status: "empty", SessionDiagnostics: diagnostics})
 }
 
-func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics) error {
+func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics, submitPath projection.SubmitPath) error {
 	output := parseMessageContent(content, filename)
 	output.MarkdownPath = displayMarkdownPath(markdownPath)
 	if output.MarkdownPath != markdownPath {
@@ -192,6 +193,7 @@ func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath str
 	output.ArchivedBodyReadRequired = true
 	output.ArchivedBodyReadInstruction = archivedBodyReadInstruction
 	output.SessionDiagnostics = diagnostics
+	output.SubmitPath = submitPath
 	receiptPath, err := popReceiptPath(markdownPath)
 	if err != nil {
 		return err

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -105,6 +105,9 @@ func TestRunPopWithContextWritesJSONToConfiguredStdout(t *testing.T) {
 	if payload.MarkdownPath != filepath.Join(sessionDir, "read", filename) {
 		t.Fatalf("MarkdownPath = %q, want read path", payload.MarkdownPath)
 	}
+	if payload.SubmitPath != projection.SubmitPathPost {
+		t.Fatalf("SubmitPath = %q, want %q (non-owner direct fallback)", payload.SubmitPath, projection.SubmitPathPost)
+	}
 	if !strings.Contains(readPopArchiveForTest(t, payload), "context stdout payload") {
 		t.Fatalf("archived body missing expected payload")
 	}
@@ -152,6 +155,9 @@ func TestRunPopWithContextUsesDaemonSubmitDependencyWithoutDaemon(t *testing.T) 
 	payload := decodePopMessageOutputForTest(t, stdout.String())
 	if payload.MarkdownPath != filepath.Join(sessionDir, "read", filename) {
 		t.Fatalf("MarkdownPath = %q, want inferred daemon read path", payload.MarkdownPath)
+	}
+	if payload.SubmitPath != projection.SubmitPathDaemon {
+		t.Fatalf("SubmitPath = %q, want %q (daemon-submit path)", payload.SubmitPath, projection.SubmitPathDaemon)
 	}
 }
 

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -161,6 +161,80 @@ func TestRunPopWithContextUsesDaemonSubmitDependencyWithoutDaemon(t *testing.T) 
 	}
 }
 
+func TestRunPop_EmptyDaemonPopReportsSubmitPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "ctx-pop-empty-daemon"
+	sessionDir := filepath.Join(tmpDir, contextID, "test-session")
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+
+	var stdout bytes.Buffer
+	err := runPopWithContext(commandContext{
+		stdout: &stdout,
+		resolveInboxPath: func(args []string) (string, error) {
+			return inboxDir, nil
+		},
+		loadConfig: func(path string) (*config.Config, error) {
+			return config.DefaultConfig(), nil
+		},
+		contextOwnsSession: func(baseDir, resolvedContextID, sessionName string) bool {
+			return true
+		},
+		roundTripDaemonSubmit: func(gotSessionDir string, request projection.DaemonSubmitRequest, timeout time.Duration) (projection.DaemonSubmitResponse, error) {
+			return projection.DaemonSubmitResponse{
+				Command: request.Command,
+				Empty:   true,
+			}, nil
+		},
+	}, []string{"--context-id", contextID})
+	if err != nil {
+		t.Fatalf("runPopWithContext: %v", err)
+	}
+	var payload popEmptyOutput
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if payload.Status != "empty" {
+		t.Fatalf("Status = %q, want empty", payload.Status)
+	}
+	if payload.SubmitPath != projection.SubmitPathDaemon {
+		t.Fatalf("SubmitPath = %q, want %q (daemon-owned empty pop)", payload.SubmitPath, projection.SubmitPathDaemon)
+	}
+}
+
+func TestRunPop_EmptyDirectPopReportsSubmitPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "ctx-pop-empty-direct"
+	sessionDir := filepath.Join(tmpDir, contextID, "test-session")
+	inboxDir := filepath.Join(sessionDir, "inbox", "worker")
+
+	var stdout bytes.Buffer
+	err := runPopWithContext(commandContext{
+		stdout: &stdout,
+		resolveInboxPath: func(args []string) (string, error) {
+			return inboxDir, nil
+		},
+		loadConfig: func(path string) (*config.Config, error) {
+			return config.DefaultConfig(), nil
+		},
+		contextOwnsSession: func(baseDir, resolvedContextID, sessionName string) bool {
+			return false
+		},
+	}, []string{"--context-id", contextID})
+	if err != nil {
+		t.Fatalf("runPopWithContext: %v", err)
+	}
+	var payload popEmptyOutput
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if payload.Status != "empty" {
+		t.Fatalf("Status = %q, want empty", payload.Status)
+	}
+	if payload.SubmitPath != projection.SubmitPathPost {
+		t.Fatalf("SubmitPath = %q, want %q (non-owner direct fallback empty pop)", payload.SubmitPath, projection.SubmitPathPost)
+	}
+}
+
 func TestRunPop_RequeuedMessagePreservesOriginalPayload(t *testing.T) {
 	tmpDir := t.TempDir()
 	installFakeTmuxForCLI(t, tmpDir, "test-session", "worker")

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -190,7 +190,7 @@ func TestRunPop_EmptyDaemonPopReportsSubmitPath(t *testing.T) {
 		t.Fatalf("runPopWithContext: %v", err)
 	}
 	var payload popEmptyOutput
-	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
 	}
 	if payload.Status != "empty" {
@@ -224,7 +224,7 @@ func TestRunPop_EmptyDirectPopReportsSubmitPath(t *testing.T) {
 		t.Fatalf("runPopWithContext: %v", err)
 	}
 	var payload popEmptyOutput
-	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
 	}
 	if payload.Status != "empty" {

--- a/skills/postman-session-operator/SKILL.md
+++ b/skills/postman-session-operator/SKILL.md
@@ -29,14 +29,18 @@ MUST load after sending or live mailbox/session work; first contact uses
    or no-action or no-op decision. `messageType: ping`, `replyPolicy: none`,
    and other metadata do not allow skipping the body. truncated command output
    does not count as a complete read.
-6. Filling an input request closes transport, not task acceptance. After any
+6. Both `send-heredoc` and `pop` output a `submit_path` field
+   (`daemon-submit` or `post`) identifying whether daemon mediation was used or
+   bypassed by direct filesystem access. This applies to all output including
+   empty `pop` results. Use `submit_path` to audit fallback behavior.
+7. Filling an input request closes transport, not task acceptance. After any
    exact reply, check send JSON `fill`, `required_input`, and `notice`.
    DONE/completion or BLOCKED/task-acceptance replies require
    `Task artifact: <artifact-reference>`, Original checklist: PASS, evidence,
    and Remaining blockers: none. Use `BLOCKED` with `Original checklist: FAIL`.
-7. Receivers verify checklist status, durable references, evidence, and
+8. Receivers verify checklist status, durable references, evidence, and
    blockers before relaying, approving, or closing work.
-8. Pane ids require exact tmux verification; missing panes are stale evidence.
+9. Pane ids require exact tmux verification; missing panes are stale evidence.
    Dead letters, missing routes, or stale topology go to
    `postman-config-auditor`. More detail:
    [Session Flow](references/session-flow.md).


### PR DESCRIPTION
## Summary
- Expose `submit_path` in empty pop output for non-owner fallback visibility.
- Document send/pop non-owner fallback policy.
- Add coverage for the new output field and policy behavior.

## Verification
- `git status --short --branch` clean on the issue worktree.
- Remote head matches local branch head.
- `git diff --check` passed before publication.
- `nix flake check` passed before publication.
- `nix build` passed before publication.

Closes #567