### PR TITLE
feat(daemon): bounded non-daemon delivery and PING goroutine budget (#572)

### DIFF
--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -324,6 +324,12 @@ func TestRunGetSessionStatus_DebugIncludesDaemonRuntimeDiagnostics(t *testing.T)
 		LateResponseCount:            1,
 		OldestLateResponseAgeSeconds: 45,
 		SaturationCount:              0,
+	}, status.NonDaemonDeliveryRuntimeDiagnostics{
+		WorkerLimit:          8,
+		ActivePostCount:      1,
+		PendingPostCount:     2,
+		ActiveAutoPingCount:  3,
+		PendingAutoPingCount: 4,
 	}, time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)))
 
 	stdout, _, runErr := captureCommandOutput(t, func() error {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -633,35 +633,68 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 					}
 					sessionTarget := cmd.Target
 					go func() {
+						workerLimit := daemonState.BeginManualPingFanout(len(targetNodes))
+						defer daemonState.FinishManualPingFanout()
 						var wg sync.WaitGroup
 						var successCount, failCount atomic.Int32
-						for nodeName, nodeInfo := range targetNodes {
-							wg.Add(1)
-							go func(name string, info discovery.NodeInfo) {
-								defer wg.Done()
-								result, err := ping.SendPingToNodeWithResult(info, contextID, name,
-									cfg.DaemonMessageTemplate, cfg, activeNodes, livenessMap,
-									pingAdjacency, freshNodes)
-								if err != nil {
-									log.Printf("❌ postman: PING to %s failed: %v\n", name, err)
-									failCount.Add(1)
-									daemonEvents <- tui.DaemonEvent{
-										Type:    "message_received",
-										Message: fmt.Sprintf("PING failed for %s: %v", name, err),
-									}
-								} else {
-									if result.Delivered {
-										recordDirectPingDelivered(name, info, "operator_tui", time.Now())
-									}
-									log.Printf("📮 postman: PING sent to %s\n", name)
-									successCount.Add(1)
-									daemonEvents <- tui.DaemonEvent{
-										Type:    "message_received",
-										Message: fmt.Sprintf("PING sent to %s", name),
-									}
-								}
-							}(nodeName, nodeInfo)
+						type pingTarget struct {
+							name string
+							info discovery.NodeInfo
 						}
+						targets := make([]pingTarget, 0, len(targetNodes))
+						for nodeName, nodeInfo := range targetNodes {
+							targets = append(targets, pingTarget{name: nodeName, info: nodeInfo})
+						}
+						sort.Slice(targets, func(i, j int) bool {
+							return targets[i].name < targets[j].name
+						})
+						jobs := make(chan pingTarget)
+						for i := 0; i < workerLimit; i++ {
+							wg.Add(1)
+							go func() {
+								defer wg.Done()
+								for target := range jobs {
+									daemonState.UnqueueManualPingDelivery()
+									if !daemonState.StartManualPingDelivery() {
+										failCount.Add(1)
+										log.Printf("postman: WARNING: manual PING budget unexpectedly saturated for %s\n", target.name)
+										daemonEvents <- tui.DaemonEvent{
+											Type:    "message_received",
+											Message: fmt.Sprintf("PING failed for %s: manual PING budget saturated", target.name),
+										}
+										continue
+									}
+									func() {
+										defer daemonState.FinishManualPingDelivery()
+										result, err := ping.SendPingToNodeWithResult(target.info, contextID, target.name,
+											cfg.DaemonMessageTemplate, cfg, activeNodes, livenessMap,
+											pingAdjacency, freshNodes)
+										if err != nil {
+											log.Printf("❌ postman: PING to %s failed: %v\n", target.name, err)
+											failCount.Add(1)
+											daemonEvents <- tui.DaemonEvent{
+												Type:    "message_received",
+												Message: fmt.Sprintf("PING failed for %s: %v", target.name, err),
+											}
+										} else {
+											if result.Delivered {
+												recordDirectPingDelivered(target.name, target.info, "operator_tui", time.Now())
+											}
+											log.Printf("📮 postman: PING sent to %s\n", target.name)
+											successCount.Add(1)
+											daemonEvents <- tui.DaemonEvent{
+												Type:    "message_received",
+												Message: fmt.Sprintf("PING sent to %s", target.name),
+											}
+										}
+									}()
+								}
+							}()
+						}
+						for _, target := range targets {
+							jobs <- target
+						}
+						close(jobs)
 						wg.Wait()
 						total := int(successCount.Load()) + int(failCount.Load())
 						daemonEvents <- tui.DaemonEvent{

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -658,10 +658,10 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 									if !daemonState.StartManualPingDelivery() {
 										failCount.Add(1)
 										log.Printf("postman: WARNING: manual PING budget unexpectedly saturated for %s\n", target.name)
-										daemonEvents <- tui.DaemonEvent{
+										tui.SendEventNonBlocking(daemonEvents, tui.DaemonEvent{
 											Type:    "message_received",
 											Message: fmt.Sprintf("PING failed for %s: manual PING budget saturated", target.name),
-										}
+										})
 										continue
 									}
 									func() {
@@ -672,20 +672,20 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 										if err != nil {
 											log.Printf("❌ postman: PING to %s failed: %v\n", target.name, err)
 											failCount.Add(1)
-											daemonEvents <- tui.DaemonEvent{
+											tui.SendEventNonBlocking(daemonEvents, tui.DaemonEvent{
 												Type:    "message_received",
 												Message: fmt.Sprintf("PING failed for %s: %v", target.name, err),
-											}
+											})
 										} else {
 											if result.Delivered {
 												recordDirectPingDelivered(target.name, target.info, "operator_tui", time.Now())
 											}
 											log.Printf("📮 postman: PING sent to %s\n", target.name)
 											successCount.Add(1)
-											daemonEvents <- tui.DaemonEvent{
+											tui.SendEventNonBlocking(daemonEvents, tui.DaemonEvent{
 												Type:    "message_received",
 												Message: fmt.Sprintf("PING sent to %s", target.name),
-											}
+											})
 										}
 									}()
 								}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -697,17 +697,17 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						close(jobs)
 						wg.Wait()
 						total := int(successCount.Load()) + int(failCount.Load())
-						daemonEvents <- tui.DaemonEvent{
+						tui.SendEventNonBlocking(daemonEvents, tui.DaemonEvent{
 							Type:    "status_update",
 							Message: fmt.Sprintf("PING: %d/%d dispatched", successCount.Load(), total),
 							Details: map[string]interface{}{"session": sessionTarget},
-						}
+						})
 						time.AfterFunc(30*time.Second, func() {
-							daemonEvents <- tui.DaemonEvent{
+							tui.SendEventNonBlocking(daemonEvents, tui.DaemonEvent{
 								Type:    "status_update",
 								Message: "",
 								Details: map[string]interface{}{"session": sessionTarget},
-							}
+							})
 						})
 					}()
 				}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -524,6 +524,7 @@ type DaemonState struct {
 	lastDeliveryBySenderRecipient map[string]time.Time       // Issue #211: Rate limit duplicate deliveries (sender:recipient -> time)
 	reservedDeliveryByRoute       map[string]time.Time       // Issue #393: in-flight rate-limit reservations (sender:recipient -> time)
 	lastDeliveryMu                sync.RWMutex               // Issue #211: Mutex for lastDeliveryBySenderRecipient
+	nonDaemonDeliveryBudget       *nonDaemonDeliveryBudget   // Issue #572: bounded concurrency for post/auto-PING/manual-PING delivery
 	clock                         func() time.Time
 }
 
@@ -547,8 +548,54 @@ func newDaemonStateWithClock(drainWindowSeconds float64, contextID string, clock
 		prevPaneToNode:                make(map[string]string),          // paneID -> nodeKey mapping
 		lastDeliveryBySenderRecipient: make(map[string]time.Time),       // Issue #211
 		reservedDeliveryByRoute:       make(map[string]time.Time),
+		nonDaemonDeliveryBudget:       newNonDaemonDeliveryBudget(clock),
 		clock:                         clock,
 	}
+}
+
+// NonDaemonDeliveryWorkerLimit returns the shared worker limit applied to
+// post/auto-PING/manual-PING delivery paths (Issue #572).
+func (ds *DaemonState) NonDaemonDeliveryWorkerLimit() int {
+	return ds.nonDaemonDeliveryBudgetForUse().workerLimit()
+}
+
+// BeginManualPingFanout reserves a bounded worker count for a manual PING
+// fanout of the given size, returning the number of workers to actually
+// spawn (capped at the shared delivery budget's worker limit).
+func (ds *DaemonState) BeginManualPingFanout(total int) int {
+	return ds.nonDaemonDeliveryBudgetForUse().beginManualFanout(total)
+}
+
+// StartManualPingDelivery attempts to acquire a manual-PING delivery slot.
+func (ds *DaemonState) StartManualPingDelivery() bool {
+	return ds.nonDaemonDeliveryBudgetForUse().tryStart(nonDaemonDeliveryPathManualPing)
+}
+
+// FinishManualPingDelivery releases a manual-PING delivery slot.
+func (ds *DaemonState) FinishManualPingDelivery() {
+	ds.nonDaemonDeliveryBudgetForUse().finish(nonDaemonDeliveryPathManualPing)
+}
+
+// UnqueueManualPingDelivery decrements the pending-manual-PING counter for a
+// job that a worker has just picked up from the fanout queue.
+func (ds *DaemonState) UnqueueManualPingDelivery() {
+	ds.nonDaemonDeliveryBudgetForUse().unqueue(nonDaemonDeliveryPathManualPing)
+}
+
+// FinishManualPingFanout resets manual-PING fanout bookkeeping once a fanout
+// round completes.
+func (ds *DaemonState) FinishManualPingFanout() {
+	ds.nonDaemonDeliveryBudgetForUse().finishManualFanout()
+}
+
+func (ds *DaemonState) nonDaemonDeliveryBudgetForUse() *nonDaemonDeliveryBudget {
+	if ds == nil {
+		return newNonDaemonDeliveryBudget(nil)
+	}
+	if ds.nonDaemonDeliveryBudget == nil {
+		ds.nonDaemonDeliveryBudget = newNonDaemonDeliveryBudget(ds.clock)
+	}
+	return ds.nonDaemonDeliveryBudget
 }
 
 func (ds *DaemonState) now() time.Time {

--- a/internal/daemon/non_daemon_delivery_budget.go
+++ b/internal/daemon/non_daemon_delivery_budget.go
@@ -10,6 +10,13 @@ import (
 
 const nonDaemonDeliveryRetryDelay = 100 * time.Millisecond
 
+// nonDaemonDeliveryBudget bounds concurrency for the post/auto-PING/
+// manual-PING delivery paths (Issue #572). Despite the "shared" name, it is
+// three INDEPENDENT per-path pools of workerLimit() each (postSem/
+// autoPingSem/manualPingSem below) — not one pool shared across paths, and
+// not coupled to config.DaemonSubmitWorkerLimit (the unrelated daemon-submit
+// CLI worker pool). At most 3*workerLimit() non-daemon-submit deliveries can
+// be in flight concurrently, split evenly across the three paths.
 type nonDaemonDeliveryPath string
 
 const (
@@ -20,6 +27,13 @@ const (
 
 type nonDaemonDeliveryBudget struct {
 	mu sync.Mutex
+
+	// manualFanoutMu serializes manual-PING fanout rounds (Issue #572 B2):
+	// beginManualFanout locks it and finishManualFanout unlocks it, so a
+	// second overlapping "p" keypress blocks until the prior round's
+	// pending/saturation bookkeeping has been finalized, instead of both
+	// rounds sharing manualPingSem and corrupting each other's counters.
+	manualFanoutMu sync.Mutex
 
 	postSem       chan struct{}
 	autoPingSem   chan struct{}
@@ -125,8 +139,16 @@ func (b *nonDaemonDeliveryBudget) unqueue(path nonDaemonDeliveryPath) {
 	}
 }
 
+// beginManualFanout starts a manual-PING fanout round, serialized against
+// any other round via manualFanoutMu (Issue #572 B2). Every call that
+// returns must be paired with a later call to finishManualFanout, including
+// the total<=0 case, to release the lock.
 func (b *nonDaemonDeliveryBudget) beginManualFanout(total int) int {
-	if b == nil || total <= 0 {
+	if b == nil {
+		return 0
+	}
+	b.manualFanoutMu.Lock()
+	if total <= 0 {
 		return 0
 	}
 	limit := b.workerLimit()
@@ -146,6 +168,7 @@ func (b *nonDaemonDeliveryBudget) finishManualFanout() {
 	b.manualSaturatedHit = false
 	b.pendingManualPing = 0
 	b.mu.Unlock()
+	b.manualFanoutMu.Unlock()
 }
 
 func (b *nonDaemonDeliveryBudget) queueManual(count int) {

--- a/internal/daemon/non_daemon_delivery_budget.go
+++ b/internal/daemon/non_daemon_delivery_budget.go
@@ -1,0 +1,219 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/status"
+)
+
+const nonDaemonDeliveryRetryDelay = 100 * time.Millisecond
+
+type nonDaemonDeliveryPath string
+
+const (
+	nonDaemonDeliveryPathPost       nonDaemonDeliveryPath = "post"
+	nonDaemonDeliveryPathAutoPing   nonDaemonDeliveryPath = "auto_ping"
+	nonDaemonDeliveryPathManualPing nonDaemonDeliveryPath = "manual_ping"
+)
+
+type nonDaemonDeliveryBudget struct {
+	mu sync.Mutex
+
+	postSem       chan struct{}
+	autoPingSem   chan struct{}
+	manualPingSem chan struct{}
+
+	pendingPost       int
+	pendingAutoPing   int
+	pendingManualPing int
+
+	saturationCount    int
+	lastSaturatedAt    time.Time
+	manualSaturatedHit bool
+
+	clock func() time.Time
+}
+
+func newNonDaemonDeliveryBudget(clock func() time.Time) *nonDaemonDeliveryBudget {
+	if clock == nil {
+		clock = time.Now
+	}
+	limit := config.DefaultDaemonSubmitWorkerLimit
+	return &nonDaemonDeliveryBudget{
+		postSem:       make(chan struct{}, limit),
+		autoPingSem:   make(chan struct{}, limit),
+		manualPingSem: make(chan struct{}, limit),
+		clock:         clock,
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) workerLimit() int {
+	if b == nil {
+		return config.DefaultDaemonSubmitWorkerLimit
+	}
+	return cap(b.postSem)
+}
+
+func (b *nonDaemonDeliveryBudget) tryStart(path nonDaemonDeliveryPath) bool {
+	if b == nil {
+		return true
+	}
+	sem := b.sem(path)
+	if sem == nil {
+		return true
+	}
+	select {
+	case sem <- struct{}{}:
+		return true
+	default:
+		b.recordSaturation()
+		return false
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) finish(path nonDaemonDeliveryPath) {
+	if b == nil {
+		return
+	}
+	sem := b.sem(path)
+	if sem == nil {
+		return
+	}
+	select {
+	case <-sem:
+	default:
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) queue(path nonDaemonDeliveryPath) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch path {
+	case nonDaemonDeliveryPathPost:
+		b.pendingPost++
+	case nonDaemonDeliveryPathAutoPing:
+		b.pendingAutoPing++
+	case nonDaemonDeliveryPathManualPing:
+		b.pendingManualPing++
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) unqueue(path nonDaemonDeliveryPath) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch path {
+	case nonDaemonDeliveryPathPost:
+		if b.pendingPost > 0 {
+			b.pendingPost--
+		}
+	case nonDaemonDeliveryPathAutoPing:
+		if b.pendingAutoPing > 0 {
+			b.pendingAutoPing--
+		}
+	case nonDaemonDeliveryPathManualPing:
+		if b.pendingManualPing > 0 {
+			b.pendingManualPing--
+		}
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) beginManualFanout(total int) int {
+	if b == nil || total <= 0 {
+		return 0
+	}
+	limit := b.workerLimit()
+	b.queueManual(total)
+	if total > limit {
+		b.recordSaturationOnceForManualFanout()
+		return limit
+	}
+	return total
+}
+
+func (b *nonDaemonDeliveryBudget) finishManualFanout() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.manualSaturatedHit = false
+	b.pendingManualPing = 0
+	b.mu.Unlock()
+}
+
+func (b *nonDaemonDeliveryBudget) queueManual(count int) {
+	if count <= 0 {
+		return
+	}
+	b.mu.Lock()
+	b.pendingManualPing += count
+	b.mu.Unlock()
+}
+
+func (b *nonDaemonDeliveryBudget) recordSaturationOnceForManualFanout() {
+	b.mu.Lock()
+	if !b.manualSaturatedHit {
+		b.saturationCount++
+		b.lastSaturatedAt = b.now()
+		b.manualSaturatedHit = true
+	}
+	b.mu.Unlock()
+}
+
+func (b *nonDaemonDeliveryBudget) recordSaturation() {
+	b.mu.Lock()
+	b.saturationCount++
+	b.lastSaturatedAt = b.now()
+	b.mu.Unlock()
+}
+
+func (b *nonDaemonDeliveryBudget) snapshot() status.NonDaemonDeliveryRuntimeDiagnostics {
+	if b == nil {
+		return status.NonDaemonDeliveryRuntimeDiagnostics{
+			WorkerLimit: config.DefaultDaemonSubmitWorkerLimit,
+		}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	diag := status.NonDaemonDeliveryRuntimeDiagnostics{
+		WorkerLimit:            b.workerLimit(),
+		ActivePostCount:        len(b.postSem),
+		PendingPostCount:       b.pendingPost,
+		ActiveAutoPingCount:    len(b.autoPingSem),
+		PendingAutoPingCount:   b.pendingAutoPing,
+		ActiveManualPingCount:  len(b.manualPingSem),
+		PendingManualPingCount: b.pendingManualPing,
+		SaturationCount:        b.saturationCount,
+	}
+	if !b.lastSaturatedAt.IsZero() {
+		diag.LastSaturatedAt = b.lastSaturatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return diag
+}
+
+func (b *nonDaemonDeliveryBudget) sem(path nonDaemonDeliveryPath) chan struct{} {
+	switch path {
+	case nonDaemonDeliveryPathPost:
+		return b.postSem
+	case nonDaemonDeliveryPathAutoPing:
+		return b.autoPingSem
+	case nonDaemonDeliveryPathManualPing:
+		return b.manualPingSem
+	default:
+		return nil
+	}
+}
+
+func (b *nonDaemonDeliveryBudget) now() time.Time {
+	if b.clock == nil {
+		return time.Now()
+	}
+	return b.clock()
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -47,8 +47,11 @@ type daemonRuntime struct {
 	configPaths []string
 	nodesDirs   []string
 	daemonState *DaemonState
-	idleTracker *idle.IdleTracker
-	clock       func() time.Time
+	// nonDaemonDeliveryBudgetFallback backs nonDaemonDeliveryBudget() when
+	// daemonState is nil (e.g. in tests constructing a bare daemonRuntime).
+	nonDaemonDeliveryBudgetFallback *nonDaemonDeliveryBudget
+	idleTracker                     *idle.IdleTracker
+	clock                           func() time.Time
 
 	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]
 
@@ -494,7 +497,7 @@ func (rt *daemonRuntime) processRuntimeDiagnosticsSubmitRequest(requestPath stri
 }
 
 func (rt *daemonRuntime) runtimeDiagnostics(now time.Time) *status.RuntimeDiagnostics {
-	diag := status.NewRuntimeDiagnostics("daemon_runtime", rt.runtimeCardinality(), rt.daemonSubmitRuntimeDiagnostics(now), now)
+	diag := status.NewRuntimeDiagnostics("daemon_runtime", rt.runtimeCardinality(), rt.daemonSubmitRuntimeDiagnostics(now), rt.nonDaemonDeliveryRuntimeDiagnostics(), now)
 	return &diag
 }
 
@@ -621,6 +624,24 @@ func (rt *daemonRuntime) daemonSubmitWorkerLimit() int {
 		return cap(rt.daemonSubmitSem)
 	}
 	return daemonSubmitWorkerLimitFromConfig(rt.cfg)
+}
+
+// nonDaemonDeliveryBudget returns the shared post/auto-PING/manual-PING
+// delivery budget (Issue #572), preferring the one owned by daemonState so
+// the budget is consistent across the daemon; falls back to a
+// runtime-local budget when daemonState is unavailable (e.g. in tests).
+func (rt *daemonRuntime) nonDaemonDeliveryBudget() *nonDaemonDeliveryBudget {
+	if rt.daemonState != nil {
+		return rt.daemonState.nonDaemonDeliveryBudgetForUse()
+	}
+	if rt.nonDaemonDeliveryBudgetFallback == nil {
+		rt.nonDaemonDeliveryBudgetFallback = newNonDaemonDeliveryBudget(rt.now)
+	}
+	return rt.nonDaemonDeliveryBudgetFallback
+}
+
+func (rt *daemonRuntime) nonDaemonDeliveryRuntimeDiagnostics() status.NonDaemonDeliveryRuntimeDiagnostics {
+	return rt.nonDaemonDeliveryBudget().snapshot()
 }
 
 func scanDaemonSubmitRequests(sessionDir string, now time.Time, diagnostics *status.DaemonSubmitRuntimeDiagnostics) {
@@ -1008,9 +1029,24 @@ func (rt *daemonRuntime) postDeliveryTraceFields(eventPath, filename string) msg
 }
 
 func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes map[string]discovery.NodeInfo, adjacency map[string][]string, cfg *config.Config, reservation postDeliveryReservation) {
+	budget := rt.nonDaemonDeliveryBudget()
+	if !budget.tryStart(nonDaemonDeliveryPathPost) {
+		budget.queue(nonDaemonDeliveryPathPost)
+		log.Printf("postman: WARNING: component=non_daemon_delivery event=workers_saturated path=post file=%s retry_in=%s\n", filename, nonDaemonDeliveryRetryDelay)
+		scheduler := rt.scheduleRuntimeTimer
+		if scheduler == nil {
+			scheduler = defaultRuntimeTimerScheduler
+		}
+		scheduler(nonDaemonDeliveryRetryDelay, "post-delivery-budget-retry", rt.events, func() {
+			budget.unqueue(nonDaemonDeliveryPathPost)
+			rt.dispatchPostDelivery(eventPath, filename, nodes, adjacency, cfg, reservation)
+		})
+		return
+	}
 	go func(eventPath, filename string, nodes map[string]discovery.NodeInfo, adjacency map[string][]string, cfg *config.Config) {
 		deliveredNormally := false
 		defer func() {
+			budget.finish(nonDaemonDeliveryPathPost)
 			if reservation.route != "" {
 				rt.daemonState.finishDeliveryRoute(reservation.route, reservation.reservedAt, reservation.hasReservation, deliveredNormally, rt.now())
 			}
@@ -1821,30 +1857,48 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 			dispatchSnapshot = newAutoPingDispatchSnapshot(freshNodes, activeNodes, livenessMap, rt.adjacency)
 		}
 
-		dispatchNodeKey := nodeKey
-		dispatchNodeInfo := nodeInfo
-		dispatchPending := pending
-		dispatchTemplate := tmpl
-		dispatchActiveNodes := dispatchSnapshot.activeNodes
-		dispatchLivenessMap := dispatchSnapshot.livenessMap
-		dispatchAdjacency := dispatchSnapshot.adjacency
-		dispatchNodes := dispatchSnapshot.nodes
-		sendAutoPing := rt.autoPingSender()
-		go func() {
-			defer rt.finishAutoPing(dispatchNodeKey)
-
-			result, err := sendAutoPing(dispatchNodeInfo, rt.contextID, dispatchNodeKey, dispatchTemplate, rt.cfg, dispatchActiveNodes, dispatchLivenessMap, dispatchAdjacency, dispatchNodes)
-			if err != nil {
-				log.Printf("postman: WARNING: auto-PING send failed for %s: %v\n", dispatchNodeKey, err)
-				return
-			}
-			if !result.Delivered {
-				return
-			}
-
-			rt.recordDeliveredAutoPing(dispatchNodeKey, dispatchNodeInfo, dispatchPending, rt.now())
-		}()
+		rt.dispatchAutoPingDelivery(nodeKey, nodeInfo, pending, tmpl,
+			dispatchSnapshot.activeNodes, dispatchSnapshot.livenessMap,
+			dispatchSnapshot.adjacency, dispatchSnapshot.nodes)
 	}
+}
+
+// dispatchAutoPingDelivery sends one auto-PING under the shared non-daemon
+// delivery budget (Issue #572). When the auto-PING path is saturated, the
+// send is queued and retried after nonDaemonDeliveryRetryDelay instead of
+// spawning an unbounded goroutine.
+func (rt *daemonRuntime) dispatchAutoPingDelivery(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, tmpl string, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo) {
+	budget := rt.nonDaemonDeliveryBudget()
+	if !budget.tryStart(nonDaemonDeliveryPathAutoPing) {
+		budget.queue(nonDaemonDeliveryPathAutoPing)
+		log.Printf("postman: WARNING: component=non_daemon_delivery event=workers_saturated path=auto_ping node=%s retry_in=%s\n", nodeKey, nonDaemonDeliveryRetryDelay)
+		scheduler := rt.scheduleRuntimeTimer
+		if scheduler == nil {
+			scheduler = defaultRuntimeTimerScheduler
+		}
+		scheduler(nonDaemonDeliveryRetryDelay, "auto-ping-budget-retry", rt.events, func() {
+			budget.unqueue(nonDaemonDeliveryPathAutoPing)
+			rt.dispatchAutoPingDelivery(nodeKey, nodeInfo, pending, tmpl, activeNodes, livenessMap, adjacency, nodes)
+		})
+		return
+	}
+
+	sendAutoPing := rt.autoPingSender()
+	go func() {
+		defer budget.finish(nonDaemonDeliveryPathAutoPing)
+		defer rt.finishAutoPing(nodeKey)
+
+		result, err := sendAutoPing(nodeInfo, rt.contextID, nodeKey, tmpl, rt.cfg, activeNodes, livenessMap, adjacency, nodes)
+		if err != nil {
+			log.Printf("postman: WARNING: auto-PING send failed for %s: %v\n", nodeKey, err)
+			return
+		}
+		if !result.Delivered {
+			return
+		}
+
+		rt.recordDeliveredAutoPing(nodeKey, nodeInfo, pending, rt.now())
+	}()
 }
 
 func newAutoPingDispatchSnapshot(freshNodes map[string]discovery.NodeInfo, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string) *autoPingDispatchSnapshot {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1039,12 +1039,30 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 		}
 		scheduler(nonDaemonDeliveryRetryDelay, "post-delivery-budget-retry", rt.events, func() {
 			budget.unqueue(nonDaemonDeliveryPathPost)
-			// Issue #572 M1: re-read rt.nodes/rt.adjacency at retry time
-			// rather than reusing the nodes/adjacency captured at the
-			// original (now stale) dispatch attempt — a rescan between
-			// the two may have repointed rt.nodes/rt.adjacency at fresher
-			// topology (e.g. a pane repurposed to a different node).
-			rt.dispatchPostDelivery(eventPath, filename, rt.nodes, rt.adjacency, cfg, reservation)
+			// Issue #572 M1: re-read nodes at retry time rather than reusing
+			// the nodes captured at the original (now stale) dispatch
+			// attempt — a rescan between the two may have repointed
+			// rt.nodes at fresher topology (e.g. a pane repurposed to a
+			// different node). This runs on its own timer goroutine while
+			// the select-loop writes rt.nodes lock-free, so the retry reads
+			// through rt.sharedNodes (an atomic.Pointer already used
+			// cross-goroutine at start.go:556) instead of rt.nodes
+			// directly. rt.adjacency is set once at construction and never
+			// mutated afterward, so it is safe to read directly here.
+			var retryNodes map[string]discovery.NodeInfo
+			if rt.sharedNodes != nil {
+				if cached := rt.sharedNodes.Load(); cached != nil {
+					retryNodes = *cached
+				}
+			}
+			if retryNodes == nil {
+				// Only reached when sharedNodes is unset (e.g. a
+				// daemonRuntime built directly in a test); in production
+				// sharedNodes is always populated before the runtime loop
+				// starts, so this fallback never races with rt.nodes writes.
+				retryNodes = rt.nodes
+			}
+			rt.dispatchPostDelivery(eventPath, filename, retryNodes, rt.adjacency, cfg, reservation)
 		})
 		return
 	}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1039,7 +1039,12 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 		}
 		scheduler(nonDaemonDeliveryRetryDelay, "post-delivery-budget-retry", rt.events, func() {
 			budget.unqueue(nonDaemonDeliveryPathPost)
-			rt.dispatchPostDelivery(eventPath, filename, nodes, adjacency, cfg, reservation)
+			// Issue #572 M1: re-read rt.nodes/rt.adjacency at retry time
+			// rather than reusing the nodes/adjacency captured at the
+			// original (now stale) dispatch attempt — a rescan between
+			// the two may have repointed rt.nodes/rt.adjacency at fresher
+			// topology (e.g. a pane repurposed to a different node).
+			rt.dispatchPostDelivery(eventPath, filename, rt.nodes, rt.adjacency, cfg, reservation)
 		})
 		return
 	}
@@ -1072,10 +1077,10 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 			resultFields.Result = "error"
 			resultFields.Reason = err.Error()
 			msgtrace.Log("delivery_result", resultFields)
-			rt.events <- tui.DaemonEvent{
+			tui.SendEventNonBlocking(rt.events, tui.DaemonEvent{
 				Type:    "error",
 				Message: fmt.Sprintf("deliver %s: %v", filename, err),
-			}
+			})
 			return
 		}
 
@@ -1099,11 +1104,11 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 		select {
 		case msgEvent := <-messageEvents:
 			deliveryEvent = msgEvent
-			rt.events <- tui.DaemonEvent{
+			tui.SendEventNonBlocking(rt.events, tui.DaemonEvent{
 				Type:    msgEvent.Type,
 				Message: msgEvent.Message,
 				Details: msgEvent.Details,
-			}
+			})
 			suppressNormalDelivery = messageEventSuppressesNormalDelivery(msgEvent)
 		default:
 		}
@@ -1133,24 +1138,24 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 		}
 
 		if !suppressNormalDelivery {
-			rt.events <- tui.DaemonEvent{
+			tui.SendEventNonBlocking(rt.events, tui.DaemonEvent{
 				Type:    "message_received",
 				Message: fmt.Sprintf("Delivered: %s", filename),
 				Details: map[string]interface{}{
 					"session": sourceSessionName,
 				},
-			}
+			})
 		}
 
 		if !suppressNormalDelivery {
 			if _, err := message.ParseMessageFilename(filename); err == nil {
 				nodeStates := rt.idleTracker.GetNodeStates()
-				rt.events <- tui.DaemonEvent{
+				tui.SendEventNonBlocking(rt.events, tui.DaemonEvent{
 					Type: "node_activity_update",
 					Details: map[string]interface{}{
 						"node_states": nodeStates,
 					},
-				}
+				})
 			}
 		}
 	}(eventPath, filename, nodes, adjacency, cfg)
@@ -1859,26 +1864,45 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 
 		rt.dispatchAutoPingDelivery(nodeKey, nodeInfo, pending, tmpl,
 			dispatchSnapshot.activeNodes, dispatchSnapshot.livenessMap,
-			dispatchSnapshot.adjacency, dispatchSnapshot.nodes)
+			dispatchSnapshot.adjacency, dispatchSnapshot.nodes, 0)
 	}
 }
