### PR TITLE
feat(runtime): explicit-config workspace tree hierarchy coordination (#504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,22 @@ Implement the requested change and report DONE or BLOCKED.
 POSTMAN_BODY
 ```
 
+When `postman.toml` defines workspace tree hierarchy, `send-heredoc` also
+accepts tree aliases and writes the compiled explicit recipient into the
+message:
+
+```sh
+tmux-a2a-postman send-heredoc --to @parent <<'POSTMAN_BODY'
+Coordinate this project with the configured parent session.
+POSTMAN_BODY
+```
+
+Use `@parent/<node>` to address a specific parent node, or
+`@child/<label-or-session-or-id>` to address a configured child
+representative. Message footers keep the concrete `session:node` recipient and
+add relationship aliases, such as `@parent` or `@child/api`, when they are
+available.
+
 Read the next inbox message:
 
 ```sh
@@ -442,11 +458,18 @@ Most users only maintain `postman.md` under the global config directory:
 - `~/.config/tmux-a2a-postman/` fallback when `XDG_CONFIG_HOME` is unset
 
 `postman.toml` is optional. Embedded defaults are enough for the daemon to run;
-add TOML only when you need to change daemon-level defaults.
+add TOML only when you need to change daemon-level defaults or define workspace
+tree hierarchy for tree aliases.
 
 The daemon reads global configuration once at startup. Restart it after editing
 `postman.md`, `postman.toml`, or `nodes/*`; runtime watchers continue to handle
 mail delivery, read/archive moves, and daemon submit queues.
+
+Workspace tree hierarchy is explicit TOML metadata; it is not inferred from
+checkout layout or live pane cwd. Each record names a session, optional stable
+ID, optional label, optional parent session, and sibling order. Status output
+reports labels and stable IDs only. Duplicate session records are reported as
+ambiguous.
 
 In `postman.md`, keep conversation edges in the Mermaid `edges` graph, durable
 role guidance under role headings, and optional `skill_path` catalogs in the

--- a/internal/cli/send_message.go
+++ b/internal/cli/send_message.go
@@ -22,6 +22,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/runtimecontext"
 	"github.com/i9wa4/tmux-a2a-postman/internal/template"
+	"github.com/i9wa4/tmux-a2a-postman/internal/workspacetree"
 )
 
 type sendStatus string
@@ -166,8 +167,14 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 	if *to == "" {
 		return fmt.Errorf("--to is required")
 	}
-	if err := cliutil.ValidateNodeAddress("--to", *to); err != nil {
-		return err
+	if workspacetree.IsAlias(*to) {
+		if err := workspacetree.ValidateAliasSyntax(*to); err != nil {
+			return fmt.Errorf("--to %q: workspace tree alias: %w", *to, err)
+		}
+	} else {
+		if err := cliutil.ValidateNodeAddress("--to", *to); err != nil {
+			return err
+		}
 	}
 	bodyText, err := resolveSendHeredocBody(ctx.stdin, ctx.stdinIsTerminal(ctx.stdin))
 	if err != nil {
@@ -207,6 +214,18 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid session name: %w", err)
 	}
+	recipient := *to
+	if workspacetree.IsAlias(recipient) {
+		resolution := workspacetree.BuildFromConfig(cfg).ResolveAlias(recipient, sessionName, nil)
+		if !resolution.Found {
+			return fmt.Errorf("workspace tree alias %q failed: %s", recipient, resolution.FailureReason)
+		}
+		recipient = resolution.Address
+	}
+	if err := cliutil.ValidateNodeAddress("--to", recipient); err != nil {
+		return err
+	}
+	workspaceTopology := workspacetree.BuildFromConfig(cfg)
 
 	var resolvedContextID string
 	if *contextID != "" {
@@ -225,7 +244,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parsing edges: %w", err)
 	}
-	recipientSessionName, recipientSimpleName, recipientHasSession := nodeaddr.Split(*to)
+	recipientSessionName, recipientSimpleName, recipientHasSession := nodeaddr.Split(recipient)
 	senderCandidates := []string{sender}
 	senderFullName := nodeaddr.Full(sender, sessionName)
 	if senderFullName != sender {
@@ -248,10 +267,10 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 			talksToList = append(talksToList, neighbor)
 		}
 	}
-	recipientCandidates := []string{*to}
+	recipientCandidates := []string{recipient}
 	if !recipientHasSession {
 		recipientFullName := nodeaddr.Full(recipientSimpleName, sessionName)
-		if recipientFullName != *to {
+		if recipientFullName != recipient {
 			recipientCandidates = append(recipientCandidates, recipientFullName)
 		}
 	} else if recipientSessionName == sessionName {
@@ -269,7 +288,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		}
 	}
 	if !recipientPresent {
-		return fmt.Errorf("missing receiver: %q is not present in configured edges", *to)
+		return fmt.Errorf("missing receiver: %q is not present in configured edges", recipient)
 	}
 	recipientAllowed := false
 	for _, n := range talksToList {
@@ -285,7 +304,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 	}
 	if !recipientAllowed {
 		return fmt.Errorf("edge violation: %q cannot send to %q — not allowed; allowed recipients: %s",
-			sender, *to, canTalkTo)
+			sender, recipient, canTalkTo)
 	}
 	sessionDir := filepath.Join(baseDir, resolvedContextID, sessionName)
 	beforeInputRequests, beforeInputRequestsOK := projectSendInputRequestState(sessionDir, sessionName)
@@ -296,7 +315,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 
 	now := time.Now()
 	ts := now.Format("20060102-150405")
-	filename, err := message.GenerateFilename(ts, sender, *to, sessionName)
+	filename, err := message.GenerateFilename(ts, sender, recipient, sessionName)
 	if err != nil {
 		return fmt.Errorf("generating filename: %w", err)
 	}
@@ -327,12 +346,12 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 	vars := map[string]string{
 		"context_id":                     resolvedContextID,
 		"sender":                         sender,
-		"recipient":                      *to,
+		"recipient":                      recipient,
 		"timestamp":                      now.Format(time.RFC3339),
 		"can_talk_to":                    canTalkTo,
-		"contacts_section":               envelope.ContactSection(cfg, talksToList),
+		"contacts_section":               contactSectionForViewpoint(cfg, workspaceTopology, talksToList, senderFullName),
 		"session_dir":                    filepath.Join(baseDir, resolvedContextID, sessionName),
-		"reply_command":                  strings.ReplaceAll(envelope.RenderReplyCommand(cfg.ReplyCommand, resolvedContextID, *to), "<recipient>", *to),
+		"reply_command":                  strings.ReplaceAll(envelope.RenderReplyCommand(cfg.ReplyCommand, resolvedContextID, recipient), "<recipient>", recipient),
 		"message_id":                     filename,
 		"reply_policy":                   generatedReplyPolicyMarker,
 		"reply_to":                       *replyTo,
@@ -341,7 +360,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		"input_request_set_id":           "",
 		"reply_arguments":                "",
 		"required_reply_completion_gate": "",
-		"template":                       envelope.MarkdownSectionContent(getNodeTemplate(cfg, *to)),
+		"template":                       envelope.MarkdownSectionContent(getNodeTemplate(cfg, recipient)),
 		"session_name":                   sessionName,
 		"sender_pane_id":                 ctx.getTmuxPaneID(),
 		"sender_runtime_context":         runtimecontext.RenderSenderMarkdown(savedRuntimeContext.Snapshot),
@@ -400,9 +419,9 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		for k, v := range vars {
 			footerVars[k] = v
 		}
-		footerTalksToList := talksToListForFooter(adjacency, *to)
+		footerTalksToList := talksToListForFooter(adjacency, recipient)
 		footerVars["can_talk_to"] = strings.Join(footerTalksToList, ", ")
-		footerVars["contacts_section"] = envelope.ContactSection(cfg, footerTalksToList)
+		footerVars["contacts_section"] = contactSectionForViewpoint(cfg, workspaceTopology, footerTalksToList, recipient)
 		footerVars["reply_command"] = strings.ReplaceAll(
 			envelope.RenderReplyCommand(cfg.ReplyCommand, resolvedContextID, sender),
 			"<recipient>",
@@ -441,14 +460,14 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 			ContextID:           resolvedContextID,
 			Session:             sessionName,
 			From:                sender,
-			To:                  *to,
+			To:                  recipient,
 			ReplyPolicy:         replyPolicy,
 			ReplyTo:             *replyTo,
 			InputRequestID:      inputRequestID,
 			FillsInputRequestID: *fillsInputRequestID,
 			SubmitPath:          projection.SubmitPathDaemon,
 		}
-		attachSendInputRequestSummary(&output, sessionDir, sessionName, sender, *to, *replyTo, *fillsInputRequestID, stripped, beforeInputRequests, beforeInputRequestsOK)
+		attachSendInputRequestSummary(&output, sessionDir, sessionName, sender, recipient, *replyTo, *fillsInputRequestID, stripped, beforeInputRequests, beforeInputRequestsOK)
 		return writeSendOutput(ctx.stdout, output)
 	}
 
