### PR TITLE
fix(config): stop a skill_path SKILL.md from aborting the whole config load (#612)

### DIFF
--- a/internal/config/markdown_test.go
+++ b/internal/config/markdown_test.go
@@ -849,6 +849,89 @@ skill_path:
 	assertContains(t, cfg.CommonTemplate, "- `markdown`: Markdown rules.")
 }
 
+// Regression for issue #612: a SKILL.md carrying standard nested-YAML
+// frontmatter (a `metadata:` mapping) and a block-scalar description must not
+// abort the whole postman.md config load. The strict frontmatter parser used
+// to reject the indented `metadata:` lines, and that error bubbled up and
+// discarded edges/nodes, leaving the daemon with zero ping targets.
+func TestLoadMarkdownConfig_SkillPathNestedYAMLFrontmatterDoesNotAbortConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "skills", "collab", "SKILL.md"), `---
+name: collab
+license: MIT
+metadata:
+  version: "1.0.0"
+description: |
+  Collaboration helper skill.
+---
+`)
+	content := `---
+skill_path:
+  - path: skills
+---
+
+## ` + "`edges`" + `
+
+` + "```mermaid" + `
+graph LR
+    agent --- orchestrator
+` + "```" + `
+`
+	path := filepath.Join(dir, "postman.md")
+	writeFile(t, path, content)
+
+	cfg, err := loadMarkdownConfig(path)
+	if err != nil {
+		t.Fatalf("loadMarkdownConfig error: %v", err)
+	}
+	// Edges must survive — discovery and ping-target selection depend on them.
+	if len(cfg.Edges) == 0 {
+		t.Fatal("edges were dropped; SKILL.md nested frontmatter aborted the config load")
+	}
+	// The nested-frontmatter skill still yields name + description.
+	assertContains(t, cfg.CommonTemplate, "- `collab`: Collaboration helper skill.")
+}
+
+// Regression for issue #612 (defect B): a single genuinely unparseable
+// SKILL.md in a skill_path directory must be skipped with a warning, not
+// abort the entire catalog load (and with it every edge/node).
+func TestLoadMarkdownConfig_SkillPathUnparseableSkillIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "skills", "broken", "SKILL.md"), `---
+this line has no colon and is not a list item
+---
+`)
+	writeFile(t, filepath.Join(dir, "skills", "good", "SKILL.md"), `---
+name: good
+description: A valid skill.
+---
+`)
+	content := `---
+skill_path:
+  - path: skills
+---
+
+## ` + "`edges`" + `
+
+` + "```mermaid" + `
+graph LR
+    agent --- orchestrator
+` + "```" + `
+`
+	path := filepath.Join(dir, "postman.md")
+	writeFile(t, path, content)
+
+	cfg, err := loadMarkdownConfig(path)
+	if err != nil {
+		t.Fatalf("loadMarkdownConfig error: %v", err)
+	}
+	if len(cfg.Edges) == 0 {
+		t.Fatal("edges were dropped; one bad SKILL.md aborted the whole catalog")
+	}
+	assertContains(t, cfg.CommonTemplate, "- `good`: A valid skill.")
+	assertNotContains(t, cfg.CommonTemplate, "- `broken`")
+}
+
 func TestLoadMarkdownConfig_SkillPathExplicitAllSkillName(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "skills", "all", "SKILL.md"), `---

--- a/internal/config/skill_catalog.go
+++ b/internal/config/skill_catalog.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -119,7 +120,11 @@ func loadSkillCatalog(markdownPath, skillPath string) ([]skillCatalogEntry, stri
 		}
 		entry, err := parseSkillCatalogEntry(skillFile)
 		if err != nil {
-			return nil, resolvedPath, err
+			// A single unparseable SKILL.md must not abort the whole catalog —
+			// and with it the entire postman.md config load (issue #612). Warn
+			// and skip just this skill so edges/nodes still load.
+			log.Printf("postman: WARNING: skipping skill %s: %v\n", dirEntry.Name(), err)
+			continue
 		}
 		if entry.Name == "" {
 			entry.Name = dirEntry.Name()
@@ -254,8 +259,18 @@ func parseSkillFrontmatter(content string) (map[string]string, error) {
 		if trimmed == "" {
 			continue
 		}
+		// Indented lines belong to a nested mapping or sequence under a
+		// previous top-level key (e.g. the `metadata:` block that standard
+		// SKILL.md frontmatter carries). We only consume top-level `name` and
+		// `description`, so skip nested content instead of failing — otherwise
+		// one third-party SKILL.md aborts the entire config load (issue #612).
 		if hasIndentPrefix(line) {
-			return nil, unsupportedFrontmatterSyntaxError(i+1, line)
+			continue
+		}
+		// Top-level YAML sequence item. SKILL.md frontmatter is a mapping, so
+		// this only appears as part of a value we ignore; skip it.
+		if trimmed == "-" || strings.HasPrefix(trimmed, "- ") {
+			continue
 		}
 		idx := strings.Index(line, ":")
 		if idx == -1 {


### PR DESCRIPTION
Closes #612

## Summary

A `postman.md` whose `skill_path` points at a directory of third-party `SKILL.md` files was silently discarded whenever any one of those files carried standard nested-YAML frontmatter (a `metadata:` mapping) or other syntax the strict postman frontmatter parser rejects. The parse error bubbled up through the skill-catalog loader into `loadMarkdownConfig`, so the **entire `postman.md`** — including `edges` and `nodes` — was skipped. With an empty topology the daemon selected **zero ping targets** and the TUI showed `Nodes not yet discovered for session ... — press 'p' again`.

## Root cause

- `postman.md` frontmatter: `skill_path` → a skills directory.
- One skill's `SKILL.md` used legitimate frontmatter such as:
  ```yaml
  ---
  name: collaboration
  license: MIT
  metadata:
    version: "1.0.0"
  description: |
    ...
  ---
  ```
- `parseSkillFrontmatter` (`internal/config/skill_catalog.go`) hard-errored on the indented `metadata:` lines.
- The dir-walk loader `loadSkillCatalog` returned that error, which propagated to `loadMarkdownConfig`, dropping the whole config.
- Empty `cfg.Edges`/`cfg.Nodes` → empty `candidateNodes` → `EdgeNodeAllowed` always false → `preclaimSessionCandidatePanes` claims 0 panes and `filterDiscoveredActivationNodes` drops every node → 0 ping targets.

## Changes

- `parseSkillFrontmatter` now skips nested mapping/sequence lines instead of erroring. It only needs `name` and `description`; nested `metadata:` blocks and list values are ignored.
- `loadSkillCatalog` (directory walk) warns and skips an individual skill whose frontmatter still fails to parse, so one bad file can never discard the daemon's routing topology (defense in depth).
- Adds two regression tests: nested-YAML frontmatter, and a genuinely unparseable `SKILL.md`; both assert `edges` survive the load.

## Verification

- `go vet ./internal/config/` — clean
- `go test ./internal/config/` — pass (incl. new tests)
- `nix build` — success
- `nix flake check` — all checks passed
- Built binary run against the real config that triggered the bug: the `skipping postman.md` warning is gone and `postman.md` loads cleanly.