+
+// maxAutoPingStaleRetries bounds how many times a saturated auto-PING is
+// retried against its original (increasingly stale) topology snapshot
+// before being dropped (Issue #572 M1). Unlike post-delivery, auto-PING's
+// activeNodes/livenessMap/adjacency/nodes cannot always be re-read from a
+// single rt field at retry time — callers of dispatchPendingAutoPings pass
+// differently-scoped freshNodes per call site, so blindly substituting a
+// "current" snapshot risks silently changing which nodes are considered.
+// Capping retries bounds the staleness window instead; re-resolving a truly
+// fresh scan on retry is deferred pending a closer look at those call sites.
+const maxAutoPingStaleRetries = 3
 
 // dispatchAutoPingDelivery sends one auto-PING under the shared non-daemon
 // delivery budget (Issue #572). When the auto-PING path is saturated, the
 // send is queued and retried after nonDaemonDeliveryRetryDelay instead of
-// spawning an unbounded goroutine.
-func (rt *daemonRuntime) dispatchAutoPingDelivery(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, tmpl string, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo) {
+// spawning an unbounded goroutine. attempt counts retries so far (0 for the
+// initial dispatch); after maxAutoPingStaleRetries the PING is dropped
+// rather than retried indefinitely against stale topology (M1).
+func (rt *daemonRuntime) dispatchAutoPingDelivery(nodeKey string, nodeInfo discovery.NodeInfo, pending projection.AutoPingNodeState, tmpl string, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo, attempt int) {
 	budget := rt.nonDaemonDeliveryBudget()
 	if !budget.tryStart(nonDaemonDeliveryPathAutoPing) {
 		budget.queue(nonDaemonDeliveryPathAutoPing)
-		log.Printf("postman: WARNING: component=non_daemon_delivery event=workers_saturated path=auto_ping node=%s retry_in=%s\n", nodeKey, nonDaemonDeliveryRetryDelay)
+		if attempt >= maxAutoPingStaleRetries {
+			budget.unqueue(nonDaemonDeliveryPathAutoPing)
+			rt.finishAutoPing(nodeKey)
+			log.Printf("postman: WARNING: component=non_daemon_delivery event=stale_retry_dropped path=auto_ping node=%s attempts=%d\n", nodeKey, attempt)
+			return
+		}
+		log.Printf("postman: WARNING: component=non_daemon_delivery event=workers_saturated path=auto_ping node=%s retry_in=%s attempt=%d\n", nodeKey, nonDaemonDeliveryRetryDelay, attempt)
 		scheduler := rt.scheduleRuntimeTimer
 		if scheduler == nil {
 			scheduler = defaultRuntimeTimerScheduler
 		}
 		scheduler(nonDaemonDeliveryRetryDelay, "auto-ping-budget-retry", rt.events, func() {
 			budget.unqueue(nonDaemonDeliveryPathAutoPing)
-			rt.dispatchAutoPingDelivery(nodeKey, nodeInfo, pending, tmpl, activeNodes, livenessMap, adjacency, nodes)
+			rt.dispatchAutoPingDelivery(nodeKey, nodeInfo, pending, tmpl, activeNodes, livenessMap, adjacency, nodes, attempt+1)
 		})
 		return
 	}

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -592,6 +592,7 @@ func TestRuntimeDiagnosticsLogLineMarksUnsupportedRSSExplicitly(t *testing.T) {
 		"daemon_runtime",
 		status.DaemonRuntimeCardinality{},
 		status.DaemonSubmitRuntimeDiagnostics{},
+		status.NonDaemonDeliveryRuntimeDiagnostics{},
 		time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
 	)
 
@@ -1133,6 +1134,122 @@ func TestDispatchDaemonSubmitRequest_ReportsSaturationWhenWorkerLimitFull(t *tes
 	}
 	if !rt.daemonSubmitLastSaturatedAt.Equal(now) {
 		t.Fatalf("daemonSubmitLastSaturatedAt = %s, want %s", rt.daemonSubmitLastSaturatedAt, now)
+	}
+}
+
+func TestDispatchPostDelivery_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
+	now := time.Date(2026, 6, 3, 9, 0, 0, 0, time.UTC)
+	timerHarness := &runtimeTimerHarness{}
+	rt := &daemonRuntime{
+		daemonState:          NewDaemonState(0, "ctx-budget"),
+		events:               make(chan tui.DaemonEvent, 8),
+		scheduleRuntimeTimer: timerHarness.schedule,
+		clock: func() time.Time {
+			return now
+		},
+	}
+	budget := rt.nonDaemonDeliveryBudget()
+	for i := 0; i < budget.workerLimit(); i++ {
+		if !budget.tryStart(nonDaemonDeliveryPathPost) {
+			t.Fatalf("pre-fill post slot %d failed", i)
+		}
+	}
+
+	rt.dispatchPostDelivery(
+		filepath.Join(t.TempDir(), "post", "20260603-090000-r1111-from-a-to-b.md"),
+		"20260603-090000-r1111-from-a-to-b.md",
+		nil,
+		nil,
+		config.DefaultConfig(),
+		postDeliveryReservation{},
+	)
+
+	if len(timerHarness.calls) != 1 {
+		t.Fatalf("scheduled retries = %d, want 1", len(timerHarness.calls))
+	}
+	if got := timerHarness.calls[0].name; got != "post-delivery-budget-retry" {
+		t.Fatalf("retry timer name = %q, want post-delivery-budget-retry", got)
+	}
+	diag := rt.nonDaemonDeliveryRuntimeDiagnostics()
+	if diag.ActivePostCount != budget.workerLimit() || diag.PendingPostCount != 1 || diag.SaturationCount != 1 {
+		t.Fatalf("non-daemon diagnostics after post saturation = %#v", diag)
+	}
+}
+
+func TestDispatchAutoPing_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
+	now := time.Date(2026, 6, 3, 9, 1, 0, 0, time.UTC)
+	timerHarness := &runtimeTimerHarness{}
+	var calls atomic.Int32
+	rt := &daemonRuntime{
+		daemonState:          NewDaemonState(0, "ctx-budget"),
+		events:               make(chan tui.DaemonEvent, 8),
+		scheduleRuntimeTimer: timerHarness.schedule,
+		sendAutoPing: func(discovery.NodeInfo, string, string, string, *config.Config, []string, map[string]bool, map[string][]string, map[string]discovery.NodeInfo) (controlplane.SystemMessageResult, error) {
+			calls.Add(1)
+			return controlplane.SystemMessageResult{Delivered: true}, nil
+		},
+		clock: func() time.Time {
+			return now
+		},
+	}
+	budget := rt.nonDaemonDeliveryBudget()
+	for i := 0; i < budget.workerLimit(); i++ {
+		if !budget.tryStart(nonDaemonDeliveryPathAutoPing) {
+			t.Fatalf("pre-fill auto-PING slot %d failed", i)
+		}
+	}
+
+	rt.dispatchAutoPingDelivery(
+		"review:worker",
+		discovery.NodeInfo{SessionName: "review", PaneID: "%1"},
+		projection.AutoPingNodeState{},
+		"PING {node}",
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	if calls.Load() != 0 {
+		t.Fatalf("auto-PING sender calls = %d, want 0 while budget saturated", calls.Load())
+	}
+	if len(timerHarness.calls) != 1 {
+		t.Fatalf("scheduled retries = %d, want 1", len(timerHarness.calls))
+	}
+	if got := timerHarness.calls[0].name; got != "auto-ping-budget-retry" {
+		t.Fatalf("retry timer name = %q, want auto-ping-budget-retry", got)
+	}
+	diag := rt.nonDaemonDeliveryRuntimeDiagnostics()
+	if diag.ActiveAutoPingCount != budget.workerLimit() || diag.PendingAutoPingCount != 1 || diag.SaturationCount != 1 {
+		t.Fatalf("non-daemon diagnostics after auto-PING saturation = %#v", diag)
+	}
+}
+
+func TestNonDaemonBudget_BoundsManualPingFanout(t *testing.T) {
+	now := time.Date(2026, 6, 3, 9, 2, 0, 0, time.UTC)
+	budget := newNonDaemonDeliveryBudget(func() time.Time { return now })
+
+	workerLimit := budget.beginManualFanout(config.DefaultDaemonSubmitWorkerLimit + 3)
+	if workerLimit != config.DefaultDaemonSubmitWorkerLimit {
+		t.Fatalf("manual worker limit = %d, want %d", workerLimit, config.DefaultDaemonSubmitWorkerLimit)
+	}
+	diag := budget.snapshot()
+	if diag.PendingManualPingCount != config.DefaultDaemonSubmitWorkerLimit+3 || diag.SaturationCount != 1 || diag.LastSaturatedAt == "" {
+		t.Fatalf("manual fanout diagnostics after begin = %#v", diag)
+	}
+
+	for i := 0; i < workerLimit; i++ {
+		budget.unqueue(nonDaemonDeliveryPathManualPing)
+		if !budget.tryStart(nonDaemonDeliveryPathManualPing) {
+			t.Fatalf("manual worker %d could not start", i)
+		}
+	}
+	if budget.tryStart(nonDaemonDeliveryPathManualPing) {
+		t.Fatal("manual worker started beyond budget limit")
+	}
+	diag = budget.snapshot()
+	if diag.ActiveManualPingCount != workerLimit || diag.PendingManualPingCount != 3 || diag.SaturationCount != 2 {
+		t.Fatalf("manual fanout diagnostics while active = %#v", diag)
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1208,6 +1209,7 @@ func TestDispatchAutoPing_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		0,
 	)
 
 	if calls.Load() != 0 {
@@ -1222,6 +1224,103 @@ func TestDispatchAutoPing_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
 	diag := rt.nonDaemonDeliveryRuntimeDiagnostics()
 	if diag.ActiveAutoPingCount != budget.workerLimit() || diag.PendingAutoPingCount != 1 || diag.SaturationCount != 1 {
 		t.Fatalf("non-daemon diagnostics after auto-PING saturation = %#v", diag)
+	}
+}
+
+// TestDispatchAutoPing_DropsAfterMaxStaleRetries guards Issue #572 M1: once
+// a saturated auto-PING has exhausted maxAutoPingStaleRetries, it must be
+// dropped (not rescheduled against ever-staler topology) and must release
+// its beginAutoPing in-flight marker so the next scan can re-attempt the
+// node with fresh data.
+func TestDispatchAutoPing_DropsAfterMaxStaleRetries(t *testing.T) {
+	now := time.Date(2026, 6, 3, 9, 3, 0, 0, time.UTC)
+	timerHarness := &runtimeTimerHarness{}
+	var calls atomic.Int32
+	rt := &daemonRuntime{
+		daemonState:          NewDaemonState(0, "ctx-budget"),
+		events:               make(chan tui.DaemonEvent, 8),
+		scheduleRuntimeTimer: timerHarness.schedule,
+		sendAutoPing: func(discovery.NodeInfo, string, string, string, *config.Config, []string, map[string]bool, map[string][]string, map[string]discovery.NodeInfo) (controlplane.SystemMessageResult, error) {
+			calls.Add(1)
+			return controlplane.SystemMessageResult{Delivered: true}, nil
+		},
+		clock: func() time.Time {
+			return now
+		},
+	}
+	if !rt.beginAutoPing("review:worker") {
+		t.Fatal("beginAutoPing: want true for first call")
+	}
+	budget := rt.nonDaemonDeliveryBudget()
+	for i := 0; i < budget.workerLimit(); i++ {
+		if !budget.tryStart(nonDaemonDeliveryPathAutoPing) {
+			t.Fatalf("pre-fill auto-PING slot %d failed", i)
+		}
+	}
+
+	rt.dispatchAutoPingDelivery(
+		"review:worker",
+		discovery.NodeInfo{SessionName: "review", PaneID: "%1"},
+		projection.AutoPingNodeState{},
+		"PING {node}",
+		nil, nil, nil, nil,
+		maxAutoPingStaleRetries,
+	)
+
+	if calls.Load() != 0 {
+		t.Fatalf("auto-PING sender calls = %d, want 0 for a dropped stale retry", calls.Load())
+	}
+	if len(timerHarness.calls) != 0 {
+		t.Fatalf("scheduled retries = %d, want 0 (dropped, not rescheduled)", len(timerHarness.calls))
+	}
+	diag := rt.nonDaemonDeliveryRuntimeDiagnostics()
+	if diag.PendingAutoPingCount != 0 {
+		t.Fatalf("PendingAutoPingCount after drop = %d, want 0 (unqueue called)", diag.PendingAutoPingCount)
+	}
+	if rt.beginAutoPing("review:worker") != true {
+		t.Fatal("beginAutoPing after drop: want true — finishAutoPing should have released the in-flight marker")
+	}
+}
+
+// TestNonDaemonBudget_BoundsConcurrentInFlightUnderBurst directly tests
+// Issue #572 AC#4's literal claim — goroutine counts bounded under bursts —
+// at the semaphore primitive dispatchPostDelivery/dispatchAutoPingDelivery/
+// manual-PING all wrap: a burst well beyond workerLimit() must never let
+// more than workerLimit() holders be active at once.
+func TestNonDaemonBudget_BoundsConcurrentInFlightUnderBurst(t *testing.T) {
+	budget := newNonDaemonDeliveryBudget(time.Now)
+	limit := budget.workerLimit()
+	burst := limit * 4
+
+	var wg sync.WaitGroup
+	var active int32
+	var maxActive int32
+	for i := 0; i < burst; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !budget.tryStart(nonDaemonDeliveryPathPost) {
+				time.Sleep(time.Millisecond)
+			}
+			cur := atomic.AddInt32(&active, 1)
+			for {
+				prevMax := atomic.LoadInt32(&maxActive)
+				if cur <= prevMax || atomic.CompareAndSwapInt32(&maxActive, prevMax, cur) {
+					break
+				}
+			}
+			time.Sleep(3 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			budget.finish(nonDaemonDeliveryPathPost)
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxActive); got > int32(limit) {
+		t.Fatalf("max concurrent in-flight post deliveries under burst = %d, want <= %d", got, limit)
+	}
+	if diag := budget.snapshot(); diag.ActivePostCount != 0 || diag.PendingPostCount != 0 {
+		t.Fatalf("diagnostics after burst drains = %#v, want zeroed", diag)
 	}
 }
 
@@ -1250,6 +1349,51 @@ func TestNonDaemonBudget_BoundsManualPingFanout(t *testing.T) {
 	diag = budget.snapshot()
 	if diag.ActiveManualPingCount != workerLimit || diag.PendingManualPingCount != 3 || diag.SaturationCount != 2 {
 		t.Fatalf("manual fanout diagnostics while active = %#v", diag)
+	}
+}
+
+// TestNonDaemonBudget_SerializesConcurrentManualFanouts guards against
+// Issue #572 B2: overlapping manual-PING fanout rounds (e.g. two quick "p"
+// keypresses) must not run concurrently, or finishManualFanout's
+// reset-to-zero corrupts a still-running round's pending/saturation
+// counters and manualPingSem gets overcommitted across rounds.
+func TestNonDaemonBudget_SerializesConcurrentManualFanouts(t *testing.T) {
+	budget := newNonDaemonDeliveryBudget(time.Now)
+
+	const rounds = 6
+	var active int32
+	var maxActive int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < rounds; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			budget.beginManualFanout(2)
+			cur := atomic.AddInt32(&active, 1)
+			for {
+				prevMax := atomic.LoadInt32(&maxActive)
+				if cur <= prevMax || atomic.CompareAndSwapInt32(&maxActive, prevMax, cur) {
+					break
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			budget.finishManualFanout()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxActive); got != 1 {
+		t.Fatalf("max concurrent manual-PING fanout rounds = %d, want 1 (serialized)", got)
+	}
+	diag := budget.snapshot()
+	if diag.PendingManualPingCount != 0 || diag.SaturationCount != 0 {
+		t.Fatalf("diagnostics after all serialized rounds finished = %#v, want zeroed", diag)
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1177,6 +1177,106 @@ func TestDispatchPostDelivery_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
 	}
 }
 
+// TestDispatchPostDelivery_RetryReadsSharedNodesUnderRealScheduler guards
+// Issue #572 R2: the saturation-retry closure in dispatchPostDelivery runs on
+// its own goroutine via the real time.AfterFunc-based scheduler (not
+// runtimeTimerHarness, which invokes callbacks synchronously in the test's
+// own goroutine and so cannot exercise this race). Concurrently, this test's
+// writer goroutine mutates rt.nodes the same way the runtime's select loop
+// does. Before the R2 fix, the retry closure read rt.nodes directly and
+// raced with that writer under -race; it must instead read through
+// rt.sharedNodes.
+func TestDispatchPostDelivery_RetryReadsSharedNodesUnderRealScheduler(t *testing.T) {
+	now := time.Date(2026, 6, 3, 9, 5, 0, 0, time.UTC)
+	rt := &daemonRuntime{
+		daemonState: NewDaemonState(0, "ctx-budget-real-scheduler"),
+		events:      make(chan tui.DaemonEvent, 8),
+		clock: func() time.Time {
+			return now
+		},
+	}
+	initialNodes := map[string]discovery.NodeInfo{
+		"review:worker": {SessionName: "review", PaneID: "%1"},
+	}
+	rt.nodes = initialNodes
+	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
+	sharedNodes.Store(&initialNodes)
+	rt.sharedNodes = &sharedNodes
+
+	budget := rt.nonDaemonDeliveryBudget()
+	for i := 0; i < budget.workerLimit(); i++ {
+		if !budget.tryStart(nonDaemonDeliveryPathPost) {
+			t.Fatalf("pre-fill post slot %d failed", i)
+		}
+	}
+
+	// The pre-filled slots are never released, so the recursive
+	// dispatchPostDelivery call made by the retry closure always
+	// re-saturates and asks to be rescheduled again. scheduleRuntimeTimer
+	// only arms a real timer (via defaultRuntimeTimerScheduler) on its first
+	// call, so exactly one retry actually fires on its own goroutine — that
+	// single firing is enough to exercise the race-critical read against
+	// the writer goroutine below. The second call (the re-saturated retry
+	// asking to be rescheduled again) is a deliberate no-op, so the test
+	// never arms an unbounded chain of real timers.
+	var retryScheduled atomic.Int32
+	rt.scheduleRuntimeTimer = func(delay time.Duration, name string, events chan<- tui.DaemonEvent, callback func()) {
+		if retryScheduled.Add(1) > 1 {
+			return
+		}
+		defaultRuntimeTimerScheduler(delay, name, events, callback)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			fresh := map[string]discovery.NodeInfo{
+				fmt.Sprintf("review:worker-%d", i): {SessionName: "review", PaneID: "%1"},
+			}
+			rt.nodes = fresh
+			rt.storeSharedNodes()
+			i++
+		}
+	}()
+
+	rt.dispatchPostDelivery(
+		filepath.Join(t.TempDir(), "post", "20260603-090500-r2222-from-a-to-b.md"),
+		"20260603-090500-r2222-from-a-to-b.md",
+		nil,
+		nil,
+		config.DefaultConfig(),
+		postDeliveryReservation{},
+	)
+
+	// retryScheduled reaches 2 once: the real timer has fired, the closure
+	// has read nodes (racing against the writer goroutine above), and its
+	// recursive dispatchPostDelivery call has re-saturated and asked to be
+	// rescheduled again (a no-op, per the wrapper above).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && retryScheduled.Load() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(stop)
+	wg.Wait()
+
+	if got := retryScheduled.Load(); got != 2 {
+		t.Fatalf("scheduleRuntimeTimer calls = %d, want exactly 2 (one real retry firing, one re-saturated no-op)", got)
+	}
+	diag := rt.nonDaemonDeliveryRuntimeDiagnostics()
+	if diag.ActivePostCount != budget.workerLimit() || diag.PendingPostCount != 1 {
+		t.Fatalf("non-daemon diagnostics after retry cycle = %#v", diag)
+	}
+}
+
 func TestDispatchAutoPing_QueuesRetryWhenNonDaemonBudgetFull(t *testing.T) {
 	now := time.Date(2026, 6, 3, 9, 1, 0, 0, time.UTC)
 	timerHarness := &runtimeTimerHarness{}

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -203,13 +203,28 @@ type DaemonSubmitRuntimeDiagnostics struct {
 	LastSaturatedAt              string `json:"last_saturated_at,omitempty"`
 }
 
+// NonDaemonDeliveryRuntimeDiagnostics reports the shared post/auto-PING/
+// manual-PING delivery budget's state (Issue #572).
+type NonDaemonDeliveryRuntimeDiagnostics struct {
+	WorkerLimit            int    `json:"worker_limit"`
+	ActivePostCount        int    `json:"active_post_count"`
+	PendingPostCount       int    `json:"pending_post_count"`
+	ActiveAutoPingCount    int    `json:"active_auto_ping_count"`
+	PendingAutoPingCount   int    `json:"pending_auto_ping_count"`
+	ActiveManualPingCount  int    `json:"active_manual_ping_count"`
+	PendingManualPingCount int    `json:"pending_manual_ping_count"`
+	SaturationCount        int    `json:"saturation_count"`
+	LastSaturatedAt        string `json:"last_saturated_at,omitempty"`
+}
+
 type RuntimeDiagnostics struct {
-	Source       string                         `json:"source"`
-	PointInTime  bool                           `json:"point_in_time"`
-	ObservedAt   string                         `json:"observed_at"`
-	GoRuntime    GoRuntimeDiagnostics           `json:"go_runtime"`
-	Daemon       DaemonRuntimeCardinality       `json:"daemon"`
-	DaemonSubmit DaemonSubmitRuntimeDiagnostics `json:"daemon_submit"`
+	Source            string                              `json:"source"`
+	PointInTime       bool                                `json:"point_in_time"`
+	ObservedAt        string                              `json:"observed_at"`
+	GoRuntime         GoRuntimeDiagnostics                `json:"go_runtime"`
+	Daemon            DaemonRuntimeCardinality            `json:"daemon"`
+	DaemonSubmit      DaemonSubmitRuntimeDiagnostics      `json:"daemon_submit"`
+	NonDaemonDelivery NonDaemonDeliveryRuntimeDiagnostics `json:"non_daemon_delivery"`
 }
 
 type AllSessionStatus struct {

--- a/internal/status/contract_test.go
+++ b/internal/status/contract_test.go
@@ -43,6 +43,16 @@ func TestNewRuntimeDiagnosticsIsScalarAndPointInTime(t *testing.T) {
 		OldestLateResponseAgeSeconds: 120,
 		SaturationCount:              1,
 		LastSaturatedAt:              "2026-05-24T12:29:00Z",
+	}, NonDaemonDeliveryRuntimeDiagnostics{
+		WorkerLimit:            8,
+		ActivePostCount:        1,
+		PendingPostCount:       2,
+		ActiveAutoPingCount:    3,
+		PendingAutoPingCount:   4,
+		ActiveManualPingCount:  5,
+		PendingManualPingCount: 6,
+		SaturationCount:        7,
+		LastSaturatedAt:        "2026-05-24T12:28:00Z",
 	}, observedAt)
 
 	if diagnostics.Source != "daemon_runtime" {
@@ -62,6 +72,9 @@ func TestNewRuntimeDiagnosticsIsScalarAndPointInTime(t *testing.T) {
 	}
 	if diagnostics.DaemonSubmit.PendingRequestCount != 3 || diagnostics.DaemonSubmit.LateResponseCount != 2 {
 		t.Fatalf("DaemonSubmit diagnostics = %#v", diagnostics.DaemonSubmit)
+	}
+	if diagnostics.NonDaemonDelivery.ActivePostCount != 1 || diagnostics.NonDaemonDelivery.PendingManualPingCount != 6 {
+		t.Fatalf("NonDaemonDelivery diagnostics = %#v", diagnostics.NonDaemonDelivery)
 	}
 
 	payload, err := json.Marshal(diagnostics)

--- a/internal/status/runtime_diagnostics.go
+++ b/internal/status/runtime_diagnostics.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func NewRuntimeDiagnostics(source string, cardinality DaemonRuntimeCardinality, daemonSubmit DaemonSubmitRuntimeDiagnostics, observedAt time.Time) RuntimeDiagnostics {
+func NewRuntimeDiagnostics(source string, cardinality DaemonRuntimeCardinality, daemonSubmit DaemonSubmitRuntimeDiagnostics, nonDaemonDelivery NonDaemonDeliveryRuntimeDiagnostics, observedAt time.Time) RuntimeDiagnostics {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
@@ -36,7 +36,8 @@ func NewRuntimeDiagnostics(source string, cardinality DaemonRuntimeCardinality, 
 			},
 			GoroutineCount: runtime.NumGoroutine(),
 		},
-		Daemon:       cardinality,
-		DaemonSubmit: daemonSubmit,
+		Daemon:            cardinality,
+		DaemonSubmit:      daemonSubmit,
+		NonDaemonDelivery: nonDaemonDelivery,
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -61,6 +61,21 @@ type DaemonEvent struct {
 // DaemonEventMsg wraps DaemonEvent for tea.Msg interface.
 type DaemonEventMsg DaemonEvent
 
+// SendEventNonBlocking attempts to deliver event on events without blocking.
+// If the channel is nil, full, or has no ready receiver, the event is
+// dropped rather than stalling the caller (Issue #572 B1: a blocking send
+// here previously let a stalled TUI relay wedge budget-gated delivery
+// goroutines forever, leaking their concurrency slot).
+func SendEventNonBlocking(events chan<- DaemonEvent, event DaemonEvent) {
+	if events == nil {
+		return
+	}
+	select {
+	case events <- event:
+	default:
+	}
+}
+
 type startupReadinessTickMsg time.Time
 
 // TUICommand represents a command from TUI to the daemon.


### PR DESCRIPTION
Adds bounded concurrency and saturation counters for post delivery dispatches, auto-PING delivery, and manual PING target fan-out — the non-daemon-submit paths that previously spawned unbounded per-event goroutines. Includes two guardian-driven rework rounds: routing the manual-PING fanout's blocking sends through the non-blocking TUI relay to prevent a stalled relay from wedging the shared fanout lock, and fixing a data race where a retry closure on its own timer goroutine read the runtime's nodes field without synchronization (reproduced and verified under the race detector).

Supersedes #607 (rebuilt against current main after dispatch-site refactors). Closes #572.