@@ -473,13 +492,13 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		freshNodes, _ := ctx.discoverNodes(baseDir, resolvedContextID, sessionName)
 		var paneID string
 		if freshNodes != nil {
-			fullKey := discovery.ResolveNodeName(*to, sessionName, freshNodes)
+			fullKey := discovery.ResolveNodeName(recipient, sessionName, freshNodes)
 			if nodeInfo, ok := freshNodes[fullKey]; ok {
 				paneID = nodeInfo.PaneID
 			}
 		}
-		notificationMsg := notification.BuildNotification(cfg, adjacency, freshNodes, resolvedContextID, *to, sender, sessionName, filename, nil)
-		recipientSimpleName := nodeaddr.Simple(*to)
+		notificationMsg := notification.BuildNotification(cfg, adjacency, freshNodes, resolvedContextID, recipient, sender, sessionName, filename, nil)
+		recipientSimpleName := nodeaddr.Simple(recipient)
 		enterDelay := time.Duration(cfg.EnterDelay * float64(time.Second))
 		if nd := cfg.GetNodeConfig(recipientSimpleName).EnterDelay; nd != 0 {
 			enterDelay = time.Duration(nd * float64(time.Second))
@@ -498,7 +517,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		ContextID:           resolvedContextID,
 		Session:             sessionName,
 		From:                sender,
-		To:                  *to,
+		To:                  recipient,
 		ReplyPolicy:         replyPolicy,
 		ReplyTo:             *replyTo,
 		InputRequestID:      inputRequestID,
@@ -506,7 +525,7 @@ func runSendHeredocWithContext(ctx commandContext, args []string) error {
 		SubmitPath:          projection.SubmitPathPost,
 		Notify:              notifyOutputValue(notifyStatus),
 	}
-	attachSendInputRequestSummary(&output, sessionDir, sessionName, sender, *to, *replyTo, *fillsInputRequestID, stripped, beforeInputRequests, beforeInputRequestsOK)
+	attachSendInputRequestSummary(&output, sessionDir, sessionName, sender, recipient, *replyTo, *fillsInputRequestID, stripped, beforeInputRequests, beforeInputRequestsOK)
 	return writeSendOutput(ctx.stdout, output)
 }
 
@@ -703,6 +722,42 @@ func talksToListForFooter(adjacency map[string][]string, nodeName string) []stri
 		return talksToList
 	}
 	return config.GetTalksTo(adjacency, nodeSimpleName)
+}
+
+func contactSectionForViewpoint(cfg *config.Config, topology workspacetree.Topology, nodes []string, viewpoint string) string {
+	contactLines := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node == "" {
+			continue
+		}
+		role := ""
+		if cfg != nil {
+			nodeConfig := cfg.GetNodeConfig(node)
+			if nodeConfig.Role == "" {
+				nodeConfig = cfg.GetNodeConfig(nodeaddr.Simple(node))
+			}
+			role = envelope.ContactRoleSummary(nodeConfig.Role)
+		}
+		displayNode := node
+		hasAlias := false
+		if alias, ok := topology.RelationshipAlias(viewpoint, node); ok {
+			displayNode = alias + ": " + node
+			hasAlias = true
+		}
+		if role != "" {
+			if hasAlias {
+				contactLines = append(contactLines, fmt.Sprintf("- %s - %s", displayNode, role))
+			} else {
+				contactLines = append(contactLines, fmt.Sprintf("- %s: %s", displayNode, role))
+			}
+		} else {
+			contactLines = append(contactLines, fmt.Sprintf("- %s", displayNode))
+		}
+	}
+	if len(contactLines) == 0 {
+		return "- none"
+	}
+	return strings.Join(contactLines, "\n")
 }
 
 func renderSendBody(content, body, footer string) string {

--- a/internal/cli/send_message_test.go
+++ b/internal/cli/send_message_test.go
@@ -801,6 +801,193 @@ role = "worker"
 	}
 }
 
+func TestSendMessage_WorkspaceParentAliasCompilesToExplicitRecipient(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	configPath := filepath.Join(tmpDir, "postman.toml")
+	configContent := `[postman]
+edges = ["test-session:messenger --- repo-session:orchestrator"]
+
+[[postman.workspace_tree]]
+session = "repo-session"
+label = "repo"
+
+[[postman.workspace_tree]]
+session = "test-session"
+label = "api"
+parent = "repo-session"
+
+["test-session:messenger"]
+role = "messenger"
+
+["repo-session:orchestrator"]
+role = "orchestrator"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	installFakeTmuxForCLI(t, tmpDir, "test-session", "messenger")
+
+	if err := runSendHeredocWithBody(t, "hello", []string{
+		"--config", configPath,
+		"--context-id", "ctx-send-workspace-parent",
+		"--to", "@parent/orchestrator",
+	}); err != nil {
+		t.Fatalf("RunSendMessage: %v", err)
+	}
+
+	postDir := filepath.Join(tmpDir, "ctx-send-workspace-parent", "test-session", "post")
+	entries, err := os.ReadDir(postDir)
+	if err != nil {
+		t.Fatalf("ReadDir post: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("post entry count = %d, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0].Name(), "-to-repo-session:orchestrator.md") {
+		t.Fatalf("post filename missing compiled recipient: %q", entries[0].Name())
+	}
+	content, err := os.ReadFile(filepath.Join(postDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile sent message: %v", err)
+	}
+	if !strings.Contains(string(content), "to: repo-session:orchestrator") {
+		t.Fatalf("message frontmatter missing compiled recipient: %s", string(content))
+	}
+}
+
+func TestSendMessage_WorkspaceParentAliasDefaultsToRepresentativeAndHintsChildAlias(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	configPath := filepath.Join(tmpDir, "postman.toml")
+	configContent := `[postman]
+message_footer = """You can talk to:
+{contacts_section}
+"""
+edges = ["test-session:messenger --- repo-session:orchestrator"]
+
+[[postman.workspace_tree]]
+session = "repo-session"
+label = "repo"
+representative = "orchestrator"
+
+[[postman.workspace_tree]]
+session = "test-session"
+label = "api"
+parent = "repo-session"
+representative = "messenger"
+
+["test-session:messenger"]
+role = "Project representative."
+
+["repo-session:orchestrator"]
+role = "Root representative."
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	installFakeTmuxForCLI(t, tmpDir, "test-session", "messenger")
+
+	if err := runSendHeredocWithBody(t, "hello", []string{
+		"--config", configPath,
+		"--context-id", "ctx-send-workspace-parent-default",
+		"--to", "@parent",
+	}); err != nil {
+		t.Fatalf("RunSendMessage: %v", err)
+	}
+
+	postDir := filepath.Join(tmpDir, "ctx-send-workspace-parent-default", "test-session", "post")
+	entries, err := os.ReadDir(postDir)
+	if err != nil {
+		t.Fatalf("ReadDir post: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("post entry count = %d, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0].Name(), "-to-repo-session:orchestrator.md") {
+		t.Fatalf("post filename missing compiled representative: %q", entries[0].Name())
+	}
+	content, err := os.ReadFile(filepath.Join(postDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile sent message: %v", err)
+	}
+	if !strings.Contains(string(content), "to: repo-session:orchestrator") {
+		t.Fatalf("message frontmatter missing compiled representative: %s", string(content))
+	}
+	if !strings.Contains(string(content), "- @child/api: test-session:messenger - Project representative.") {
+		t.Fatalf("message footer missing child relationship alias: %s", string(content))
+	}
+}
+
+func TestSendMessage_WorkspaceChildAliasDefaultsToRepresentativeAndHintsParentAlias(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	configPath := filepath.Join(tmpDir, "postman.toml")
+	configContent := `[postman]
+message_footer = """You can talk to:
+{contacts_section}
+"""
+edges = ["repo-session:orchestrator --- test-session:worker"]
+
+[[postman.workspace_tree]]
+session = "repo-session"
+label = "repo"
+representative = "orchestrator"
+
+[[postman.workspace_tree]]
+session = "test-session"
+label = "api"
+parent = "repo-session"
+representative = "worker"
+
+["repo-session:orchestrator"]
+role = "Root representative."
+
+["test-session:worker"]
+role = "Project representative."
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	installFakeTmuxForCLI(t, tmpDir, "repo-session", "orchestrator")
+
+	if err := runSendHeredocWithBody(t, "hello", []string{
+		"--config", configPath,
+		"--context-id", "ctx-send-workspace-child-default",
+		"--to", "@child/api",
+	}); err != nil {
+		t.Fatalf("RunSendMessage: %v", err)
+	}
+
+	postDir := filepath.Join(tmpDir, "ctx-send-workspace-child-default", "repo-session", "post")
+	entries, err := os.ReadDir(postDir)
+	if err != nil {
+		t.Fatalf("ReadDir post: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("post entry count = %d, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0].Name(), "-to-test-session:worker.md") {
+		t.Fatalf("post filename missing compiled representative: %q", entries[0].Name())
+	}
+	content, err := os.ReadFile(filepath.Join(postDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile sent message: %v", err)
+	}
+	if !strings.Contains(string(content), "to: test-session:worker") {
+		t.Fatalf("message frontmatter missing compiled representative: %s", string(content))
+	}
+	if !strings.Contains(string(content), "- @parent: repo-session:orchestrator - Root representative.") {
+		t.Fatalf("message footer missing parent relationship alias: %s", string(content))
+	}
+}
+
 func TestSendMessage_AllowsMixedSenderGraphKeys(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -16,6 +16,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/status"
+	"github.com/i9wa4/tmux-a2a-postman/internal/workspacetree"
 )
 
 type sessionPane struct {
@@ -86,6 +87,7 @@ type sessionStatusInputs struct {
 	contextID        string
 	sessionName      string
 	sessionDir       string
+	cfg              *config.Config
 	orderedEdgeNodes []string
 	edgeNodeRank     map[string]int
 	nodes            map[string]discovery.NodeInfo
@@ -172,8 +174,70 @@ func buildSessionStatusSnapshot(inputs sessionStatusInputs) status.SessionStatus
 	result.VisibleState = status.SessionVisibleState(result.Nodes)
 	result.Queues = inputs.queues
 	result.Windows = buildSessionWindows(result.Nodes, inputs.panes)
+	result.WorkspaceTree = buildWorkspaceTreeStatus(inputs.cfg, inputs.sessionName)
 	result.Compact = buildSessionCompact(result, inputs.panes)
 	applySessionStatusEnrichment(&result, inputs.delivery, inputs.blockedByNode)
+	return result
+}
+
+func buildWorkspaceTreeStatus(cfg *config.Config, sessionName string) *status.WorkspaceTreeStatus {
+	topology := workspacetree.BuildFromConfig(cfg)
+	diagnostics := workspaceTreeDiagnostics(topology.Diagnostics())
+	node, ok, reason := topology.NodeForSession(sessionName)
+	if !ok {
+		if reason == workspacetree.FailureUnknownSourceSession && len(diagnostics) == 0 {
+			return nil
+		}
+		return &status.WorkspaceTreeStatus{
+			Diagnostics: diagnostics,
+		}
+	}
+
+	result := &status.WorkspaceTreeStatus{
+		Current: &status.WorkspaceTreeNodeStatus{
+			SessionName: node.SessionName,
+			Label:       node.Label,
+			ID:          node.ID,
+			State:       "configured",
+		},
+		Diagnostics: diagnostics,
+	}
+	if parent, found, _ := topology.NearestParent(sessionName); found {
+		result.Parent = workspaceTreeRef(parent)
+	}
+	if children, childReason := topology.NearestChildren(sessionName); childReason == workspacetree.FailureNone {
+		for _, child := range children {
+			result.Children = append(result.Children, *workspaceTreeRef(child))
+		}
+	}
+	return result
+}
+
+func workspaceTreeRef(node workspacetree.Node) *status.WorkspaceTreeRef {
+	return &status.WorkspaceTreeRef{
+		SessionName: node.SessionName,
+		Label:       node.Label,
+		ID:          node.ID,
+	}
+}
+
+func workspaceTreeDiagnostics(diagnostics []workspacetree.Diagnostic) []status.WorkspaceTreeDiagnostic {
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	result := make([]status.WorkspaceTreeDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, status.WorkspaceTreeDiagnostic{
+			Code:              diagnostic.Code,
+			ID:                diagnostic.ID,
+			IDs:               append([]string{}, diagnostic.IDs...),
+			SessionName:       diagnostic.SessionName,
+			SessionNames:      append([]string{}, diagnostic.SessionNames...),
+			ParentSessionName: diagnostic.ParentSessionName,
+			Labels:            append([]string{}, diagnostic.Labels...),
+			Message:           diagnostic.Message,
+		})
+	}
 	return result
 }
 
@@ -238,6 +302,7 @@ func collectSessionStatusWithInboxCounts(baseDir, contextID, sessionName string,
 		contextID:        contextID,
 		sessionName:      sessionName,
 		sessionDir:       sessionDir,
+		cfg:              cfg,
 		orderedEdgeNodes: orderedEdgeNodes,
 		edgeNodeRank:     edgeNodeRank,
 		nodes:            nodes,

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -363,6 +363,74 @@ func TestRunGetSessionStatus_IncludesVisibleStateAndTopology(t *testing.T) {
 	}
 }
 
+func TestCollectLiveSessionStatus_IncludesWorkspaceTree(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "20260601-tree"
+	sessionName := "repo-session"
+
+	for _, session := range []string{"repo-session", "api-session", "pkg-session", "docs-session"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, contextID, session, "inbox", "worker"), 0o755); err != nil {
+			t.Fatalf("MkdirAll inbox for %s: %v", session, err)
+		}
+	}
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  \"list-panes -a -F\"*)\n" +
+		"    printf '%s\\n' '%11\t" + contextID + "\trepo-session\tworker' '%12\t" + contextID + "\tapi-session\tworker' '%13\t" + contextID + "\tpkg-session\tworker' '%14\t" + contextID + "\tdocs-session\tworker'\n" +
+		"    ;;\n" +
+		"  \"list-windows -t repo-session\"*)\n" +
+		"    printf '%s\\n' '0'\n" +
+		"    ;;\n" +
+		"  \"list-panes -t repo-session:0\"*)\n" +
+		"    printf '%s\\n' '0\t0\t%11\tworker\tclaude'\n" +
+		"    ;;\n" +
+		"  *)\n" +
+		"    exit 1\n" +
+		"    ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	health, err := collectLiveSessionStatus(tmpDir, contextID, sessionName, &config.Config{
+		Edges: []string{"worker --- orchestrator"},
+		WorkspaceTree: []config.WorkspaceTreeNodeConfig{
+			{SessionName: "repo-session", ID: "repo-id", Label: "repo"},
+			{SessionName: "api-session", ID: "api-id", Label: "api", ParentSessionName: "repo-session", Order: 20},
+			{SessionName: "pkg-session", ID: "pkg-id", Label: "pkg", ParentSessionName: "api-session"},
+			{SessionName: "docs-session", ID: "docs-id", Label: "docs", ParentSessionName: "repo-session", Order: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("collectLiveSessionStatus: %v", err)
+	}
+	if health.WorkspaceTree == nil || health.WorkspaceTree.Current == nil {
+		t.Fatalf("WorkspaceTree = %#v, want current node", health.WorkspaceTree)
+	}
+	if health.WorkspaceTree.Current.SessionName != "repo-session" || health.WorkspaceTree.Current.Label != "repo" || health.WorkspaceTree.Current.ID != "repo-id" || health.WorkspaceTree.Current.State != "configured" {
+		t.Fatalf("workspace current = %#v, want redacted repo-session node", health.WorkspaceTree.Current)
+	}
+	childSessions := []string{}
+	for _, child := range health.WorkspaceTree.Children {
+		childSessions = append(childSessions, child.SessionName)
+		if child.ID == "" {
+			t.Fatalf("child missing id: %#v", child)
+		}
+	}
+	wantChildren := []string{"docs-session", "api-session"}
+	if strings.Join(childSessions, ",") != strings.Join(wantChildren, ",") {
+		t.Fatalf("workspace children = %v, want nearest children %v", childSessions, wantChildren)
+	}
+
+	if _, err := json.Marshal(health); err != nil {
+		t.Fatalf("Marshal health: %v", err)
+	}
+}
+
 func TestRunGetSessionStatus_DebugIncludesDaemonRuntimeDiagnostics(t *testing.T) {
 	tmpDir := t.TempDir()
 	contextID := "20260524-debug"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,10 +66,11 @@ type Config struct {
 	MessageFooter                string            `toml:"message_footer"`                  // Footer appended to outgoing messages by `send` after message content
 
 	// Global settings
-	Edges                 []string `toml:"edges"`
-	ReplyCommand          string   `toml:"reply_command"`
-	UINode                string   `toml:"ui_node"`                  // Optional target filter for startup auto-PING
-	AutoEnableNewSessions *bool    `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
+	Edges                 []string                  `toml:"edges"`
+	ReplyCommand          string                    `toml:"reply_command"`
+	UINode                string                    `toml:"ui_node"`                  // Optional target filter for startup auto-PING
+	AutoEnableNewSessions *bool                     `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
+	WorkspaceTree         []WorkspaceTreeNodeConfig `toml:"workspace_tree"`           // Optional explicit hierarchy for tree aliases
 
 	// Node-specific configurations (loaded from [nodename] sections)
 	Nodes map[string]NodeConfig
@@ -92,6 +93,16 @@ type NodeConfig struct {
 	Role       string  `toml:"role"`
 	EnterCount int     `toml:"enter_count"`         // Issue #126: Number of Enter keystrokes to send (0/1 = single, 2+ = double)
 	EnterDelay float64 `toml:"enter_delay_seconds"` // 0 = use global default
+}
+
+// WorkspaceTreeNodeConfig describes one node in the explicit workspace tree hierarchy.
+type WorkspaceTreeNodeConfig struct {
+	SessionName       string `toml:"session"`
+	ID                string `toml:"id"`
+	Label             string `toml:"label"`
+	ParentSessionName string `toml:"parent"`
+	Representative    string `toml:"representative"`
+	Order             int    `toml:"order"`
 }
 
 // BoolVal dereferences a *bool with a default fallback (#219).
@@ -574,6 +585,9 @@ func mergeConfig(base, override *Config) {
 	}
 	if override.DaemonSubmitWorkerLimit != 0 {
 		base.DaemonSubmitWorkerLimit = override.DaemonSubmitWorkerLimit
+	}
+	if len(override.WorkspaceTree) > 0 {
+		base.WorkspaceTree = override.WorkspaceTree
 	}
 
 	// *bool fields: bidirectional override (#219)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -235,6 +235,56 @@ edges = [
 	}
 }
 
+func TestLoadConfig_WorkspaceTree(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	configPath := filepath.Join(tmpDir, "postman.toml")
+
+	content := `
+[postman]
+edges = ["messenger --- worker"]
+
+[[postman.workspace_tree]]
+session = "repo"
+label = "repo"
+id = "repo-root"
+representative = "orchestrator"
+order = 10
+
+[[postman.workspace_tree]]
+session = "project"
+label = "api"
+parent = "repo"
+order = 20
+
+[messenger]
+role = "messenger"
+
+[worker]
+role = "worker"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if len(cfg.WorkspaceTree) != 2 {
+		t.Fatalf("WorkspaceTree length = %d, want 2", len(cfg.WorkspaceTree))
+	}
+	if got := cfg.WorkspaceTree[0]; got.SessionName != "repo" || got.Label != "repo" || got.ID != "repo-root" || got.Representative != "orchestrator" || got.Order != 10 {
+		t.Fatalf("WorkspaceTree[0] = %#v, want repo node", got)
+	}
+	if got := cfg.WorkspaceTree[1]; got.SessionName != "project" || got.Label != "api" || got.ParentSessionName != "repo" || got.Order != 20 {
+		t.Fatalf("WorkspaceTree[1] = %#v, want project child node", got)
+	}
+}
+
 func TestLoadConfig_XDGMarkdownEdgesOnlyMaterializesNodes(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -98,6 +98,32 @@ base_dir = ""                      # Override session dir (default: XDG_STATE_HO
 # ]
 edges = []
 
+# Optional workspace tree hierarchy for cross-session tree aliases.
+# Hierarchy is captured from explicit session metadata at daemon/CLI load time;
+# pane cwd changes do not affect routing eligibility. There is no directory-root
+# inference — parent/child relationships are always explicit config entries.
+# Public status reports labels and stable IDs only.
+# Alias syntax:
+#   @parent                              # parent representative
+#   @parent/<node>
+#   @child/<label-or-session-or-id>       # selected child representative
+#   @child/<node>                         # only when there is one configured child
+#   @child/<label-or-session-or-id>/<node>
+#
+# [[postman.workspace_tree]]
+# session = "repo"
+# label = "repo"
+# id = "repo-root"
+# representative = "orchestrator"
+# order = 10
+#
+# [[postman.workspace_tree]]
+# session = "project"
+# label = "api"
+# parent = "repo"
+# representative = "worker"
+# order = 20
+
 # Global settings
 reply_command = "tmux-a2a-postman send-heredoc --to <recipient>"
 ui_node = "messenger"            # Optional target filter for startup auto-PING

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
 )
 
 // ValidationError represents a configuration validation issue (Issue #70).
@@ -104,6 +106,52 @@ func ValidateConfig(cfg *Config) []ValidationError {
 
 	// Rule 4: Deprecated fields (none currently, placeholder for future)
 	// Add deprecated field checks here as needed
+	for i, node := range cfg.WorkspaceTree {
+		field := fmt.Sprintf("workspace_tree[%d]", i)
+		if strings.TrimSpace(node.SessionName) == "" {
+			errors = append(errors, ValidationError{
+				Field:    field + ".session",
+				Message:  "session is required",
+				Severity: "error",
+			})
+		} else if _, err := ValidateSessionName(node.SessionName); err != nil {
+			errors = append(errors, ValidationError{
+				Field:    field + ".session",
+				Message:  err.Error(),
+				Severity: "error",
+			})
+		}
+		if strings.TrimSpace(node.ParentSessionName) != "" {
+			if _, err := ValidateSessionName(node.ParentSessionName); err != nil {
+				errors = append(errors, ValidationError{
+					Field:    field + ".parent",
+					Message:  err.Error(),
+					Severity: "error",
+				})
+			}
+		}
+		if node.Label != "" && !binding.ValidateNodeName(node.Label) {
+			errors = append(errors, ValidationError{
+				Field:    field + ".label",
+				Message:  fmt.Sprintf("label %q must match %s", node.Label, binding.NodeNamePattern),
+				Severity: "error",
+			})
+		}
+		if node.ID != "" && !binding.ValidateNodeName(node.ID) {
+			errors = append(errors, ValidationError{
+				Field:    field + ".id",
+				Message:  fmt.Sprintf("id %q must match %s", node.ID, binding.NodeNamePattern),
+				Severity: "error",
+			})
+		}
+		if node.Representative != "" && !binding.ValidateNodeName(node.Representative) {
+			errors = append(errors, ValidationError{
+				Field:    field + ".representative",
+				Message:  fmt.Sprintf("representative %q must match %s", node.Representative, binding.NodeNamePattern),
+				Severity: "error",
+			})
+		}
+	}
 
 	return errors
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -251,3 +251,38 @@ func TestValidateConfig_DuplicateEdges_ReverseUndirectedDuplicate(t *testing.T) 
 		t.Fatalf("expected duplicate warning for reversed edge, got: %v", errors)
 	}
 }
+
+func TestValidateConfig_WorkspaceTree(t *testing.T) {
+	cfg := &Config{
+		Edges: []string{"worker --- orchestrator"},
+		Nodes: map[string]NodeConfig{
+			"worker":       {},
+			"orchestrator": {},
+		},
+		WorkspaceTree: []WorkspaceTreeNodeConfig{
+			{SessionName: "repo", Label: "repo", ID: "repo-root"},
+			{SessionName: "", ParentSessionName: "repo"},
+			{SessionName: "project", Label: "bad_label", ParentSessionName: "repo"},
+			{SessionName: "docs", ID: "bad_id", ParentSessionName: "bad/parent", Representative: "bad/representative"},
+		},
+	}
+
+	errors := ValidateConfig(cfg)
+	wantFields := map[string]bool{
+		"workspace_tree[1].session":        false,
+		"workspace_tree[2].label":          false,
+		"workspace_tree[3].parent":         false,
+		"workspace_tree[3].id":             false,
+		"workspace_tree[3].representative": false,
+	}
+	for _, err := range errors {
+		if _, ok := wantFields[err.Field]; ok && err.Severity == "error" {
+			wantFields[err.Field] = true
+		}
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("missing workspace tree validation error for %s in %#v", field, errors)
+		}
+	}
+}

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -202,7 +202,7 @@ func ContactSection(cfg *config.Config, nodes []string) string {
 			if nodeConfig.Role == "" {
 				nodeConfig = cfg.GetNodeConfig(nodeaddr.Simple(node))
 			}
-			role = summarizeContactRole(nodeConfig.Role)
+			role = ContactRoleSummary(nodeConfig.Role)
 		}
 		if role != "" {
 			contactLines = append(contactLines, fmt.Sprintf("- %s: %s", node, role))
@@ -216,7 +216,7 @@ func ContactSection(cfg *config.Config, nodes []string) string {
 	return strings.Join(contactLines, "\n")
 }
 
-func summarizeContactRole(role string) string {
+func ContactRoleSummary(role string) string {
 	role = strings.ReplaceAll(role, "\r\n", "\n")
 	for _, line := range strings.Split(role, "\n") {
 		line = strings.TrimSpace(line)

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -133,23 +133,55 @@ type SessionQueues struct {
 	DeadLetterCount int `json:"dead_letter_count"`
 }
 
+type WorkspaceTreeRef struct {
+	SessionName string `json:"session_name"`
+	Label       string `json:"label,omitempty"`
+	ID          string `json:"id"`
+}
+
+type WorkspaceTreeNodeStatus struct {
+	SessionName string `json:"session_name"`
+	Label       string `json:"label,omitempty"`
+	ID          string `json:"id"`
+	State       string `json:"state"`
+}
+
+type WorkspaceTreeDiagnostic struct {
+	Code              string   `json:"code"`
+	ID                string   `json:"id,omitempty"`
+	IDs               []string `json:"ids,omitempty"`
+	SessionName       string   `json:"session_name,omitempty"`
+	SessionNames      []string `json:"session_names,omitempty"`
+	ParentSessionName string   `json:"parent_session_name,omitempty"`
+	Labels            []string `json:"labels,omitempty"`
+	Message           string   `json:"message,omitempty"`
+}
+
+type WorkspaceTreeStatus struct {
+	Current     *WorkspaceTreeNodeStatus  `json:"current,omitempty"`
+	Parent      *WorkspaceTreeRef         `json:"parent,omitempty"`
+	Children    []WorkspaceTreeRef        `json:"children,omitempty"`
+	Diagnostics []WorkspaceTreeDiagnostic `json:"diagnostics,omitempty"`
+}
+
 type SessionStatus struct {
-	SchemaVersion      int                 `json:"schema_version"`
-	ContextID          string              `json:"context_id"`
-	SessionName        string              `json:"session_name"`
-	NodeCount          int                 `json:"node_count"`
-	VisibleState       string              `json:"visible_state"`
-	Severity           string              `json:"severity,omitempty"`
-	SeveritySource     string              `json:"severity_source,omitempty"`
-	SeverityReason     string              `json:"severity_reason,omitempty"`
-	Compact            string              `json:"compact"`
-	CompactSeverity    string              `json:"compact_severity,omitempty"`
-	Queues             SessionQueues       `json:"queues"`
-	Delivery           *DeliveryStatus     `json:"delivery,omitempty"`
-	RuntimeDiagnostics *RuntimeDiagnostics `json:"runtime_diagnostics,omitempty"`
-	Tasks              []TaskRunProjection `json:"tasks,omitempty"`
-	Nodes              []NodeStatus        `json:"nodes"`
-	Windows            []SessionWindow     `json:"windows"`
+	SchemaVersion      int                  `json:"schema_version"`
+	ContextID          string               `json:"context_id"`
+	SessionName        string               `json:"session_name"`
+	NodeCount          int                  `json:"node_count"`
+	VisibleState       string               `json:"visible_state"`
+	Severity           string               `json:"severity,omitempty"`
+	SeveritySource     string               `json:"severity_source,omitempty"`
+	SeverityReason     string               `json:"severity_reason,omitempty"`
+	Compact            string               `json:"compact"`
+	CompactSeverity    string               `json:"compact_severity,omitempty"`
+	Queues             SessionQueues        `json:"queues"`
+	Delivery           *DeliveryStatus      `json:"delivery,omitempty"`
+	RuntimeDiagnostics *RuntimeDiagnostics  `json:"runtime_diagnostics,omitempty"`
+	Tasks              []TaskRunProjection  `json:"tasks,omitempty"`
+	WorkspaceTree      *WorkspaceTreeStatus `json:"workspace_tree,omitempty"`
+	Nodes              []NodeStatus         `json:"nodes"`
+	Windows            []SessionWindow      `json:"windows"`
 }
 
 type TaskRunProjection struct {

--- a/internal/workspacetree/config.go
+++ b/internal/workspacetree/config.go
@@ -1,0 +1,25 @@
+package workspacetree
+
+import "github.com/i9wa4/tmux-a2a-postman/internal/config"
+
+func RegistrationsFromConfig(cfg *config.Config) []Registration {
+	if cfg == nil || len(cfg.WorkspaceTree) == 0 {
+		return nil
+	}
+	registrations := make([]Registration, 0, len(cfg.WorkspaceTree))
+	for _, node := range cfg.WorkspaceTree {
+		registrations = append(registrations, Registration{
+			SessionName:       node.SessionName,
+			ID:                node.ID,
+			Label:             node.Label,
+			ParentSessionName: node.ParentSessionName,
+			Representative:    node.Representative,
+			Order:             node.Order,
+		})
+	}
+	return registrations
+}
+
+func BuildFromConfig(cfg *config.Config) Topology {
+	return Build(RegistrationsFromConfig(cfg))
+}

--- a/internal/workspacetree/workspacetree.go
+++ b/internal/workspacetree/workspacetree.go
@@ -1,0 +1,427 @@
+package workspacetree
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
+	"github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr"
+)
+
+const (
+	ParentAlias       = "@parent"
+	ChildAliasPrefix  = "@child/"
+	ParentAliasPrefix = ParentAlias + "/"
+)
+
+type FailureReason string
+
+const (
+	FailureNone                 FailureReason = ""
+	FailureNotAlias             FailureReason = "not_alias"
+	FailureInvalidAlias         FailureReason = "invalid_alias"
+	FailureUnknownSourceSession FailureReason = "unknown_source_session"
+	FailureAmbiguousHierarchy   FailureReason = "ambiguous_hierarchy"
+	FailureUnknownParent        FailureReason = "unknown_parent"
+	FailureNoParent             FailureReason = "no_parent"
+	FailureNoChild              FailureReason = "no_child"
+	FailureAmbiguousChild       FailureReason = "ambiguous_child"
+	FailureUnknownNode          FailureReason = "unknown_node"
+)
+
+type Registration struct {
+	SessionName       string
+	ID                string
+	Label             string
+	ParentSessionName string
+	Representative    string
+	Order             int
+}
+
+type Node struct {
+	SessionName       string
+	ID                string
+	Label             string
+	ParentSessionName string
+	Representative    string
+	Order             int
+}
+
+type Diagnostic struct {
+	Code              string
+	ID                string
+	IDs               []string
+	SessionName       string
+	SessionNames      []string
+	ParentSessionName string
+	Labels            []string
+	Message           string
+}
+
+type Topology struct {
+	nodes            []Node
+	bySession        map[string][]int
+	childrenByParent map[string][]int
+	diagnostics      []Diagnostic
+}
+
+type AliasResolution struct {
+	Input         string
+	Address       string
+	SessionName   string
+	NodeName      string
+	AliasKind     string
+	Selector      string
+	Found         bool
+	FailureReason FailureReason
+}
+
+func Build(registrations []Registration) Topology {
+	topology := Topology{
+		bySession:        make(map[string][]int),
+		childrenByParent: make(map[string][]int),
+	}
+
+	for _, registration := range registrations {
+		sessionName := strings.TrimSpace(registration.SessionName)
+		if sessionName == "" {
+			continue
+		}
+		label := strings.TrimSpace(registration.Label)
+		if label == "" {
+			label = sessionName
+		}
+		id := strings.TrimSpace(registration.ID)
+		if id == "" {
+			id = sessionName
+		}
+		parentSessionName := strings.TrimSpace(registration.ParentSessionName)
+
+		idx := len(topology.nodes)
+		topology.nodes = append(topology.nodes, Node{
+			SessionName:       sessionName,
+			ID:                id,
+			Label:             label,
+			ParentSessionName: parentSessionName,
+			Representative:    strings.TrimSpace(registration.Representative),
+			Order:             registration.Order,
+		})
+		topology.bySession[sessionName] = append(topology.bySession[sessionName], idx)
+		if parentSessionName != "" {
+			topology.childrenByParent[parentSessionName] = append(topology.childrenByParent[parentSessionName], idx)
+		}
+	}
+
+	topology.recordDuplicateSessions()
+	topology.recordUnknownParents()
+	sortDiagnostics(topology.diagnostics)
+	return topology
+}
+
+func (t *Topology) recordDuplicateSessions() {
+	for sessionName, idxs := range t.bySession {
+		if len(idxs) < 2 {
+			continue
+		}
+		var ids, labels []string
+		for _, idx := range idxs {
+			ids = append(ids, t.nodes[idx].ID)
+			labels = append(labels, t.nodes[idx].Label)
+		}
+		t.diagnostics = append(t.diagnostics, Diagnostic{
+			Code:        "duplicate_session",
+			IDs:         sortedUnique(ids),
+			SessionName: sessionName,
+			Labels:      sortedUnique(labels),
+			Message:     "session appears more than once in workspace tree",
+		})
+	}
+}
+
+func (t *Topology) recordUnknownParents() {
+	for _, node := range t.nodes {
+		if node.ParentSessionName == "" {
+			continue
+		}
+		if len(t.bySession[node.ParentSessionName]) == 0 {
+			t.diagnostics = append(t.diagnostics, Diagnostic{
+				Code:              "unknown_parent",
+				ID:                node.ID,
+				SessionName:       node.SessionName,
+				ParentSessionName: node.ParentSessionName,
+				Message:           "workspace tree parent session is not configured",
+			})
+		}
+	}
+}
+
+func (t Topology) Diagnostics() []Diagnostic {
+	result := make([]Diagnostic, len(t.diagnostics))
+	copy(result, t.diagnostics)
+	return result
+}
+
+func (t Topology) NodeForSession(sessionName string) (Node, bool, FailureReason) {
+	idxs := t.bySession[sessionName]
+	if len(idxs) == 0 {
+		return Node{}, false, FailureUnknownSourceSession
+	}
+	if len(idxs) > 1 {
+		return Node{}, false, FailureAmbiguousHierarchy
+	}
+	return t.nodes[idxs[0]], true, FailureNone
+}
+
+func (t Topology) NearestParent(sessionName string) (Node, bool, FailureReason) {
+	source, ok, reason := t.NodeForSession(sessionName)
+	if !ok {
+		return Node{}, false, reason
+	}
+	if source.ParentSessionName == "" {
+		return Node{}, false, FailureNoParent
+	}
+	parent, ok, reason := t.NodeForSession(source.ParentSessionName)
+	if !ok {
+		if reason == FailureUnknownSourceSession {
+			return Node{}, false, FailureUnknownParent
+		}
+		return Node{}, false, reason
+	}
+	return parent, true, FailureNone
+}
+
+func (t Topology) NearestChildren(sessionName string) ([]Node, FailureReason) {
+	if _, ok, reason := t.NodeForSession(sessionName); !ok {
+		return nil, reason
+	}
+
+	childIdxs := append([]int(nil), t.childrenByParent[sessionName]...)
+	children := make([]Node, 0, len(childIdxs))
+	for _, idx := range childIdxs {
+		child := t.nodes[idx]
+		if _, ok, reason := t.NodeForSession(child.SessionName); !ok {
+			return nil, reason
+		}
+		children = append(children, child)
+	}
+	sortNodes(children)
+	return children, FailureNone
+}
+
+func (t Topology) ResolveAlias(alias, sourceSessionName string, nodeExists func(string) bool) AliasResolution {
+	parsed, err := parseAlias(alias)
+	if err != nil {
+		if !IsAlias(alias) {
+			return AliasResolution{Input: alias, FailureReason: FailureNotAlias}
+		}
+		return AliasResolution{Input: alias, FailureReason: FailureInvalidAlias}
+	}
+
+	var target Node
+	switch parsed.kind {
+	case "parent":
+		parent, ok, reason := t.NearestParent(sourceSessionName)
+		if !ok {
+			return AliasResolution{Input: alias, AliasKind: parsed.kind, NodeName: parsed.nodeName, FailureReason: reason}
+		}
+		target = parent
+	case "child":
+		children, reason := t.NearestChildren(sourceSessionName)
+		if reason != FailureNone {
+			return AliasResolution{Input: alias, AliasKind: parsed.kind, Selector: parsed.selector, NodeName: parsed.nodeName, FailureReason: reason}
+		}
+		matches := selectChildren(children, parsed.selector)
+		if len(matches) == 0 {
+			switch {
+			case parsed.nodeName == "" && len(children) == 1:
+				parsed.nodeName = parsed.selector
+				parsed.selector = ""
+				matches = children
+			case parsed.nodeName == "" && len(children) > 1:
+				return AliasResolution{Input: alias, AliasKind: parsed.kind, Selector: parsed.selector, NodeName: parsed.nodeName, FailureReason: FailureAmbiguousChild}
+			default:
+				return AliasResolution{Input: alias, AliasKind: parsed.kind, Selector: parsed.selector, NodeName: parsed.nodeName, FailureReason: FailureNoChild}
+			}
+		}
+		if len(matches) > 1 {
+			return AliasResolution{Input: alias, AliasKind: parsed.kind, Selector: parsed.selector, NodeName: parsed.nodeName, FailureReason: FailureAmbiguousChild}
+		}
+		target = matches[0]
+	default:
+		return AliasResolution{Input: alias, FailureReason: FailureInvalidAlias}
+	}
+
+	resolvedNodeName := parsed.nodeName
+	address := nodeaddr.Full(resolvedNodeName, target.SessionName)
+	if parsed.nodeName == "" {
+		if target.Representative == "" {
+			return AliasResolution{
+				Input:         alias,
+				SessionName:   target.SessionName,
+				AliasKind:     parsed.kind,
+				Selector:      parsed.selector,
+				FailureReason: FailureUnknownNode,
+			}
+		}
+		resolvedNodeName = target.Representative
+		address = nodeaddr.Full(resolvedNodeName, target.SessionName)
+	}
+	if nodeExists != nil && !nodeExists(address) {
+		return AliasResolution{
+			Input:         alias,
+			Address:       address,
+			SessionName:   target.SessionName,
+			NodeName:      resolvedNodeName,
+			AliasKind:     parsed.kind,
+			Selector:      parsed.selector,
+			FailureReason: FailureUnknownNode,
+		}
+	}
+	return AliasResolution{
+		Input:       alias,
+		Address:     address,
+		SessionName: target.SessionName,
+		NodeName:    resolvedNodeName,
+		AliasKind:   parsed.kind,
+		Selector:    parsed.selector,
+		Found:       true,
+	}
+}
+
+func IsAlias(address string) bool {
+	return strings.HasPrefix(address, "@")
+}
+
+func ValidateAliasSyntax(alias string) error {
+	_, err := parseAlias(alias)
+	return err
+}
+
+func (t Topology) RelationshipAlias(viewpointAddress, targetAddress string) (string, bool) {
+	viewSessionName, _, viewHasSession := nodeaddr.Split(viewpointAddress)
+	targetSessionName, targetNodeName, targetHasSession := nodeaddr.Split(targetAddress)
+	if !viewHasSession || !targetHasSession {
+		return "", false
+	}
+	view, ok, _ := t.NodeForSession(viewSessionName)
+	if !ok {
+		return "", false
+	}
+	target, ok, _ := t.NodeForSession(targetSessionName)
+	if !ok || target.Representative == "" || targetNodeName != target.Representative {
+		return "", false
+	}
+	if view.ParentSessionName == target.SessionName {
+		return ParentAlias, true
+	}
+	if target.ParentSessionName == view.SessionName {
+		return ChildAliasPrefix + target.Label, true
+	}
+	return "", false
+}
+
+type parsedAlias struct {
+	kind     string
+	selector string
+	nodeName string
+}
+
+func parseAlias(alias string) (parsedAlias, error) {
+	switch {
+	case alias == ParentAlias:
+		return parsedAlias{kind: "parent"}, nil
+	case strings.HasPrefix(alias, ParentAliasPrefix):
+		nodeName := strings.TrimPrefix(alias, ParentAliasPrefix)
+		if err := validateAliasNode(nodeName); err != nil {
+			return parsedAlias{}, err
+		}
+		return parsedAlias{kind: "parent", nodeName: nodeName}, nil
+	case strings.HasPrefix(alias, ChildAliasPrefix):
+		rest := strings.TrimPrefix(alias, ChildAliasPrefix)
+		parts := strings.Split(rest, "/")
+		switch len(parts) {
+		case 1:
+			if strings.TrimSpace(parts[0]) == "" {
+				return parsedAlias{}, fmt.Errorf("child selector or node is required")
+			}
+			if err := validateAliasNode(parts[0]); err != nil {
+				return parsedAlias{}, err
+			}
+			return parsedAlias{kind: "child", selector: parts[0]}, nil
+		case 2:
+			if strings.TrimSpace(parts[0]) == "" {
+				return parsedAlias{}, fmt.Errorf("child selector is required")
+			}
+			if err := validateAliasNode(parts[1]); err != nil {
+				return parsedAlias{}, err
+			}
+			return parsedAlias{kind: "child", selector: parts[0], nodeName: parts[1]}, nil
+		default:
+			return parsedAlias{}, fmt.Errorf("invalid child alias")
+		}
+	default:
+		return parsedAlias{}, fmt.Errorf("workspace tree aliases must use %q or %q", ParentAliasPrefix, ChildAliasPrefix)
+	}
+}
+
+func validateAliasNode(nodeName string) error {
+	if !binding.ValidateNodeName(nodeName) {
+		return fmt.Errorf("invalid alias node %q (must match %s)", nodeName, binding.NodeNamePattern)
+	}
+	return nil
+}
+
+func selectChildren(children []Node, selector string) []Node {
+	if selector == "" {
+		return children
+	}
+	var matches []Node
+	for _, child := range children {
+		if child.Label == selector || child.SessionName == selector || child.ID == selector {
+			matches = append(matches, child)
+		}
+	}
+	return matches
+}
+
+func sortNodes(nodes []Node) {
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Order != nodes[j].Order {
+			return nodes[i].Order < nodes[j].Order
+		}
+		if nodes[i].Label != nodes[j].Label {
+			return nodes[i].Label < nodes[j].Label
+		}
+		if nodes[i].SessionName != nodes[j].SessionName {
+			return nodes[i].SessionName < nodes[j].SessionName
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+}
+
+func sortedUnique(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	var result []string
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.Slice(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Code != diagnostics[j].Code {
+			return diagnostics[i].Code < diagnostics[j].Code
+		}
+		if diagnostics[i].SessionName != diagnostics[j].SessionName {
+			return diagnostics[i].SessionName < diagnostics[j].SessionName
+		}
+		return diagnostics[i].ID < diagnostics[j].ID
+	})
+}

--- a/internal/workspacetree/workspacetree_test.go
+++ b/internal/workspacetree/workspacetree_test.go
@@ -1,0 +1,178 @@
+package workspacetree
+
+import "testing"
+
+func TestNearestParentDoesNotRequireRegisteredRoot(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo"},
+		{SessionName: "project", Label: "api", ParentSessionName: "repo"},
+	})
+
+	parent, ok, reason := topology.NearestParent("project")
+	if !ok {
+		t.Fatalf("NearestParent = false/%s, want repo parent", reason)
+	}
+	if parent.SessionName != "repo" {
+		t.Fatalf("parent session = %q, want repo", parent.SessionName)
+	}
+}
+
+func TestNearestChildrenUsesExplicitHierarchyAndOrder(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo"},
+		{SessionName: "api", Label: "api", ParentSessionName: "repo", Order: 20},
+		{SessionName: "pkg", Label: "pkg", ParentSessionName: "api"},
+		{SessionName: "docs", Label: "docs", ParentSessionName: "repo", Order: 10},
+	})
+
+	children, reason := topology.NearestChildren("repo")
+	if reason != FailureNone {
+		t.Fatalf("NearestChildren reason = %s, want none", reason)
+	}
+	got := []string{}
+	for _, child := range children {
+		got = append(got, child.SessionName)
+	}
+	want := []string{"docs", "api"}
+	if len(got) != len(want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("children = %v, want %v", got, want)
+		}
+	}
+
+	projectChildren, reason := topology.NearestChildren("api")
+	if reason != FailureNone {
+		t.Fatalf("NearestChildren(api) reason = %s, want none", reason)
+	}
+	if len(projectChildren) != 1 || projectChildren[0].SessionName != "pkg" {
+		t.Fatalf("project children = %#v, want pkg", projectChildren)
+	}
+}
+
+func TestDuplicateHierarchySessionsAreReportedAndAmbiguous(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo-a", ID: "repo-a"},
+		{SessionName: "repo", Label: "repo-b", ID: "repo-b"},
+		{SessionName: "project", Label: "api", ParentSessionName: "repo"},
+	})
+
+	diagnostics := topology.Diagnostics()
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want one duplicate_session", diagnostics)
+	}
+	if diagnostics[0].Code != "duplicate_session" {
+		t.Fatalf("diagnostic code = %q, want duplicate_session", diagnostics[0].Code)
+	}
+	if len(diagnostics[0].IDs) != 2 {
+		t.Fatalf("diagnostic ids = %#v, want both duplicate ids", diagnostics[0].IDs)
+	}
+
+	_, ok, reason := topology.NearestParent("project")
+	if ok || reason != FailureAmbiguousHierarchy {
+		t.Fatalf("NearestParent duplicate = ok:%v reason:%s, want ambiguous_hierarchy", ok, reason)
+	}
+	resolution := topology.ResolveAlias("@parent/worker", "project", nil)
+	if resolution.Found || resolution.FailureReason != FailureAmbiguousHierarchy {
+		t.Fatalf("ResolveAlias duplicate = %#v, want ambiguous_hierarchy", resolution)
+	}
+}
+
+func TestResolveAliasCompilesToExplicitSessionNodeAddress(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", ID: "repo-id", Label: "repo", Representative: "orchestrator"},
+		{SessionName: "api", ID: "api-id", Label: "api", ParentSessionName: "repo", Representative: "worker"},
+		{SessionName: "docs", ID: "docs-id", Label: "docs", ParentSessionName: "repo", Representative: "worker"},
+	})
+
+	defaultParent := topology.ResolveAlias("@parent", "api", nil)
+	if !defaultParent.Found || defaultParent.Address != "repo:orchestrator" {
+		t.Fatalf("default parent alias = %#v, want repo:orchestrator", defaultParent)
+	}
+
+	parent := topology.ResolveAlias("@parent/orchestrator", "api", nil)
+	if !parent.Found || parent.Address != "repo:orchestrator" {
+		t.Fatalf("parent alias = %#v, want repo:orchestrator", parent)
+	}
+
+	child := topology.ResolveAlias("@child/api/worker", "repo", nil)
+	if !child.Found || child.Address != "api:worker" {
+		t.Fatalf("child alias = %#v, want api:worker", child)
+	}
+
+	byID := topology.ResolveAlias("@child/docs-id/worker", "repo", nil)
+	if !byID.Found || byID.Address != "docs:worker" {
+		t.Fatalf("child alias by id = %#v, want docs:worker", byID)
+	}
+
+	defaultChild := topology.ResolveAlias("@child/api", "repo", nil)
+	if !defaultChild.Found || defaultChild.Address != "api:worker" {
+		t.Fatalf("default child alias = %#v, want api:worker", defaultChild)
+	}
+}
+
+func TestRelationshipAliasNamesRepresentativeContacts(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo", Representative: "orchestrator"},
+		{SessionName: "api", Label: "api", ParentSessionName: "repo", Representative: "worker"},
+	})
+
+	parent, ok := topology.RelationshipAlias("api:worker", "repo:orchestrator")
+	if !ok || parent != "@parent" {
+		t.Fatalf("parent contact alias = %q/%v, want @parent", parent, ok)
+	}
+	child, ok := topology.RelationshipAlias("repo:orchestrator", "api:worker")
+	if !ok || child != "@child/api" {
+		t.Fatalf("child contact alias = %q/%v, want @child/api", child, ok)
+	}
+	if alias, ok := topology.RelationshipAlias("repo:orchestrator", "api:reviewer"); ok {
+		t.Fatalf("non-representative child alias = %q/%v, want none", alias, ok)
+	}
+}
+
+func TestResolveAliasFailuresAreTyped(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo"},
+		{SessionName: "api", Label: "api", ParentSessionName: "repo"},
+		{SessionName: "docs", Label: "docs", ParentSessionName: "repo"},
+		{SessionName: "orphan", Label: "orphan", ParentSessionName: "missing-parent"},
+	})
+
+	cases := []struct {
+		name    string
+		alias   string
+		session string
+		want    FailureReason
+	}{
+		{name: "invalid", alias: "@child/api/worker/extra", session: "repo", want: FailureInvalidAlias},
+		{name: "unknown source", alias: "@parent/worker", session: "missing", want: FailureUnknownSourceSession},
+		{name: "ambiguous child", alias: "@child/worker", session: "repo", want: FailureAmbiguousChild},
+		{name: "no parent", alias: "@parent/worker", session: "repo", want: FailureNoParent},
+		{name: "unknown parent", alias: "@parent/worker", session: "orphan", want: FailureUnknownParent},
+		{name: "no selected child", alias: "@child/mobile/worker", session: "repo", want: FailureNoChild},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolution := topology.ResolveAlias(tc.alias, tc.session, nil)
+			if resolution.Found || resolution.FailureReason != tc.want {
+				t.Fatalf("ResolveAlias(%q, %q) = %#v, want %s", tc.alias, tc.session, resolution, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveAliasCanRequireLiveNodeExistence(t *testing.T) {
+	topology := Build([]Registration{
+		{SessionName: "repo", Label: "repo"},
+		{SessionName: "api", Label: "api", ParentSessionName: "repo"},
+	})
+
+	resolution := topology.ResolveAlias("@parent/orchestrator", "api", func(address string) bool {
+		return address == "repo:messenger"
+	})
+	if resolution.Found || resolution.FailureReason != FailureUnknownNode || resolution.Address != "repo:orchestrator" {
+		t.Fatalf("ResolveAlias nodeExists = %#v, want unknown_node with compiled address", resolution)
+	}
+}

--- a/skills/postman-config-auditor/references/audit-guide.md
+++ b/skills/postman-config-auditor/references/audit-guide.md
@@ -31,6 +31,9 @@ Important merge rules:
 - Non-empty scalar values override lower layers.
 - `edges` replaces lower-layer edges only when the override has at least one
   edge.
+- `workspace_tree` is configured only in `postman.toml`; hierarchy is explicit
+  session and parent metadata captured at daemon or CLI load time, not inferred
+  from pane cwd. Roots are optional metadata only.
 - Node configs merge field by field for main config files.
 - Split `nodes/*.toml` files replace that node at their layer.
 - `postman.md` frontmatter `skill_path` generates compact skill catalogs from
@@ -72,6 +75,11 @@ Important merge rules:
   overrides or clears `ui_node`.
 - Confirm missing routes explain dead-letter behavior before blaming role
   templates.
+- If tree aliases such as `@parent`, `@parent/<node>`,
+  `@child/<label-or-session-or-id>`, or
+  `@child/<label-or-session-or-id>/<node>` fail, inspect `workspace_tree`
+  diagnostics in `get-status` and check for duplicate sessions, missing
+  parents, missing representatives, or ambiguous child selectors.
 - Confirm node names in templates are reachable from the sender when the text
   instructs an agent to contact that node.
 - Treat node names as local protocol identifiers, not generic job titles.

--- a/skills/postman-config-auditor/references/postman-md.md
+++ b/skills/postman-config-auditor/references/postman-md.md
@@ -287,6 +287,8 @@ Important rules:
 - Split `nodes/*.md` files update only non-empty role and template fields.
 - `postman.md` edges replace lower-layer edges only when the parsed edge list is
   non-empty.
+- `workspace_tree` is TOML-only. `postman.md` does not parse or override
+  explicit workspace hierarchy metadata.
 - A Mermaid `ui_node` class in the `edges` graph sets `ui_node` when
   frontmatter does not set it. Frontmatter `ui_node` wins within the same
   Markdown file.

--- a/skills/postman-send-message/SKILL.md
+++ b/skills/postman-send-message/SKILL.md
@@ -25,6 +25,8 @@ skill, not a waiting skill.
 
 2. Do not pass message text as a CLI argument, file-body shortcut, or generic
    pipe-oriented body.
+   When workspace tree hierarchy is configured, `<node>` may also be a tree
+   alias such as `@parent`, `@parent/orchestrator`, or `@child/api`.
 3. Leave Markdown headings unchanged.
 4. The sender is auto-detected from the current tmux pane title. Use
    `tmux-a2a-postman help send-heredoc` for details.

--- a/skills/postman-session-operator/references/session-flow.md
+++ b/skills/postman-session-operator/references/session-flow.md
@@ -27,6 +27,12 @@ archived path after `pop`; prefer `markdown_absolute_path` when present.
 and recipient before delivery. A failed `send-heredoc` is stronger evidence
 than stale footer text.
 
+When workspace tree hierarchy is configured in `postman.toml`,
+`send-heredoc --to` accepts tree aliases (`@parent`, `@parent/<node>`,
+`@child/<label-or-session-or-id>`, `@child/<node>` for a single child, or
+`@child/<label-or-session-or-id>/<node>`). The CLI compiles a successful alias
+to an explicit `session:node` recipient before writing the message.
+
 Use `--reply-required` when the recipient must answer. Use `--no-reply` for
 terminal or informational mail. Without either flag, reply policy is resolved
 from message metadata and ordinary message bodies are usually no-reply.


### PR DESCRIPTION
Adds explicit-config workspace tree hierarchy coordination between tmux-a2a-postman sessions. Sessions declare hierarchy via `[[postman.workspace_tree]]` TOML entries (session, id, label, parent, representative, order); `@parent`/`@child/<selector>` aliases resolve against that declared topology and compile to explicit `session:node` targets before delivery, still subject to existing edge authorization. Public status output reports labels and stable IDs only.

Supersedes #593 (rebuilt from current main; original branch had unresolvable drift). Closes #504.