### PR TITLE
feat(config): reviewer_node — route command approval to a designated node (#626)

### DIFF
--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -75,15 +75,21 @@ changed-digest approvals do not run.
 ## 4. Decisions
 
 When `execute-bash` requests approval, it prints the approval thread id in the
-wrapper metadata. A reviewer can decide the thread explicitly:
+wrapper metadata. The configured `reviewer_node`, running `--record-decision`
+from its own pane, can decide the thread explicitly:
 
 ```sh
 tmux-a2a-postman execute-bash \
   --thread-id command-approval-... \
-  --reviewer orchestrator \
   --record-decision approved \
   --reason "digest reviewed"
 ```
+
+The decision's reviewer identity always comes from the calling process's own
+tmux pane title, never from a flag; a `--reviewer` flag passed here has no
+effect on the outcome. A caller whose pane identity is not the thread's
+`reviewer_node` is refused with an error and no decision is recorded (#626
+B1-residual).
 
 Use `--record-decision rejected` to reject a pending command.
 
@@ -108,9 +114,16 @@ approval request.
 Only a reply whose sender matches the request's config-resolved
 `reviewer_node` is ever honored; a reply from anyone else is recorded as
 `wrong_reviewer` and has no effect on the command, regardless of what the
-policy's `reviewer` audit label says (#626 B1) — this is what makes
-self-approval impossible even though the `reviewer` label itself is a plain,
-requester-influenceable string.
+policy's `reviewer` audit label says (#626 B1) — the `reviewer` label itself
+is a plain, requester-influenceable string and has no bearing on this check.
+
+The same authenticated-caller requirement applies to `--record-decision`
+(#626 B1-residual): the decision's reviewer identity is always the calling
+process's own tmux pane title, never the `--reviewer` flag. A caller whose
+pane identity is not the thread's `reviewer_node` is refused outright, with
+no decision recorded — passing `--reviewer <reviewer_node_name>` on the
+command line has no effect on this check, since that name is a plain,
+readable config value, not proof of who is actually calling.
 
 ## 5. Inspection
 

--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -96,10 +96,21 @@ directly, carrying the command hash, label, mode, and the approval thread id
 record a decision by replying instead of running `--record-decision`
 directly, start the reply body with `APPROVED: <reason>` or
 `NOT APPROVED: <reason>` and keep the given `thread_id` in the reply's own
-frontmatter; the daemon records the decision automatically on delivery.
-Delivery is best-effort — a delivery failure (for example, the reviewer_node
-is not currently discoverable) is logged but never blocks or duplicates the
-already-journaled approval request.
+frontmatter; the daemon records the decision automatically on delivery. A
+reply on a command approval thread whose body does not start with one of
+those two prefixes is logged as a warning and not recorded as a decision at
+all — use `--record-decision` directly if you need to attach a reply body
+that doesn't fit that convention. Delivery itself is best-effort — a
+delivery failure (for example, the reviewer_node is not currently
+discoverable) is logged but never blocks or duplicates the already-journaled
+approval request.
+
+Only a reply whose sender matches the request's config-resolved
+`reviewer_node` is ever honored; a reply from anyone else is recorded as
+`wrong_reviewer` and has no effect on the command, regardless of what the
+policy's `reviewer` audit label says (#626 B1) — this is what makes
+self-approval impossible even though the `reviewer` label itself is a plain,
+requester-influenceable string.
 
 ## 5. Inspection
 

--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -14,6 +14,7 @@ requester = "worker"
 label = "nix-build"
 category = "verification"
 reviewer = "orchestrator"
+reviewer_node = "orchestrator"
 mode = "blocking"
 approval_ttl_seconds = 900
 ```
@@ -21,6 +22,27 @@ approval_ttl_seconds = 900
 `requester`, `label`, and `category` are match keys. Empty values and `*`
 match any value. CLI flags may override `reviewer`, `mode`, and expiry for a
 single command.
+
+`reviewer` is a plain audit label with no topology meaning. `reviewer_node`
+is different: it names a real, configured node (same family as `ui_node`),
+either globally under `[postman]` or per policy here, overriding the global
+default. It is what makes a mode restrictive at all — see the fail-open rule
+below.
+
+### 1.1. Fail-open rule (#626)
+
+Unless a VALID `reviewer_node` is configured — the field set AND resolving to
+a node that actually exists in this config — every command is treated as
+approved, in every mode, including `blocking`. This covers both an
+unconfigured `reviewer_node` and one that names a node that doesn't exist (a
+typo). Approval only becomes restrictive once a valid `reviewer_node` exists.
+
+Such commands are recorded with the decision `auto_approved_no_reviewer`,
+distinct from a real recorded approval, so the audit trail never confuses the
+two. A configured-but-unresolvable `reviewer_node` also produces a load-time
+warning and a visible `command_approval.unresolved_reviewers` marker in
+`get-status`, so a typo that silently disables blocking mode is loud rather
+than a silent no-op.
 
 ## 2. Running Commands
 
@@ -64,6 +86,20 @@ tmux-a2a-postman execute-bash \
 ```
 
 Use `--record-decision rejected` to reject a pending command.
+
+### 4.1. Delivery to a valid reviewer_node (#626)
+
+When a valid `reviewer_node` is configured and a command needs approval,
+`execute-bash` also delivers a reply-required postman message to that node
+directly, carrying the command hash, label, mode, and the approval thread id
+— so the reviewer does not have to poll `inspect-command-approvals`. To
+record a decision by replying instead of running `--record-decision`
+directly, start the reply body with `APPROVED: <reason>` or
+`NOT APPROVED: <reason>` and keep the given `thread_id` in the reply's own
+frontmatter; the daemon records the decision automatically on delivery.
+Delivery is best-effort — a delivery failure (for example, the reviewer_node
+is not currently discoverable) is logged but never blocks or duplicates the
+already-journaled approval request.
 
 ## 5. Inspection
 

--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -14,7 +14,7 @@ requester = "worker"
 label = "nix-build"
 category = "verification"
 reviewer = "orchestrator"
-reviewer_node = "orchestrator"
+command_approver_node = "orchestrator"
 mode = "blocking"
 approval_ttl_seconds = 900
 ```
@@ -23,26 +23,27 @@ approval_ttl_seconds = 900
 match any value. CLI flags may override `reviewer`, `mode`, and expiry for a
 single command.
 
-`reviewer` is a plain audit label with no topology meaning. `reviewer_node`
-is different: it names a real, configured node (same family as `ui_node`),
-either globally under `[postman]` or per policy here, overriding the global
-default. It is what makes a mode restrictive at all — see the fail-open rule
-below.
+`reviewer` is a plain audit label with no topology meaning.
+`command_approver_node` is different: it names a real, configured node (same
+family as `ui_node`), either globally under `[postman]` or per policy here,
+overriding the global default. It is what makes a mode restrictive at all — see
+the fail-open rule below.
 
 ### 1.1. Fail-open rule (#626)
 
-Unless a VALID `reviewer_node` is configured — the field set AND resolving to
-a node that actually exists in this config — every command is treated as
-approved, in every mode, including `blocking`. This covers both an
-unconfigured `reviewer_node` and one that names a node that doesn't exist (a
-typo). Approval only becomes restrictive once a valid `reviewer_node` exists.
+Unless a VALID `command_approver_node` is configured — the field set AND
+resolving to a node that actually exists in this config — every command is
+treated as approved, in every mode, including `blocking`. This covers both an
+unconfigured `command_approver_node` and one that names a node that doesn't
+exist (a typo). Approval only becomes restrictive once a valid
+`command_approver_node` exists.
 
 Such commands are recorded with the decision `auto_approved_no_reviewer`,
 distinct from a real recorded approval, so the audit trail never confuses the
-two. A configured-but-unresolvable `reviewer_node` also produces a load-time
-warning and a visible `command_approval.unresolved_reviewers` marker in
-`get-status`, so a typo that silently disables blocking mode is loud rather
-than a silent no-op.
+two. A configured-but-unresolvable `command_approver_node` also produces a
+load-time warning and a visible `command_approval.unresolved_command_approvers`
+marker in `get-status`, so a typo that silently disables blocking mode is loud
+rather than a silent no-op.
 
 ## 2. Running Commands
 
@@ -75,8 +76,8 @@ changed-digest approvals do not run.
 ## 4. Decisions
 
 When `execute-bash` requests approval, it prints the approval thread id in the
-wrapper metadata. The configured `reviewer_node`, running `--record-decision`
-from its own pane, can decide the thread explicitly:
+wrapper metadata. The configured `command_approver_node`, running
+`--record-decision` from its own pane, can decide the thread explicitly:
 
 ```sh
 tmux-a2a-postman execute-bash \
@@ -88,14 +89,14 @@ tmux-a2a-postman execute-bash \
 The decision's reviewer identity always comes from the calling process's own
 tmux pane title, never from a flag; a `--reviewer` flag passed here has no
 effect on the outcome. A caller whose pane identity is not the thread's
-`reviewer_node` is refused with an error and no decision is recorded (#626
-B1-residual).
+`command_approver_node` is refused with an error and no decision is recorded
+(#626 B1-residual).
 
 Use `--record-decision rejected` to reject a pending command.
 
-### 4.1. Delivery to a valid reviewer_node (#626)
+### 4.1. Delivery to a valid command_approver_node (#626)
 
-When a valid `reviewer_node` is configured and a command needs approval,
+When a valid `command_approver_node` is configured and a command needs approval,
 `execute-bash` also delivers a reply-required postman message to that node
 directly, carrying the command hash, label, mode, and the approval thread id
 — so the reviewer does not have to poll `inspect-command-approvals`. To
@@ -107,23 +108,23 @@ reply on a command approval thread whose body does not start with one of
 those two prefixes is logged as a warning and not recorded as a decision at
 all — use `--record-decision` directly if you need to attach a reply body
 that doesn't fit that convention. Delivery itself is best-effort — a
-delivery failure (for example, the reviewer_node is not currently
+delivery failure (for example, the command_approver_node is not currently
 discoverable) is logged but never blocks or duplicates the already-journaled
 approval request.
 
 Only a reply whose sender matches the request's config-resolved
-`reviewer_node` is ever honored; a reply from anyone else is recorded as
+`command_approver_node` is ever honored; a reply from anyone else is recorded as
 `wrong_reviewer` and has no effect on the command, regardless of what the
 policy's `reviewer` audit label says (#626 B1) — the `reviewer` label itself
 is a plain, requester-influenceable string and has no bearing on this check.
 
-The same authenticated-caller requirement applies to `--record-decision`
-(#626 B1-residual): the decision's reviewer identity is always the calling
-process's own tmux pane title, never the `--reviewer` flag. A caller whose
-pane identity is not the thread's `reviewer_node` is refused outright, with
-no decision recorded — passing `--reviewer <reviewer_node_name>` on the
-command line has no effect on this check, since that name is a plain,
-readable config value, not proof of who is actually calling.
+The same authenticated-caller requirement applies to `--record-decision` (#626
+B1-residual): the decision's reviewer identity is always the calling process's
+own tmux pane title, never the `--reviewer` flag. A caller whose pane identity
+is not the thread's `command_approver_node` is refused outright, with no
+decision recorded — passing `--reviewer <command_approver_node_name>` on the
+command line has no effect on this check, since that name is a plain, readable
+config value, not proof of who is actually calling.
 
 ## 5. Inspection
 

--- a/internal/cli/command_approval_delivery.go
+++ b/internal/cli/command_approval_delivery.go
@@ -20,7 +20,7 @@ import (
 var discoverNodesForCommandApprovalDeliveryFn = discovery.DiscoverNodesWithCollisions
 
 // deliverCommandApprovalRequest sends a reply-required postman message to
-// the resolved reviewer_node when a command needs approval (#626). This is
+// the resolved command_approver_node when a command needs approval (#626). This is
 // best-effort: a delivery failure is logged, not returned as an error — the
 // approval request has already been journaled by the caller regardless, so
 // a failed delivery only means the reviewer must be notified some other way
@@ -35,15 +35,15 @@ var discoverNodesForCommandApprovalDeliveryFn = discovery.DiscoverNodesWithColli
 // for the reviewer, reusing the existing fill-tracking UX; the reviewer's
 // reply must preserve the given thread_id in its own frontmatter for the
 // decision to be recorded automatically.
-func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, reviewerNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) {
+func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, commandApproverNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) {
 	nodes, _, err := discoverNodesForCommandApprovalDeliveryFn(baseDir, contextID, requesterSessionName)
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: discovering nodes: %v\n", err)
 		return
 	}
-	reviewerInfo, ok := nodes[reviewerNode]
+	reviewerInfo, ok := nodes[commandApproverNode]
 	if !ok {
-		log.Printf("postman: WARNING: command approval delivery: reviewer_node %q not found among discovered nodes; falling back to inspect-command-approvals\n", reviewerNode)
+		log.Printf("postman: WARNING: command approval delivery: command_approver_node %q not found among discovered nodes; falling back to inspect-command-approvals\n", commandApproverNode)
 		return
 	}
 	if err := config.CreateSessionDirs(reviewerInfo.SessionDir); err != nil {
@@ -55,7 +55,7 @@ func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, reque
 		log.Printf("postman: WARNING: command approval delivery: generating input request id: %v\n", err)
 		return
 	}
-	filename, err := message.GenerateFilename(now.Format("20060102-150405"), policy.Requester, reviewerNode, reviewerInfo.SessionName)
+	filename, err := message.GenerateFilename(now.Format("20060102-150405"), policy.Requester, commandApproverNode, reviewerInfo.SessionName)
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: generating filename: %v\n", err)
 		return
@@ -74,7 +74,7 @@ func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, reque
 
 	content := fmt.Sprintf(
 		"---\nparams:\n  contextId: %s\n  from: %s\n  to: %s\n  messageId: %s\n  replyPolicy: required\n  input_request_id: %s\n  thread_id: %s\n  timestamp: %s\n---\n\n%s\n",
-		contextID, policy.Requester, reviewerNode, filename, inputRequestID, threadID, now.UTC().Format(time.RFC3339), body.String(),
+		contextID, policy.Requester, commandApproverNode, filename, inputRequestID, threadID, now.UTC().Format(time.RFC3339), body.String(),
 	)
 
 	// Write to draft/ then rename into post/ (matching send_message.go's

--- a/internal/cli/command_approval_delivery.go
+++ b/internal/cli/command_approval_delivery.go
@@ -13,6 +13,12 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
 )
 
+// discoverNodesForCommandApprovalDeliveryFn is a seam over
+// discovery.DiscoverNodesWithCollisions (#626 M2): the real implementation
+// shells out to tmux, which is unavailable/nondeterministic in unit tests;
+// tests override this var and restore it via t.Cleanup.
+var discoverNodesForCommandApprovalDeliveryFn = discovery.DiscoverNodesWithCollisions
+
 // deliverCommandApprovalRequest sends a reply-required postman message to
 // the resolved reviewer_node when a command needs approval (#626). This is
 // best-effort: a delivery failure is logged, not returned as an error — the
@@ -30,7 +36,7 @@ import (
 // reply must preserve the given thread_id in its own frontmatter for the
 // decision to be recorded automatically.
 func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, reviewerNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) {
-	nodes, _, err := discovery.DiscoverNodesWithCollisions(baseDir, contextID, requesterSessionName)
+	nodes, _, err := discoverNodesForCommandApprovalDeliveryFn(baseDir, contextID, requesterSessionName)
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: discovering nodes: %v\n", err)
 		return
@@ -71,12 +77,26 @@ func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, reque
 		contextID, policy.Requester, reviewerNode, filename, inputRequestID, threadID, now.UTC().Format(time.RFC3339), body.String(),
 	)
 
+	// Write to draft/ then rename into post/ (matching send_message.go's
+	// atomicity convention, #626 FIX-SOON) rather than writing post/
+	// directly — this was the only post/ writer skipping it, and a partial
+	// direct write could be picked up mid-write by the daemon's watcher.
+	draftDir := filepath.Join(reviewerInfo.SessionDir, "draft")
+	if err := os.MkdirAll(draftDir, 0o700); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: creating draft directory: %v\n", err)
+		return
+	}
+	draftPath := filepath.Join(draftDir, filename)
+	if err := os.WriteFile(draftPath, []byte(content), 0o600); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: writing draft: %v\n", err)
+		return
+	}
 	postDir := filepath.Join(reviewerInfo.SessionDir, "post")
 	if err := os.MkdirAll(postDir, 0o700); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: creating post directory: %v\n", err)
 		return
 	}
-	if err := os.WriteFile(filepath.Join(postDir, filename), []byte(content), 0o644); err != nil {
-		log.Printf("postman: WARNING: command approval delivery: writing message: %v\n", err)
+	if err := os.Rename(draftPath, filepath.Join(postDir, filename)); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: moving message into post: %v\n", err)
 	}
 }

--- a/internal/cli/command_approval_delivery.go
+++ b/internal/cli/command_approval_delivery.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/message"
+)
+
+// deliverCommandApprovalRequest sends a reply-required postman message to
+// the resolved reviewer_node when a command needs approval (#626). This is
+// best-effort: a delivery failure is logged, not returned as an error — the
+// approval request has already been journaled by the caller regardless, so
+// a failed delivery only means the reviewer must be notified some other way
+// (e.g. inspect-command-approvals), never that anything blocks or that the
+// request goes unrecorded.
+//
+// The reviewer's reply is matched back to this request by thread_id (the
+// same content-level correlation the daemon already uses for the
+// orchestrator/critic approval flow), not by the input_request_id set here.
+// input_request_id/reply_policy: required are still set so the request
+// shows up as a normal open input request in get-status and inspect-message
+// for the reviewer, reusing the existing fill-tracking UX; the reviewer's
+// reply must preserve the given thread_id in its own frontmatter for the
+// decision to be recorded automatically.
+func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, reviewerNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) {
+	nodes, _, err := discovery.DiscoverNodesWithCollisions(baseDir, contextID, requesterSessionName)
+	if err != nil {
+		log.Printf("postman: WARNING: command approval delivery: discovering nodes: %v\n", err)
+		return
+	}
+	reviewerInfo, ok := nodes[reviewerNode]
+	if !ok {
+		log.Printf("postman: WARNING: command approval delivery: reviewer_node %q not found among discovered nodes; falling back to inspect-command-approvals\n", reviewerNode)
+		return
+	}
+	if err := config.CreateSessionDirs(reviewerInfo.SessionDir); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: creating reviewer session directories: %v\n", err)
+		return
+	}
+	inputRequestID, err := generateInputRequestID()
+	if err != nil {
+		log.Printf("postman: WARNING: command approval delivery: generating input request id: %v\n", err)
+		return
+	}
+	filename, err := message.GenerateFilename(now.Format("20060102-150405"), policy.Requester, reviewerNode, reviewerInfo.SessionName)
+	if err != nil {
+		log.Printf("postman: WARNING: command approval delivery: generating filename: %v\n", err)
+		return
+	}
+
+	var body strings.Builder
+	fmt.Fprintf(&body, "Command approval requested by %s (mode: %s, label: %s, category: %s).\n\n", policy.Requester, policy.Mode, policy.Label, policy.Category)
+	fmt.Fprintf(&body, "Command hash: %s\n", commandHash)
+	if strings.TrimSpace(reason) != "" {
+		fmt.Fprintf(&body, "Requester-provided reason: %s\n", reason)
+	}
+	if storeCommandText {
+		fmt.Fprintf(&body, "\nThe full command text is stored in this session's durable audit journal (--store-command-text was set); it is not repeated in this message.\n")
+	}
+	fmt.Fprintf(&body, "\nTo record your decision, reply with a body starting with `APPROVED: <reason>` or `NOT APPROVED: <reason>`, and keep this thread id in your reply's frontmatter:\n\nthread_id: %s\n", threadID)
+
+	content := fmt.Sprintf(
+		"---\nparams:\n  contextId: %s\n  from: %s\n  to: %s\n  messageId: %s\n  replyPolicy: required\n  input_request_id: %s\n  thread_id: %s\n  timestamp: %s\n---\n\n%s\n",
+		contextID, policy.Requester, reviewerNode, filename, inputRequestID, threadID, now.UTC().Format(time.RFC3339), body.String(),
+	)
+
+	postDir := filepath.Join(reviewerInfo.SessionDir, "post")
+	if err := os.MkdirAll(postDir, 0o700); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: creating post directory: %v\n", err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(postDir, filename), []byte(content), 0o644); err != nil {
+		log.Printf("postman: WARNING: command approval delivery: writing message: %v\n", err)
+	}
+}

--- a/internal/cli/command_approval_delivery_test.go
+++ b/internal/cli/command_approval_delivery_test.go
@@ -91,7 +91,7 @@ func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testi
 }
 
 // TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort guards the
-// no-op-not-crash behavior when the reviewer_node isn't currently
+// no-op-not-crash behavior when the command_approver_node isn't currently
 // discoverable: delivery must log and return without writing anything or
 // panicking, since the approval request has already been journaled by the
 // caller regardless of delivery outcome.

--- a/internal/cli/command_approval_delivery_test.go
+++ b/internal/cli/command_approval_delivery_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+)
+
+// TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir guards
+// #626 M2: command_approval_delivery.go had zero test coverage because the
+// real discovery.DiscoverNodesWithCollisions shells out to tmux. This test
+// exercises deliverCommandApprovalRequest through the discovery seam
+// instead, and asserts the delivered message lands in the reviewer's post/
+// directory (not left behind in draft/), with 0600 permissions and the
+// expected frontmatter and thread id instructions.
+func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testing.T) {
+	baseDir := t.TempDir()
+	reviewerSessionDir := filepath.Join(baseDir, "ctx-626", "reviewer-session")
+	if err := config.CreateSessionDirs(reviewerSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(reviewer) failed: %v", err)
+	}
+
+	original := discoverNodesForCommandApprovalDeliveryFn
+	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"orchestrator": {PaneID: "%2", SessionName: "reviewer-session", SessionDir: reviewerSessionDir},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
+
+	policy := resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "unassigned",
+		Mode:      "blocking",
+		Label:     "protected",
+		Category:  "release",
+	}
+	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
+	threadID := "command-approval-aabbccdd11223344"
+
+	deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", threadID, "sha256:deadbeef", "verify release build", false, now)
+
+	draftEntries, err := os.ReadDir(filepath.Join(reviewerSessionDir, "draft"))
+	if err != nil {
+		t.Fatalf("ReadDir(draft) error = %v", err)
+	}
+	if len(draftEntries) != 0 {
+		t.Fatalf("draft/ has %d leftover entries, want 0 (message must be renamed into post/)", len(draftEntries))
+	}
+
+	postEntries, err := os.ReadDir(filepath.Join(reviewerSessionDir, "post"))
+	if err != nil {
+		t.Fatalf("ReadDir(post) error = %v", err)
+	}
+	if len(postEntries) != 1 {
+		t.Fatalf("post/ has %d entries, want 1", len(postEntries))
+	}
+
+	postPath := filepath.Join(reviewerSessionDir, "post", postEntries[0].Name())
+	info, err := os.Stat(postPath)
+	if err != nil {
+		t.Fatalf("Stat(post message) error = %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("post message perm = %v, want 0600", perm)
+	}
+
+	content, err := os.ReadFile(postPath)
+	if err != nil {
+		t.Fatalf("ReadFile(post message) error = %v", err)
+	}
+	body := string(content)
+	for _, want := range []string{
+		"from: worker",
+		"to: orchestrator",
+		"replyPolicy: required",
+		"thread_id: " + threadID,
+		"Command hash: sha256:deadbeef",
+		"Requester-provided reason: verify release build",
+		"APPROVED: <reason>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("delivered message missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+// TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort guards the
+// no-op-not-crash behavior when the reviewer_node isn't currently
+// discoverable: delivery must log and return without writing anything or
+// panicking, since the approval request has already been journaled by the
+// caller regardless of delivery outcome.
+func TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort(t *testing.T) {
+	baseDir := t.TempDir()
+
+	original := discoverNodesForCommandApprovalDeliveryFn
+	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
+
+	policy := resolvedCommandApprovalPolicy{Requester: "worker", Mode: "blocking", Label: "protected"}
+	deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", "command-approval-x", "sha256:x", "", false, time.Now())
+	// No panic and no filesystem assertion needed: absence of a reviewer
+	// session directory under baseDir is itself proof nothing was written.
+	if _, err := os.Stat(filepath.Join(baseDir, "ctx-626")); !os.IsNotExist(err) {
+		t.Fatalf("expected no session directories to be created, stat error = %v", err)
+	}
+}

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -55,13 +55,13 @@ func (e commandExitError) ExitCode() int {
 }
 
 type resolvedCommandApprovalPolicy struct {
-	Requester            string
-	Reviewer             string
-	Mode                 string
-	Label                string
-	Category             string
-	TTL                  time.Duration
-	ReviewerNodeOverride string // per-policy reviewer_node override, if any (#626)
+	Requester                   string
+	Reviewer                    string
+	Mode                        string
+	Label                       string
+	Category                    string
+	TTL                         time.Duration
+	CommandApproverNodeOverride string // per-policy command_approver_node override, if any (#626)
 }
 
 type commandApprovalEvaluation struct {
@@ -158,7 +158,7 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		resolvedThreadID = commandApprovalThreadID(policy, commandHash)
 	}
 	expiresAt := ctx.now().Add(policy.TTL).UTC().Format(time.RFC3339Nano)
-	reviewerNode, validReviewer := cfg.ResolveReviewerNode(policy.ReviewerNodeOverride)
+	commandApproverNode, validReviewer := cfg.ResolveCommandApproverNode(policy.CommandApproverNodeOverride)
 
 	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, validReviewer, ctx.now())
 	if err != nil {
@@ -166,14 +166,14 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 	}
 	if !evaluation.Allowed {
 		// Reached only when validReviewer is true: evaluateCommandApproval
-		// short-circuits to Allowed:true whenever no valid reviewer_node is
-		// configured, so reviewerNode here is always the trusted,
+		// short-circuits to Allowed:true whenever no valid command_approver_node is
+		// configured, so commandApproverNode here is always the trusted,
 		// config-resolved node name (#626 B1) — never a requester-supplied
 		// value.
-		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, reviewerNode, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
+		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, commandApproverNode, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
 			return err
 		}
-		deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, reviewerNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
+		deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, commandApproverNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
 	}
 
 	decision := decisionForPolicy(policy.Mode, evaluation, *overrideApproval)
@@ -273,10 +273,10 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 	// #626 B1-residual: the decision's reviewer identity is the CALLER's
 	// own authenticated identity (tmux pane title), never a flag.
 	// --reviewer must never influence whether a decision is accepted — a
-	// requester could otherwise pass --reviewer <reviewer_node_name>,
+	// requester could otherwise pass --reviewer <command_approver_node_name>,
 	// trivially readable from postman.toml or get-status, and self-approve
 	// exactly as before. The caller is accepted only when this
-	// authenticated identity matches the thread's own ReviewerNode, the
+	// authenticated identity matches the thread's own CommandApproverNode, the
 	// trusted, config-resolved value captured once at request time (#626
 	// B1) — never re-resolved from current config, so a decision can't be
 	// laundered through a config change between request and decision time
@@ -289,14 +289,14 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 	if err != nil {
 		return err
 	}
-	var reviewerNode string
+	var commandApproverNode string
 	if ok {
 		if thread, found := state.Threads[opts.threadID]; found {
-			reviewerNode = thread.ReviewerNode
+			commandApproverNode = thread.CommandApproverNode
 		}
 	}
-	if reviewerNode == "" || authenticatedCaller != reviewerNode {
-		return fmt.Errorf("--record-decision refused: caller %q is not the configured reviewer_node for thread %q", authenticatedCaller, opts.threadID)
+	if commandApproverNode == "" || authenticatedCaller != commandApproverNode {
+		return fmt.Errorf("--record-decision refused: caller %q is not the configured command_approver_node for thread %q", authenticatedCaller, opts.threadID)
 	}
 
 	payload := journal.CommandApprovalDecisionPayload{
@@ -372,7 +372,7 @@ func resolveCommandApprovalPolicy(cfg *config.Config, requester, label, category
 		if candidate.ApprovalTTLSeconds > 0 {
 			policy.TTL = time.Duration(candidate.ApprovalTTLSeconds * float64(time.Second))
 		}
-		policy.ReviewerNodeOverride = strings.TrimSpace(candidate.ReviewerNode)
+		policy.CommandApproverNodeOverride = strings.TrimSpace(candidate.CommandApproverNode)
 		break
 	}
 	if strings.TrimSpace(reviewerFlag) != "" {
@@ -433,21 +433,21 @@ func validateCommandApprovalThreadID(threadID string) error {
 
 // commandApprovalDecisionAutoApprovedNoReviewer is the distinct decision
 // label used whenever the unified fail-open rule (#626) applies: no valid
-// reviewer_node is configured, so the command is approved regardless of
+// command_approver_node is configured, so the command is approved regardless of
 // mode. This must never be conflated with an actual recorded approval.
 const commandApprovalDecisionAutoApprovedNoReviewer = "auto_approved_no_reviewer"
 
 func evaluateCommandApproval(sessionDir string, policy resolvedCommandApprovalPolicy, threadID, commandHash string, validReviewer bool, now time.Time) (commandApprovalEvaluation, error) {
 	if !validReviewer {
 		// #626 decided requirement 1 (unified fail-open rule): unless a
-		// valid reviewer_node is configured, every command is treated as
+		// valid command_approver_node is configured, every command is treated as
 		// approved across all three modes, including blocking. This is
 		// evaluated before any projection lookup so a missing/unresolvable
-		// reviewer_node never depends on prior approval state.
+		// command_approver_node never depends on prior approval state.
 		return commandApprovalEvaluation{
 			Decision: commandApprovalDecisionAutoApprovedNoReviewer,
 			Allowed:  true,
-			Reason:   "no valid reviewer_node configured; command approval fails open",
+			Reason:   "no valid command_approver_node configured; command approval fails open",
 		}, nil
 	}
 	state, ok, err := projection.ProjectCommandApprovalState(sessionDir, now)
@@ -553,17 +553,17 @@ func blockedCommandApprovalReason(mode string, evaluation commandApprovalEvaluat
 	}
 }
 
-func recordCommandApprovalRequest(sessionDir, contextID, sessionName, threadID string, policy resolvedCommandApprovalPolicy, reviewerNode, commandHash, reason, expiresAt, commandText string, storeCommandText bool, now time.Time) error {
+func recordCommandApprovalRequest(sessionDir, contextID, sessionName, threadID string, policy resolvedCommandApprovalPolicy, commandApproverNode, commandHash, reason, expiresAt, commandText string, storeCommandText bool, now time.Time) error {
 	payload := journal.CommandApprovalRequestPayload{
-		Requester:    policy.Requester,
-		Reviewer:     policy.Reviewer,
-		ReviewerNode: reviewerNode,
-		Mode:         policy.Mode,
-		Label:        policy.Label,
-		Category:     policy.Category,
-		CommandHash:  commandHash,
-		Reason:       reason,
-		ExpiresAt:    expiresAt,
+		Requester:           policy.Requester,
+		Reviewer:            policy.Reviewer,
+		CommandApproverNode: commandApproverNode,
+		Mode:                policy.Mode,
+		Label:               policy.Label,
+		Category:            policy.Category,
+		CommandHash:         commandHash,
+		Reason:              reason,
+		ExpiresAt:           expiresAt,
 	}
 	if storeCommandText {
 		payload.CommandText = commandText

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -54,12 +54,13 @@ func (e commandExitError) ExitCode() int {
 }
 
 type resolvedCommandApprovalPolicy struct {
-	Requester string
-	Reviewer  string
-	Mode      string
-	Label     string
-	Category  string
-	TTL       time.Duration
+	Requester            string
+	Reviewer             string
+	Mode                 string
+	Label                string
+	Category             string
+	TTL                  time.Duration
+	ReviewerNodeOverride string // per-policy reviewer_node override, if any (#626)
 }
 
 type commandApprovalEvaluation struct {
@@ -155,14 +156,18 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		resolvedThreadID = commandApprovalThreadID(policy, commandHash)
 	}
 	expiresAt := ctx.now().Add(policy.TTL).UTC().Format(time.RFC3339Nano)
+	reviewerNode, validReviewer := cfg.ResolveReviewerNode(policy.ReviewerNodeOverride)
 
-	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, ctx.now())
+	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, validReviewer, ctx.now())
 	if err != nil {
 		return err
 	}
 	if !evaluation.Allowed {
 		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
 			return err
+		}
+		if validReviewer {
+			deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, reviewerNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
 		}
 	}
 
@@ -338,6 +343,7 @@ func resolveCommandApprovalPolicy(cfg *config.Config, requester, label, category
 		if candidate.ApprovalTTLSeconds > 0 {
 			policy.TTL = time.Duration(candidate.ApprovalTTLSeconds * float64(time.Second))
 		}
+		policy.ReviewerNodeOverride = strings.TrimSpace(candidate.ReviewerNode)
 		break
 	}
 	if strings.TrimSpace(reviewerFlag) != "" {
@@ -375,7 +381,25 @@ func commandApprovalThreadID(policy resolvedCommandApprovalPolicy, commandHash s
 	return "command-approval-" + hex.EncodeToString(sum[:8])
 }
 
-func evaluateCommandApproval(sessionDir string, policy resolvedCommandApprovalPolicy, threadID, commandHash string, now time.Time) (commandApprovalEvaluation, error) {
+// commandApprovalDecisionAutoApprovedNoReviewer is the distinct decision
+// label used whenever the unified fail-open rule (#626) applies: no valid
+// reviewer_node is configured, so the command is approved regardless of
+// mode. This must never be conflated with an actual recorded approval.
+const commandApprovalDecisionAutoApprovedNoReviewer = "auto_approved_no_reviewer"
+
+func evaluateCommandApproval(sessionDir string, policy resolvedCommandApprovalPolicy, threadID, commandHash string, validReviewer bool, now time.Time) (commandApprovalEvaluation, error) {
+	if !validReviewer {
+		// #626 decided requirement 1 (unified fail-open rule): unless a
+		// valid reviewer_node is configured, every command is treated as
+		// approved across all three modes, including blocking. This is
+		// evaluated before any projection lookup so a missing/unresolvable
+		// reviewer_node never depends on prior approval state.
+		return commandApprovalEvaluation{
+			Decision: commandApprovalDecisionAutoApprovedNoReviewer,
+			Allowed:  true,
+			Reason:   "no valid reviewer_node configured; command approval fails open",
+		}, nil
+	}
 	state, ok, err := projection.ProjectCommandApprovalState(sessionDir, now)
 	if err != nil {
 		return commandApprovalEvaluation{}, err
@@ -444,6 +468,9 @@ func evaluationForThread(thread projection.CommandApprovalThread) commandApprova
 }
 
 func decisionForPolicy(mode string, evaluation commandApprovalEvaluation, override bool) string {
+	if evaluation.Decision == commandApprovalDecisionAutoApprovedNoReviewer {
+		return evaluation.Decision
+	}
 	if evaluation.Allowed {
 		return "approved"
 	}

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -152,6 +153,9 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 	}
 	commandHash := commandDigest(commandText)
 	resolvedThreadID := strings.TrimSpace(*threadID)
+	if err := validateCommandApprovalThreadID(resolvedThreadID); err != nil {
+		return err
+	}
 	if resolvedThreadID == "" {
 		resolvedThreadID = commandApprovalThreadID(policy, commandHash)
 	}
@@ -163,12 +167,15 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		return err
 	}
 	if !evaluation.Allowed {
-		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
+		// Reached only when validReviewer is true: evaluateCommandApproval
+		// short-circuits to Allowed:true whenever no valid reviewer_node is
+		// configured, so reviewerNode here is always the trusted,
+		// config-resolved node name (#626 B1) — never a requester-supplied
+		// value.
+		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, reviewerNode, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
 			return err
 		}
-		if validReviewer {
-			deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, reviewerNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
-		}
+		deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, reviewerNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
 	}
 
 	decision := decisionForPolicy(policy.Mode, evaluation, *overrideApproval)
@@ -256,6 +263,9 @@ type executeBashDecisionOptions struct {
 func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptions) error {
 	if strings.TrimSpace(opts.threadID) == "" {
 		return fmt.Errorf("--thread-id is required with --record-decision")
+	}
+	if err := validateCommandApprovalThreadID(strings.TrimSpace(opts.threadID)); err != nil {
+		return err
 	}
 	reviewer := strings.TrimSpace(opts.reviewer)
 	if reviewer == "" {
@@ -381,6 +391,27 @@ func commandApprovalThreadID(policy resolvedCommandApprovalPolicy, commandHash s
 	return "command-approval-" + hex.EncodeToString(sum[:8])
 }
 
+var commandApprovalThreadIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// validateCommandApprovalThreadID rejects a --thread-id containing anything
+// outside a conservative safe charset (#626 M1). resolvedThreadID gets
+// interpolated directly into hand-built YAML frontmatter in
+// deliverCommandApprovalRequest via fmt.Sprintf, and that frontmatter is
+// parsed by a naive line scanner (internal/envelope) — a newline plus
+// indentation in an otherwise-unvalidated --thread-id could inject or
+// override other params fields (for example forcing replyPolicy: none to
+// hide the delivered request). An empty value is fine here; the caller then
+// derives a fresh, safe thread id via commandApprovalThreadID.
+func validateCommandApprovalThreadID(threadID string) error {
+	if threadID == "" {
+		return nil
+	}
+	if !commandApprovalThreadIDPattern.MatchString(threadID) {
+		return fmt.Errorf("--thread-id %q contains characters outside [A-Za-z0-9._-]", threadID)
+	}
+	return nil
+}
+
 // commandApprovalDecisionAutoApprovedNoReviewer is the distinct decision
 // label used whenever the unified fail-open rule (#626) applies: no valid
 // reviewer_node is configured, so the command is approved regardless of
@@ -503,16 +534,17 @@ func blockedCommandApprovalReason(mode string, evaluation commandApprovalEvaluat
 	}
 }
 
-func recordCommandApprovalRequest(sessionDir, contextID, sessionName, threadID string, policy resolvedCommandApprovalPolicy, commandHash, reason, expiresAt, commandText string, storeCommandText bool, now time.Time) error {
+func recordCommandApprovalRequest(sessionDir, contextID, sessionName, threadID string, policy resolvedCommandApprovalPolicy, reviewerNode, commandHash, reason, expiresAt, commandText string, storeCommandText bool, now time.Time) error {
 	payload := journal.CommandApprovalRequestPayload{
-		Requester:   policy.Requester,
-		Reviewer:    policy.Reviewer,
-		Mode:        policy.Mode,
-		Label:       policy.Label,
-		Category:    policy.Category,
-		CommandHash: commandHash,
-		Reason:      reason,
-		ExpiresAt:   expiresAt,
+		Requester:    policy.Requester,
+		Reviewer:     policy.Reviewer,
+		ReviewerNode: reviewerNode,
+		Mode:         policy.Mode,
+		Label:        policy.Label,
+		Category:     policy.Category,
+		CommandHash:  commandHash,
+		Reason:       reason,
+		ExpiresAt:    expiresAt,
 	}
 	if storeCommandText {
 		payload.CommandText = commandText

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -117,18 +117,12 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		return fmt.Errorf("creating session directories: %w", err)
 	}
 
-	resolvedRequester, err := resolveExecuteBashRequester(ctx, *requester)
-	if err != nil {
-		return err
-	}
 	if *recordDecision != "" {
 		return recordExecuteBashDecision(ctx, executeBashDecisionOptions{
 			sessionDir:       sessionDir,
 			contextID:        resolvedContextID,
 			sessionName:      resolvedSessionName,
 			threadID:         *threadID,
-			reviewer:         *reviewer,
-			fallbackReviewer: resolvedRequester,
 			decision:         *recordDecision,
 			reason:           *reason,
 			storeCommandText: *storeCommandText,
@@ -136,6 +130,10 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		})
 	}
 
+	resolvedRequester, err := resolveExecuteBashRequester(ctx, *requester)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(*label) == "" {
 		return fmt.Errorf("--label is required")
 	}
@@ -252,8 +250,6 @@ type executeBashDecisionOptions struct {
 	contextID        string
 	sessionName      string
 	threadID         string
-	reviewer         string
-	fallbackReviewer string
 	decision         string
 	reason           string
 	storeCommandText bool
@@ -267,21 +263,44 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 	if err := validateCommandApprovalThreadID(strings.TrimSpace(opts.threadID)); err != nil {
 		return err
 	}
-	reviewer := strings.TrimSpace(opts.reviewer)
-	if reviewer == "" {
-		reviewer = strings.TrimSpace(opts.fallbackReviewer)
-	}
-	if reviewer == "" {
-		return fmt.Errorf("--reviewer is required with --record-decision when requester auto-detection is unavailable")
-	}
 	decision := strings.TrimSpace(opts.decision)
 	switch decision {
 	case string(journal.ApprovalDecisionApproved), string(journal.ApprovalDecisionRejected):
 	default:
 		return fmt.Errorf("--record-decision must be approved or rejected")
 	}
+
+	// #626 B1-residual: the decision's reviewer identity is the CALLER's
+	// own authenticated identity (tmux pane title), never a flag.
+	// --reviewer must never influence whether a decision is accepted — a
+	// requester could otherwise pass --reviewer <reviewer_node_name>,
+	// trivially readable from postman.toml or get-status, and self-approve
+	// exactly as before. The caller is accepted only when this
+	// authenticated identity matches the thread's own ReviewerNode, the
+	// trusted, config-resolved value captured once at request time (#626
+	// B1) — never re-resolved from current config, so a decision can't be
+	// laundered through a config change between request and decision time
+	// either.
+	authenticatedCaller := strings.TrimSpace(ctx.getTmuxPaneName())
+	if authenticatedCaller == "" {
+		return fmt.Errorf("--record-decision requires a resolvable tmux pane title identity; run inside tmux")
+	}
+	state, ok, err := projection.ProjectCommandApprovalState(opts.sessionDir, ctx.now())
+	if err != nil {
+		return err
+	}
+	var reviewerNode string
+	if ok {
+		if thread, found := state.Threads[opts.threadID]; found {
+			reviewerNode = thread.ReviewerNode
+		}
+	}
+	if reviewerNode == "" || authenticatedCaller != reviewerNode {
+		return fmt.Errorf("--record-decision refused: caller %q is not the configured reviewer_node for thread %q", authenticatedCaller, opts.threadID)
+	}
+
 	payload := journal.CommandApprovalDecisionPayload{
-		Reviewer: reviewer,
+		Reviewer: authenticatedCaller,
 		Decision: journal.ApprovalDecision(decision),
 		Reason:   opts.reason,
 	}
@@ -290,7 +309,7 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 	}
 	result := executeBashResult{
 		Status:         "decision_recorded",
-		Reviewer:       reviewer,
+		Reviewer:       authenticatedCaller,
 		ThreadID:       opts.threadID,
 		Decision:       decision,
 		Reason:         opts.reason,

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -18,20 +18,20 @@ import (
 )
 
 type executeBashFixture struct {
-	baseDir      string
-	contextID    string
-	sessionName  string
-	sessionDir   string
-	now          time.Time
-	policies     []config.CommandApprovalPolicy
-	reviewerNode string
-	nodes        map[string]config.NodeConfig
-	stdout       bytes.Buffer
-	stderr       bytes.Buffer
-	runCount     int
-	commands     []string
-	runStatus    int
-	runErr       error
+	baseDir             string
+	contextID           string
+	sessionName         string
+	sessionDir          string
+	now                 time.Time
+	policies            []config.CommandApprovalPolicy
+	commandApproverNode string
+	nodes               map[string]config.NodeConfig
+	stdout              bytes.Buffer
+	stderr              bytes.Buffer
+	runCount            int
+	commands            []string
+	runStatus           int
+	runErr              error
 }
 
 func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolicy) *executeBashFixture {
@@ -49,13 +49,13 @@ func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolic
 		policies:    policies,
 		// #626: every existing fixture test uses "orchestrator" as the
 		// approval Reviewer label; defaulting it here as a valid
-		// reviewer_node too keeps these tests exercising the real
+		// command_approver_node too keeps these tests exercising the real
 		// advisory/warn-only/blocking evaluation path instead of the
 		// unified fail-open rule (which only applies when no VALID
-		// reviewer_node is configured). Tests exercising the fail-open rule
-		// itself override reviewerNode/nodes before calling context().
-		reviewerNode: "orchestrator",
-		nodes:        map[string]config.NodeConfig{"orchestrator": {}},
+		// command_approver_node is configured). Tests exercising the fail-open rule
+		// itself override commandApproverNode/nodes before calling context().
+		commandApproverNode: "orchestrator",
+		nodes:               map[string]config.NodeConfig{"orchestrator": {}},
 	}
 }
 
@@ -67,7 +67,7 @@ func (f *executeBashFixture) context() commandContext {
 // authenticated caller identity --record-decision relies on, #626
 // B1-residual) is paneName instead of the default "worker" requester
 // identity — used to simulate a --record-decision call actually coming
-// from the reviewer_node's own pane, structurally distinct from the
+// from the command_approver_node's own pane, structurally distinct from the
 // requester's.
 func (f *executeBashFixture) contextAsPane(paneName string) commandContext {
 	return commandContext{
@@ -75,10 +75,10 @@ func (f *executeBashFixture) contextAsPane(paneName string) commandContext {
 		stderr: &f.stderr,
 		loadConfig: func(string) (*config.Config, error) {
 			return &config.Config{
-				BaseDir:         f.baseDir,
-				CommandApproval: f.policies,
-				ReviewerNode:    f.reviewerNode,
-				Nodes:           f.nodes,
+				BaseDir:             f.baseDir,
+				CommandApproval:     f.policies,
+				CommandApproverNode: f.commandApproverNode,
+				Nodes:               f.nodes,
 			}, nil
 		},
 		getTmuxPaneName:    func() string { return paneName },
@@ -320,12 +320,12 @@ func TestRunExecuteBashBlockingRefusesInvalidApprovals(t *testing.T) {
 
 // TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer guards #626
 // B1-residual: a requester calling --record-decision from their OWN tmux
-// pane, self-declaring via --reviewer as the configured reviewer_node's
+// pane, self-declaring via --reviewer as the configured command_approver_node's
 // name (trivially readable from postman.toml or get-status), must be
 // refused at the decision-recording step itself — --reviewer must have no
 // bearing on acceptance. Only a call whose AUTHENTICATED caller identity
-// (tmux pane title) matches the trusted reviewer_node is ever honored; see
-// TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel
+// (tmux pane title) matches the trusted command_approver_node is ever honored; see
+// TestRunExecuteBashBlockingAcceptsRealCommandApproverNodeDespiteUnassignedLabel
 // for that positive case, exercised from a structurally different caller
 // identity via contextAsPane.
 func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
@@ -336,7 +336,7 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 		Mode:      "blocking",
 	}
 	fixture := newExecuteBashFixture(t, policyConfig)
-	fixture.reviewerNode = "orchestrator" // the actual, admin-configured reviewer_node
+	fixture.commandApproverNode = "orchestrator" // the actual, admin-configured command_approver_node
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}, "worker": {}}
 	commandText := "printf self-approve"
 
@@ -362,7 +362,7 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 	// to self-declare as the reviewer via --reviewer=orchestrator (the
 	// exploit: this name is public, readable from config/get-status). This
 	// must be refused at the decision-recording step itself, because the
-	// AUTHENTICATED caller ("worker") does not match reviewer_node
+	// AUTHENTICATED caller ("worker") does not match command_approver_node
 	// ("orchestrator") — regardless of what --reviewer claims.
 	err = runExecuteBashWithContext(fixture.context(), fixture.args(
 		"--thread-id", threadID,
@@ -393,12 +393,12 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 
 // TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller is
 // the CLI refusal test guardian asked for explicitly: --record-decision
-// --reviewer <reviewer_node_name> issued from a caller whose own pane
-// identity is NOT the reviewer_node must be refused, independent of the
+// --reviewer <command_approver_node_name> issued from a caller whose own pane
+// identity is NOT the command_approver_node must be refused, independent of the
 // self-approval framing above.
 func TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller(t *testing.T) {
 	fixture := newExecuteBashFixture(t)
-	fixture.reviewerNode = "orchestrator"
+	fixture.commandApproverNode = "orchestrator"
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}, "bystander": {}}
 	commandText := "printf non-reviewer-caller"
 
@@ -418,8 +418,8 @@ func TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller(t *tes
 	}, commandDigest(commandText))
 
 	// A third-party pane ("bystander"), neither the requester nor the real
-	// reviewer_node, tries to record a decision naming the real
-	// reviewer_node via --reviewer.
+	// command_approver_node, tries to record a decision naming the real
+	// command_approver_node via --reviewer.
 	err = runExecuteBashWithContext(fixture.contextAsPane("bystander"), fixture.args(
 		"--thread-id", threadID,
 		"--reviewer", "orchestrator",
@@ -433,15 +433,15 @@ func TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller(t *tes
 	}
 }
 
-// TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel
+// TestRunExecuteBashBlockingAcceptsRealCommandApproverNodeDespiteUnassignedLabel
 // guards the honest-admin side of #626 B1: when policy.Reviewer is left at
 // its "unassigned" default (no matching command_approval policy sets a
-// Reviewer label) but a valid reviewer_node is configured, a decision from
-// that real reviewer_node must be accepted — it must not get stuck as
+// Reviewer label) but a valid command_approver_node is configured, a decision from
+// that real command_approver_node must be accepted — it must not get stuck as
 // wrong_reviewer just because the audit label never matched anything.
-func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *testing.T) {
+func TestRunExecuteBashBlockingAcceptsRealCommandApproverNodeDespiteUnassignedLabel(t *testing.T) {
 	fixture := newExecuteBashFixture(t) // no policies: Reviewer stays "unassigned"
-	fixture.reviewerNode = "orchestrator"
+	fixture.commandApproverNode = "orchestrator"
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}}
 	commandText := "printf honest-reviewer"
 
@@ -460,7 +460,7 @@ func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *
 		Label:     "protected",
 	}, commandDigest(commandText))
 
-	// The decision is recorded from the real reviewer_node's own pane
+	// The decision is recorded from the real command_approver_node's own pane
 	// ("orchestrator"), not the requester's — this is the authenticated
 	// caller identity the fix now requires; --reviewer is no longer what
 	// makes this call legitimate.
@@ -478,7 +478,7 @@ func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *
 		"--command", commandText,
 	))
 	if err != nil {
-		t.Fatalf("second invocation error = %v, want the real reviewer_node's approval honored", err)
+		t.Fatalf("second invocation error = %v, want the real command_approver_node's approval honored", err)
 	}
 	if fixture.runCount != 1 {
 		t.Fatalf("runCount = %d, want 1", fixture.runCount)
@@ -487,7 +487,7 @@ func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *
 
 // TestRunExecuteBashRejectsThreadIDInjection guards #626 M1: --thread-id is
 // interpolated directly into hand-built YAML frontmatter for delivery to
-// the reviewer_node, so a newline (with or without a fake params key) must
+// the command_approver_node, so a newline (with or without a fake params key) must
 // be rejected before it ever reaches that interpolation, both on the
 // request path and the --record-decision path.
 func TestRunExecuteBashRejectsThreadIDInjection(t *testing.T) {
@@ -560,12 +560,12 @@ func TestRunExecuteBashBlockingRunsMatchingApprovedDigest(t *testing.T) {
 	}
 }
 
-// TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured guards
+// TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnconfigured guards
 // #626's decided requirement 1 (unified fail-open rule): with no
-// reviewer_node configured at all, even blocking mode must run the command,
+// command_approver_node configured at all, even blocking mode must run the command,
 // recorded distinctly as auto_approved_no_reviewer rather than a real
 // approval.
-func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured(t *testing.T) {
+func TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnconfigured(t *testing.T) {
 	policyConfig := config.CommandApprovalPolicy{
 		Requester: "worker",
 		Reviewer:  "orchestrator",
@@ -574,7 +574,7 @@ func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured(t *testing.
 		Mode:      "blocking",
 	}
 	fixture := newExecuteBashFixture(t, policyConfig)
-	fixture.reviewerNode = ""
+	fixture.commandApproverNode = ""
 	fixture.nodes = nil
 
 	err := runExecuteBashWithContext(fixture.context(), fixture.args(
@@ -594,11 +594,11 @@ func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured(t *testing.
 	}
 }
 
-// TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnresolvable guards the
-// second case of #626's decided requirement 1: reviewer_node configured but
+// TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnresolvable guards the
+// second case of #626's decided requirement 1: command_approver_node configured but
 // naming a node that doesn't exist must fail open exactly like an
-// unconfigured reviewer_node, not fail closed.
-func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnresolvable(t *testing.T) {
+// unconfigured command_approver_node, not fail closed.
+func TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnresolvable(t *testing.T) {
 	policyConfig := config.CommandApprovalPolicy{
 		Requester: "worker",
 		Reviewer:  "orchestrator",
@@ -607,7 +607,7 @@ func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnresolvable(t *testing.
 		Mode:      "blocking",
 	}
 	fixture := newExecuteBashFixture(t, policyConfig)
-	fixture.reviewerNode = "typo-reviewer"
+	fixture.commandApproverNode = "typo-reviewer"
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}}
 
 	err := runExecuteBashWithContext(fixture.context(), fixture.args(
@@ -761,7 +761,7 @@ func (f *executeBashFixture) appendCommandApprovalRequest(t *testing.T, policy r
 	writer := f.openWriter(t)
 	commandHash := commandDigest(commandText)
 	threadID := commandApprovalThreadID(policy, commandHash)
-	// #626 B1: ReviewerNode mirrors the fixture's own reviewerNode, exactly
+	// #626 B1: CommandApproverNode mirrors the fixture's own commandApproverNode, exactly
 	// as recordCommandApprovalRequest always populates it from the
 	// config-resolved node in production — this is the field decisions are
 	// actually validated against now, never the plain Reviewer label.
@@ -769,15 +769,15 @@ func (f *executeBashFixture) appendCommandApprovalRequest(t *testing.T, policy r
 		journal.CommandApprovalRequestedEventType,
 		journal.VisibilityOperatorVisible,
 		journal.CommandApprovalRequestPayload{
-			Requester:    policy.Requester,
-			Reviewer:     policy.Reviewer,
-			ReviewerNode: f.reviewerNode,
-			Mode:         policy.Mode,
-			Label:        policy.Label,
-			Category:     policy.Category,
-			CommandHash:  commandHash,
-			Reason:       "review requested",
-			ExpiresAt:    expiresAt.UTC().Format(time.RFC3339Nano),
+			Requester:           policy.Requester,
+			Reviewer:            policy.Reviewer,
+			CommandApproverNode: f.commandApproverNode,
+			Mode:                policy.Mode,
+			Label:               policy.Label,
+			Category:            policy.Category,
+			CommandHash:         commandHash,
+			Reason:              "review requested",
+			ExpiresAt:           expiresAt.UTC().Format(time.RFC3339Nano),
 		},
 		journal.AppendOptions{ThreadID: threadID},
 		f.now,

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -308,6 +308,163 @@ func TestRunExecuteBashBlockingRefusesInvalidApprovals(t *testing.T) {
 	}
 }
 
+// TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer guards #626 B1: a
+// requester who controls both the policy match (thus thread.Reviewer) and
+// the --record-decision --reviewer flag must NOT be able to self-approve a
+// blocking-mode command by making the two requester-controlled strings
+// match each other. The decision must only be honored when its reviewer
+// matches the config-resolved reviewer_node, which the requester has no
+// flag to control.
+func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "worker", // requester-controlled label naming itself as reviewer
+		Label:     "protected",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	fixture.reviewerNode = "orchestrator" // the actual, admin-configured reviewer_node
+	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}, "worker": {}}
+	commandText := "printf self-approve"
+
+	// First invocation: creates the approval request and blocks.
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--reviewer", "worker",
+		"--mode", "blocking",
+		"--command", commandText,
+	))
+	if err == nil {
+		t.Fatal("first invocation error = nil, want blocking refusal")
+	}
+	threadID := commandApprovalThreadID(resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "worker",
+		Mode:      "blocking",
+		Label:     "protected",
+	}, commandDigest(commandText))
+
+	// Requester self-declares as reviewer for the decision, exactly as in
+	// the reported exploit.
+	err = runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--thread-id", threadID,
+		"--reviewer", "worker",
+		"--record-decision", "approved",
+	))
+	if err != nil {
+		t.Fatalf("record-decision error = %v", err)
+	}
+
+	// Second invocation must still refuse: the recorded decision's reviewer
+	// ("worker") does not match the trusted reviewer_node ("orchestrator").
+	err = runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--reviewer", "worker",
+		"--mode", "blocking",
+		"--command", commandText,
+	))
+	if err == nil {
+		t.Fatal("second invocation error = nil, want blocking refusal (self-approval must not succeed)")
+	}
+	if !strings.Contains(err.Error(), "reviewer does not match") {
+		t.Fatalf("error = %v, want wrong-reviewer refusal", err)
+	}
+	if fixture.runCount != 0 {
+		t.Fatalf("runCount = %d, want 0 (self-approved command must never run)", fixture.runCount)
+	}
+}
+
+// TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel
+// guards the honest-admin side of #626 B1: when policy.Reviewer is left at
+// its "unassigned" default (no matching command_approval policy sets a
+// Reviewer label) but a valid reviewer_node is configured, a decision from
+// that real reviewer_node must be accepted — it must not get stuck as
+// wrong_reviewer just because the audit label never matched anything.
+func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *testing.T) {
+	fixture := newExecuteBashFixture(t) // no policies: Reviewer stays "unassigned"
+	fixture.reviewerNode = "orchestrator"
+	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}}
+	commandText := "printf honest-reviewer"
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--mode", "blocking",
+		"--command", commandText,
+	))
+	if err == nil {
+		t.Fatal("first invocation error = nil, want blocking refusal pending approval")
+	}
+	threadID := commandApprovalThreadID(resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "unassigned",
+		Mode:      "blocking",
+		Label:     "protected",
+	}, commandDigest(commandText))
+
+	err = runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--thread-id", threadID,
+		"--reviewer", "orchestrator",
+		"--record-decision", "approved",
+	))
+	if err != nil {
+		t.Fatalf("record-decision error = %v", err)
+	}
+
+	err = runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--mode", "blocking",
+		"--command", commandText,
+	))
+	if err != nil {
+		t.Fatalf("second invocation error = %v, want the real reviewer_node's approval honored", err)
+	}
+	if fixture.runCount != 1 {
+		t.Fatalf("runCount = %d, want 1", fixture.runCount)
+	}
+}
+
+// TestRunExecuteBashRejectsThreadIDInjection guards #626 M1: --thread-id is
+// interpolated directly into hand-built YAML frontmatter for delivery to
+// the reviewer_node, so a newline (with or without a fake params key) must
+// be rejected before it ever reaches that interpolation, both on the
+// request path and the --record-decision path.
+func TestRunExecuteBashRejectsThreadIDInjection(t *testing.T) {
+	malicious := "safe-id\n  replyPolicy: none"
+
+	t.Run("request path", func(t *testing.T) {
+		fixture := newExecuteBashFixture(t)
+		err := runExecuteBashWithContext(fixture.context(), fixture.args(
+			"--label", "protected",
+			"--thread-id", malicious,
+			"--command", "printf injected",
+		))
+		if err == nil {
+			t.Fatal("error = nil, want rejection of unsafe --thread-id")
+		}
+		if !strings.Contains(err.Error(), "thread-id") {
+			t.Fatalf("error = %v, want a --thread-id rejection message", err)
+		}
+		if fixture.runCount != 0 {
+			t.Fatalf("runCount = %d, want 0", fixture.runCount)
+		}
+	})
+
+	t.Run("record-decision path", func(t *testing.T) {
+		fixture := newExecuteBashFixture(t)
+		err := runExecuteBashWithContext(fixture.context(), fixture.args(
+			"--thread-id", malicious,
+			"--reviewer", "orchestrator",
+			"--record-decision", "approved",
+		))
+		if err == nil {
+			t.Fatal("error = nil, want rejection of unsafe --thread-id")
+		}
+		if !strings.Contains(err.Error(), "thread-id") {
+			t.Fatalf("error = %v, want a --thread-id rejection message", err)
+		}
+	})
+}
+
 func TestRunExecuteBashBlockingRunsMatchingApprovedDigest(t *testing.T) {
 	policyConfig := config.CommandApprovalPolicy{
 		Requester: "worker",
@@ -543,18 +700,23 @@ func (f *executeBashFixture) appendCommandApprovalRequest(t *testing.T, policy r
 	writer := f.openWriter(t)
 	commandHash := commandDigest(commandText)
 	threadID := commandApprovalThreadID(policy, commandHash)
+	// #626 B1: ReviewerNode mirrors the fixture's own reviewerNode, exactly
+	// as recordCommandApprovalRequest always populates it from the
+	// config-resolved node in production — this is the field decisions are
+	// actually validated against now, never the plain Reviewer label.
 	_, err := writer.AppendEventWithOptions(
 		journal.CommandApprovalRequestedEventType,
 		journal.VisibilityOperatorVisible,
 		journal.CommandApprovalRequestPayload{
-			Requester:   policy.Requester,
-			Reviewer:    policy.Reviewer,
-			Mode:        policy.Mode,
-			Label:       policy.Label,
-			Category:    policy.Category,
-			CommandHash: commandHash,
-			Reason:      "review requested",
-			ExpiresAt:   expiresAt.UTC().Format(time.RFC3339Nano),
+			Requester:    policy.Requester,
+			Reviewer:     policy.Reviewer,
+			ReviewerNode: f.reviewerNode,
+			Mode:         policy.Mode,
+			Label:        policy.Label,
+			Category:     policy.Category,
+			CommandHash:  commandHash,
+			Reason:       "review requested",
+			ExpiresAt:    expiresAt.UTC().Format(time.RFC3339Nano),
 		},
 		journal.AppendOptions{ThreadID: threadID},
 		f.now,

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -60,6 +60,16 @@ func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolic
 }
 
 func (f *executeBashFixture) context() commandContext {
+	return f.contextAsPane("worker")
+}
+
+// contextAsPane returns a commandContext whose tmux pane title (the
+// authenticated caller identity --record-decision relies on, #626
+// B1-residual) is paneName instead of the default "worker" requester
+// identity — used to simulate a --record-decision call actually coming
+// from the reviewer_node's own pane, structurally distinct from the
+// requester's.
+func (f *executeBashFixture) contextAsPane(paneName string) commandContext {
 	return commandContext{
 		stdout: &f.stdout,
 		stderr: &f.stderr,
@@ -71,7 +81,7 @@ func (f *executeBashFixture) context() commandContext {
 				Nodes:           f.nodes,
 			}, nil
 		},
-		getTmuxPaneName:    func() string { return "worker" },
+		getTmuxPaneName:    func() string { return paneName },
 		getTmuxSessionName: func() string { return f.sessionName },
 		now:                func() time.Time { return f.now },
 		runBash: func(command string, stdout, stderr io.Writer) (int, error) {
@@ -308,13 +318,16 @@ func TestRunExecuteBashBlockingRefusesInvalidApprovals(t *testing.T) {
 	}
 }
 
-// TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer guards #626 B1: a
-// requester who controls both the policy match (thus thread.Reviewer) and
-// the --record-decision --reviewer flag must NOT be able to self-approve a
-// blocking-mode command by making the two requester-controlled strings
-// match each other. The decision must only be honored when its reviewer
-// matches the config-resolved reviewer_node, which the requester has no
-// flag to control.
+// TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer guards #626
+// B1-residual: a requester calling --record-decision from their OWN tmux
+// pane, self-declaring via --reviewer as the configured reviewer_node's
+// name (trivially readable from postman.toml or get-status), must be
+// refused at the decision-recording step itself — --reviewer must have no
+// bearing on acceptance. Only a call whose AUTHENTICATED caller identity
+// (tmux pane title) matches the trusted reviewer_node is ever honored; see
+// TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel
+// for that positive case, exercised from a structurally different caller
+// identity via contextAsPane.
 func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 	policyConfig := config.CommandApprovalPolicy{
 		Requester: "worker",
@@ -327,7 +340,8 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}, "worker": {}}
 	commandText := "printf self-approve"
 
-	// First invocation: creates the approval request and blocks.
+	// First invocation, from the requester's own pane ("worker"): creates
+	// the approval request and blocks.
 	err := runExecuteBashWithContext(fixture.context(), fixture.args(
 		"--label", "protected",
 		"--reviewer", "worker",
@@ -344,19 +358,25 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 		Label:     "protected",
 	}, commandDigest(commandText))
 
-	// Requester self-declares as reviewer for the decision, exactly as in
-	// the reported exploit.
+	// The requester, still calling from their own "worker" pane, attempts
+	// to self-declare as the reviewer via --reviewer=orchestrator (the
+	// exploit: this name is public, readable from config/get-status). This
+	// must be refused at the decision-recording step itself, because the
+	// AUTHENTICATED caller ("worker") does not match reviewer_node
+	// ("orchestrator") — regardless of what --reviewer claims.
 	err = runExecuteBashWithContext(fixture.context(), fixture.args(
 		"--thread-id", threadID,
-		"--reviewer", "worker",
+		"--reviewer", "orchestrator",
 		"--record-decision", "approved",
 	))
-	if err != nil {
-		t.Fatalf("record-decision error = %v", err)
+	if err == nil {
+		t.Fatal("record-decision error = nil, want refusal (self-declared --reviewer must not authenticate the caller)")
+	}
+	if !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("error = %v, want a --record-decision refusal", err)
 	}
 
-	// Second invocation must still refuse: the recorded decision's reviewer
-	// ("worker") does not match the trusted reviewer_node ("orchestrator").
+	// The command must still refuse: no valid decision was ever recorded.
 	err = runExecuteBashWithContext(fixture.context(), fixture.args(
 		"--label", "protected",
 		"--reviewer", "worker",
@@ -366,11 +386,50 @@ func TestRunExecuteBashBlockingRejectsSelfDeclaredReviewer(t *testing.T) {
 	if err == nil {
 		t.Fatal("second invocation error = nil, want blocking refusal (self-approval must not succeed)")
 	}
-	if !strings.Contains(err.Error(), "reviewer does not match") {
-		t.Fatalf("error = %v, want wrong-reviewer refusal", err)
-	}
 	if fixture.runCount != 0 {
 		t.Fatalf("runCount = %d, want 0 (self-approved command must never run)", fixture.runCount)
+	}
+}
+
+// TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller is
+// the CLI refusal test guardian asked for explicitly: --record-decision
+// --reviewer <reviewer_node_name> issued from a caller whose own pane
+// identity is NOT the reviewer_node must be refused, independent of the
+// self-approval framing above.
+func TestRunExecuteBashBlockingRecordDecisionRefusedFromNonReviewerCaller(t *testing.T) {
+	fixture := newExecuteBashFixture(t)
+	fixture.reviewerNode = "orchestrator"
+	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}, "bystander": {}}
+	commandText := "printf non-reviewer-caller"
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--mode", "blocking",
+		"--command", commandText,
+	))
+	if err == nil {
+		t.Fatal("first invocation error = nil, want blocking refusal pending approval")
+	}
+	threadID := commandApprovalThreadID(resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "unassigned",
+		Mode:      "blocking",
+		Label:     "protected",
+	}, commandDigest(commandText))
+
+	// A third-party pane ("bystander"), neither the requester nor the real
+	// reviewer_node, tries to record a decision naming the real
+	// reviewer_node via --reviewer.
+	err = runExecuteBashWithContext(fixture.contextAsPane("bystander"), fixture.args(
+		"--thread-id", threadID,
+		"--reviewer", "orchestrator",
+		"--record-decision", "approved",
+	))
+	if err == nil {
+		t.Fatal("record-decision error = nil, want refusal from a non-reviewer caller")
+	}
+	if !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("error = %v, want a --record-decision refusal", err)
 	}
 }
 
@@ -401,9 +460,12 @@ func TestRunExecuteBashBlockingAcceptsRealReviewerNodeDespiteUnassignedLabel(t *
 		Label:     "protected",
 	}, commandDigest(commandText))
 
-	err = runExecuteBashWithContext(fixture.context(), fixture.args(
+	// The decision is recorded from the real reviewer_node's own pane
+	// ("orchestrator"), not the requester's — this is the authenticated
+	// caller identity the fix now requires; --reviewer is no longer what
+	// makes this call legitimate.
+	err = runExecuteBashWithContext(fixture.contextAsPane("orchestrator"), fixture.args(
 		"--thread-id", threadID,
-		"--reviewer", "orchestrator",
 		"--record-decision", "approved",
 	))
 	if err != nil {
@@ -649,9 +711,8 @@ func TestRunExecuteBashRecordDecisionAndInspectCommandApprovals(t *testing.T) {
 	commandText := "printf approve-me"
 	threadID := fixture.appendCommandApprovalRequest(t, policy, commandText, time.Now().Add(time.Hour))
 
-	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+	err := runExecuteBashWithContext(fixture.contextAsPane("orchestrator"), fixture.args(
 		"--thread-id", threadID,
-		"--reviewer", "orchestrator",
 		"--record-decision", "approved",
 		"--reason", "digest reviewed",
 	))

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -18,18 +18,20 @@ import (
 )
 
 type executeBashFixture struct {
-	baseDir     string
-	contextID   string
-	sessionName string
-	sessionDir  string
-	now         time.Time
-	policies    []config.CommandApprovalPolicy
-	stdout      bytes.Buffer
-	stderr      bytes.Buffer
-	runCount    int
-	commands    []string
-	runStatus   int
-	runErr      error
+	baseDir      string
+	contextID    string
+	sessionName  string
+	sessionDir   string
+	now          time.Time
+	policies     []config.CommandApprovalPolicy
+	reviewerNode string
+	nodes        map[string]config.NodeConfig
+	stdout       bytes.Buffer
+	stderr       bytes.Buffer
+	runCount     int
+	commands     []string
+	runStatus    int
+	runErr       error
 }
 
 func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolicy) *executeBashFixture {
@@ -45,6 +47,15 @@ func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolic
 		sessionDir:  filepath.Join(baseDir, contextID, sessionName),
 		now:         time.Date(2026, time.June, 1, 10, 0, 0, 0, time.UTC),
 		policies:    policies,
+		// #626: every existing fixture test uses "orchestrator" as the
+		// approval Reviewer label; defaulting it here as a valid
+		// reviewer_node too keeps these tests exercising the real
+		// advisory/warn-only/blocking evaluation path instead of the
+		// unified fail-open rule (which only applies when no VALID
+		// reviewer_node is configured). Tests exercising the fail-open rule
+		// itself override reviewerNode/nodes before calling context().
+		reviewerNode: "orchestrator",
+		nodes:        map[string]config.NodeConfig{"orchestrator": {}},
 	}
 }
 
@@ -56,6 +67,8 @@ func (f *executeBashFixture) context() commandContext {
 			return &config.Config{
 				BaseDir:         f.baseDir,
 				CommandApproval: f.policies,
+				ReviewerNode:    f.reviewerNode,
+				Nodes:           f.nodes,
 			}, nil
 		},
 		getTmuxPaneName:    func() string { return "worker" },
@@ -325,6 +338,73 @@ func TestRunExecuteBashBlockingRunsMatchingApprovedDigest(t *testing.T) {
 	}
 	if fixture.runCount != 1 {
 		t.Fatalf("runCount = %d, want 1", fixture.runCount)
+	}
+}
+
+// TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured guards
+// #626's decided requirement 1 (unified fail-open rule): with no
+// reviewer_node configured at all, even blocking mode must run the command,
+// recorded distinctly as auto_approved_no_reviewer rather than a real
+// approval.
+func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnconfigured(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Category:  "release",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	fixture.reviewerNode = ""
+	fixture.nodes = nil
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--category", "release",
+		"--command", "printf unconfigured",
+	))
+	if err != nil {
+		t.Fatalf("runExecuteBashWithContext() error = %v, want nil (fail open)", err)
+	}
+	if fixture.runCount != 1 {
+		t.Fatalf("runCount = %d, want 1", fixture.runCount)
+	}
+	decision := findExecutionDecisionPayload(t, fixture.sessionDir)
+	if decision.Decision != commandApprovalDecisionAutoApprovedNoReviewer {
+		t.Fatalf("decision = %q, want %q", decision.Decision, commandApprovalDecisionAutoApprovedNoReviewer)
+	}
+}
+
+// TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnresolvable guards the
+// second case of #626's decided requirement 1: reviewer_node configured but
+// naming a node that doesn't exist must fail open exactly like an
+// unconfigured reviewer_node, not fail closed.
+func TestRunExecuteBashBlockingFailsOpenWhenReviewerNodeUnresolvable(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Category:  "release",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	fixture.reviewerNode = "typo-reviewer"
+	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}}
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--category", "release",
+		"--command", "printf unresolvable",
+	))
+	if err != nil {
+		t.Fatalf("runExecuteBashWithContext() error = %v, want nil (fail open)", err)
+	}
+	if fixture.runCount != 1 {
+		t.Fatalf("runCount = %d, want 1", fixture.runCount)
+	}
+	decision := findExecutionDecisionPayload(t, fixture.sessionDir)
+	if decision.Decision != commandApprovalDecisionAutoApprovedNoReviewer {
+		t.Fatalf("decision = %q, want %q", decision.Decision, commandApprovalDecisionAutoApprovedNoReviewer)
 	}
 }
 

--- a/internal/cli/helptext/execute-bash.txt
+++ b/internal/cli/helptext/execute-bash.txt
@@ -41,7 +41,11 @@ Fail-open rule (reviewer_node):
   When a valid reviewer_node exists, execute-bash also delivers the approval
   request to it directly as a reply-required message; reply with a body
   starting APPROVED:/NOT APPROVED: and the given thread_id to record a
-  decision without running --record-decision yourself.
+  decision without running --record-decision yourself. A reply body that
+  doesn't start with one of those two prefixes is logged and not recorded.
+  Only a reply whose sender matches the resolved reviewer_node is ever
+  honored, regardless of the reviewer audit label, so self-approval by the
+  requester is not possible.
 
 Bypass boundary:
   This wrapper coordinates command review through Postman. It does not sandbox

--- a/internal/cli/helptext/execute-bash.txt
+++ b/internal/cli/helptext/execute-bash.txt
@@ -28,6 +28,21 @@ Modes:
   blocking   Runs only when the matching thread has a non-expired approved decision
              from the configured reviewer for the exact command digest.
 
+Fail-open rule (reviewer_node):
+  Every mode above, including blocking, only becomes restrictive once a VALID
+  reviewer_node is configured (postman.toml [postman] reviewer_node, or a
+  per-policy reviewer_node override under [[postman.command_approval]] —
+  naming a real, configured node, same family as ui_node). Unset, or set to a
+  node name that does not resolve, means every command runs, recorded
+  distinctly as auto_approved_no_reviewer rather than a real approval. An
+  unresolvable reviewer_node also produces a load-time warning and a visible
+  marker in get-status, so a typo never silently disables blocking mode.
+
+  When a valid reviewer_node exists, execute-bash also delivers the approval
+  request to it directly as a reply-required message; reply with a body
+  starting APPROVED:/NOT APPROVED: and the given thread_id to record a
+  decision without running --record-decision yourself.
+
 Bypass boundary:
   This wrapper coordinates command review through Postman. It does not sandbox
   bash, prevent direct shell execution, or enforce OS-level policy. Use it for

--- a/internal/cli/helptext/execute-bash.txt
+++ b/internal/cli/helptext/execute-bash.txt
@@ -23,7 +23,7 @@ Decision flags:
   --record-decision <decision> approved or rejected. The decision's reviewer
                                 identity is always the calling process's own
                                 tmux pane title, never --reviewer; a caller
-                                whose pane is not the thread's reviewer_node
+                                whose pane is not the thread's command_approver_node
                                 is refused and no decision is recorded.
 
 Modes:
@@ -32,26 +32,26 @@ Modes:
   blocking   Runs only when the matching thread has a non-expired approved decision
              from the configured reviewer for the exact command digest.
 
-Fail-open rule (reviewer_node):
+Fail-open rule (command_approver_node):
   Every mode above, including blocking, only becomes restrictive once a VALID
-  reviewer_node is configured (postman.toml [postman] reviewer_node, or a
-  per-policy reviewer_node override under [[postman.command_approval]] —
+  command_approver_node is configured (postman.toml [postman] command_approver_node, or a
+  per-policy command_approver_node override under [[postman.command_approval]] —
   naming a real, configured node, same family as ui_node). Unset, or set to a
   node name that does not resolve, means every command runs, recorded
   distinctly as auto_approved_no_reviewer rather than a real approval. An
-  unresolvable reviewer_node also produces a load-time warning and a visible
+  unresolvable command_approver_node also produces a load-time warning and a visible
   marker in get-status, so a typo never silently disables blocking mode.
 
-  When a valid reviewer_node exists, execute-bash also delivers the approval
+  When a valid command_approver_node exists, execute-bash also delivers the approval
   request to it directly as a reply-required message; reply with a body
   starting APPROVED:/NOT APPROVED: and the given thread_id to record a
   decision without running --record-decision yourself. A reply body that
   doesn't start with one of those two prefixes is logged and not recorded.
-  Only a reply whose sender matches the resolved reviewer_node is ever
+  Only a reply whose sender matches the resolved command_approver_node is ever
   honored, regardless of the reviewer audit label. The same rule applies to
   --record-decision itself: the decision's reviewer identity is always the
   calling process's own tmux pane title, never the --reviewer flag, and a
-  caller whose pane is not the reviewer_node is refused outright.
+  caller whose pane is not the command_approver_node is refused outright.
 
 Bypass boundary:
   This wrapper coordinates command review through Postman. It does not sandbox

--- a/internal/cli/helptext/execute-bash.txt
+++ b/internal/cli/helptext/execute-bash.txt
@@ -3,7 +3,7 @@ execute-bash — run bash through command approval choreography
 Usage:
   tmux-a2a-postman execute-bash --label <label> --command <bash>
   tmux-a2a-postman execute-bash --label <label> --mode blocking --reviewer <node> --command <bash>
-  tmux-a2a-postman execute-bash --thread-id <thread> --record-decision approved --reviewer <node>
+  tmux-a2a-postman execute-bash --thread-id <thread> --record-decision approved
 
 Execution flags:
   --label <label>              Command label used for policy matching and audit
@@ -20,7 +20,11 @@ Execution flags:
 
 Decision flags:
   --thread-id <thread>         Approval thread id to decide or reuse
-  --record-decision <decision> approved or rejected
+  --record-decision <decision> approved or rejected. The decision's reviewer
+                                identity is always the calling process's own
+                                tmux pane title, never --reviewer; a caller
+                                whose pane is not the thread's reviewer_node
+                                is refused and no decision is recorded.
 
 Modes:
   advisory   Records request and audit metadata, then runs even without approval.
@@ -44,8 +48,10 @@ Fail-open rule (reviewer_node):
   decision without running --record-decision yourself. A reply body that
   doesn't start with one of those two prefixes is logged and not recorded.
   Only a reply whose sender matches the resolved reviewer_node is ever
-  honored, regardless of the reviewer audit label, so self-approval by the
-  requester is not possible.
+  honored, regardless of the reviewer audit label. The same rule applies to
+  --record-decision itself: the decision's reviewer identity is always the
+  calling process's own tmux pane title, never the --reviewer flag, and a
+  caller whose pane is not the reviewer_node is refused outright.
 
 Bypass boundary:
   This wrapper coordinates command review through Postman. It does not sandbox

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -175,6 +175,7 @@ func buildSessionStatusSnapshot(inputs sessionStatusInputs) status.SessionStatus
 	result.Queues = inputs.queues
 	result.Windows = buildSessionWindows(result.Nodes, inputs.panes)
 	result.WorkspaceTree = buildWorkspaceTreeStatus(inputs.cfg, inputs.sessionName)
+	result.CommandApproval = buildCommandApprovalStatus(inputs.cfg)
 	result.Compact = buildSessionCompact(result, inputs.panes)
 	applySessionStatusEnrichment(&result, inputs.delivery, inputs.blockedByNode)
 	return result
@@ -211,6 +212,37 @@ func buildWorkspaceTreeStatus(cfg *config.Config, sessionName string) *status.Wo
 		}
 	}
 	return result
+}
+
+// buildCommandApprovalStatus surfaces any configured-but-unresolvable
+// reviewer_node (global or per-policy) so get-status makes the fail-open
+// condition visible (#626), mirroring config.ValidateConfig's warning rule
+// without depending on its message wording.
+func buildCommandApprovalStatus(cfg *config.Config) *status.CommandApprovalStatus {
+	if cfg == nil {
+		return nil
+	}
+	var unresolved []status.CommandApprovalUnresolvedReviewer
+	if name, valid := cfg.ResolveReviewerNode(""); name != "" && !valid {
+		unresolved = append(unresolved, status.CommandApprovalUnresolvedReviewer{
+			Field:   "reviewer_node",
+			Value:   name,
+			Message: fmt.Sprintf("reviewer_node %q does not match any configured node; command approval is failing open", name),
+		})
+	}
+	for i, policy := range cfg.CommandApproval {
+		if name, valid := cfg.ResolveReviewerNode(policy.ReviewerNode); name != "" && !valid && strings.TrimSpace(policy.ReviewerNode) != "" {
+			unresolved = append(unresolved, status.CommandApprovalUnresolvedReviewer{
+				Field:   fmt.Sprintf("command_approval[%d].reviewer_node", i),
+				Value:   name,
+				Message: fmt.Sprintf("reviewer_node %q does not match any configured node; this policy is failing open", name),
+			})
+		}
+	}
+	if len(unresolved) == 0 {
+		return nil
+	}
+	return &status.CommandApprovalStatus{UnresolvedReviewers: unresolved}
 }
 
 func workspaceTreeRef(node workspacetree.Node) *status.WorkspaceTreeRef {

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -215,34 +215,34 @@ func buildWorkspaceTreeStatus(cfg *config.Config, sessionName string) *status.Wo
 }
 
 // buildCommandApprovalStatus surfaces any configured-but-unresolvable
-// reviewer_node (global or per-policy) so get-status makes the fail-open
+// command_approver_node (global or per-policy) so get-status makes the fail-open
 // condition visible (#626), mirroring config.ValidateConfig's warning rule
 // without depending on its message wording.
 func buildCommandApprovalStatus(cfg *config.Config) *status.CommandApprovalStatus {
 	if cfg == nil {
 		return nil
 	}
-	var unresolved []status.CommandApprovalUnresolvedReviewer
-	if name, valid := cfg.ResolveReviewerNode(""); name != "" && !valid {
-		unresolved = append(unresolved, status.CommandApprovalUnresolvedReviewer{
-			Field:   "reviewer_node",
+	var unresolved []status.CommandApprovalUnresolvedApprover
+	if name, valid := cfg.ResolveCommandApproverNode(""); name != "" && !valid {
+		unresolved = append(unresolved, status.CommandApprovalUnresolvedApprover{
+			Field:   "command_approver_node",
 			Value:   name,
-			Message: fmt.Sprintf("reviewer_node %q does not match any configured node; command approval is failing open", name),
+			Message: fmt.Sprintf("command_approver_node %q does not match any configured node; command approval is failing open", name),
 		})
 	}
 	for i, policy := range cfg.CommandApproval {
-		if name, valid := cfg.ResolveReviewerNode(policy.ReviewerNode); name != "" && !valid && strings.TrimSpace(policy.ReviewerNode) != "" {
-			unresolved = append(unresolved, status.CommandApprovalUnresolvedReviewer{
-				Field:   fmt.Sprintf("command_approval[%d].reviewer_node", i),
+		if name, valid := cfg.ResolveCommandApproverNode(policy.CommandApproverNode); name != "" && !valid && strings.TrimSpace(policy.CommandApproverNode) != "" {
+			unresolved = append(unresolved, status.CommandApprovalUnresolvedApprover{
+				Field:   fmt.Sprintf("command_approval[%d].command_approver_node", i),
 				Value:   name,
-				Message: fmt.Sprintf("reviewer_node %q does not match any configured node; this policy is failing open", name),
+				Message: fmt.Sprintf("command_approver_node %q does not match any configured node; this policy is failing open", name),
 			})
 		}
 	}
 	if len(unresolved) == 0 {
 		return nil
 	}
-	return &status.CommandApprovalStatus{UnresolvedReviewers: unresolved}
+	return &status.CommandApprovalStatus{UnresolvedCommandApprovers: unresolved}
 }
 
 func workspaceTreeRef(node workspacetree.Node) *status.WorkspaceTreeRef {

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -1033,16 +1033,16 @@ func TestCollectAllSessionStatus_IncludesSessionsWithoutCanonicalPanesInSessionI
 	}
 }
 
-// TestBuildCommandApprovalStatus_UnresolvedReviewers guards #626 decided
+// TestBuildCommandApprovalStatus_UnresolvedCommandApprovers guards #626 decided
 // requirement 2's get-status marker: both an unresolvable global
-// reviewer_node and an unresolvable per-policy override must surface as
-// distinct UnresolvedReviewers entries.
-func TestBuildCommandApprovalStatus_UnresolvedReviewers(t *testing.T) {
+// command_approver_node and an unresolvable per-policy override must surface as
+// distinct UnresolvedCommandApprovers entries.
+func TestBuildCommandApprovalStatus_UnresolvedCommandApprovers(t *testing.T) {
 	cfg := &config.Config{
-		ReviewerNode: "typo-reviewer",
-		Nodes:        map[string]config.NodeConfig{"orchestrator": {}},
+		CommandApproverNode: "typo-reviewer",
+		Nodes:               map[string]config.NodeConfig{"orchestrator": {}},
 		CommandApproval: []config.CommandApprovalPolicy{
-			{Requester: "worker", Label: "deploy", ReviewerNode: "another-typo"},
+			{Requester: "worker", Label: "deploy", CommandApproverNode: "another-typo"},
 			{Requester: "worker", Label: "diagnostic"}, // no override: must not duplicate the global warning
 		},
 	}
@@ -1051,33 +1051,33 @@ func TestBuildCommandApprovalStatus_UnresolvedReviewers(t *testing.T) {
 	if got == nil {
 		t.Fatal("buildCommandApprovalStatus() = nil, want a populated status")
 	}
-	if len(got.UnresolvedReviewers) != 2 {
-		t.Fatalf("UnresolvedReviewers = %#v, want exactly 2 entries", got.UnresolvedReviewers)
+	if len(got.UnresolvedCommandApprovers) != 2 {
+		t.Fatalf("UnresolvedCommandApprovers = %#v, want exactly 2 entries", got.UnresolvedCommandApprovers)
 	}
 	wantFields := map[string]bool{
-		"reviewer_node":                     false,
-		"command_approval[0].reviewer_node": false,
+		"command_approver_node":                     false,
+		"command_approval[0].command_approver_node": false,
 	}
-	for _, entry := range got.UnresolvedReviewers {
+	for _, entry := range got.UnresolvedCommandApprovers {
 		if _, ok := wantFields[entry.Field]; ok {
 			wantFields[entry.Field] = true
 		}
 	}
 	for field, found := range wantFields {
 		if !found {
-			t.Fatalf("missing UnresolvedReviewers entry for %s in %#v", field, got.UnresolvedReviewers)
+			t.Fatalf("missing UnresolvedCommandApprovers entry for %s in %#v", field, got.UnresolvedCommandApprovers)
 		}
 	}
 }
 
-// TestBuildCommandApprovalStatus_NoUnresolvedReviewers guards against a
-// false-positive marker when reviewer_node resolves cleanly or isn't
+// TestBuildCommandApprovalStatus_NoUnresolvedCommandApprovers guards against a
+// false-positive marker when command_approver_node resolves cleanly or isn't
 // configured at all.
-func TestBuildCommandApprovalStatus_NoUnresolvedReviewers(t *testing.T) {
+func TestBuildCommandApprovalStatus_NoUnresolvedCommandApprovers(t *testing.T) {
 	for _, cfg := range []*config.Config{
 		nil,
 		{},
-		{ReviewerNode: "orchestrator", Nodes: map[string]config.NodeConfig{"orchestrator": {}}},
+		{CommandApproverNode: "orchestrator", Nodes: map[string]config.NodeConfig{"orchestrator": {}}},
 	} {
 		if got := buildCommandApprovalStatus(cfg); got != nil {
 			t.Fatalf("buildCommandApprovalStatus(%#v) = %#v, want nil", cfg, got)

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -1032,3 +1032,55 @@ func TestCollectAllSessionStatus_IncludesSessionsWithoutCanonicalPanesInSessionI
 		t.Fatalf("ghost compact = %q, want %q", payload.Sessions[1].Compact, "⚫")
 	}
 }
+
+// TestBuildCommandApprovalStatus_UnresolvedReviewers guards #626 decided
+// requirement 2's get-status marker: both an unresolvable global
+// reviewer_node and an unresolvable per-policy override must surface as
+// distinct UnresolvedReviewers entries.
+func TestBuildCommandApprovalStatus_UnresolvedReviewers(t *testing.T) {
+	cfg := &config.Config{
+		ReviewerNode: "typo-reviewer",
+		Nodes:        map[string]config.NodeConfig{"orchestrator": {}},
+		CommandApproval: []config.CommandApprovalPolicy{
+			{Requester: "worker", Label: "deploy", ReviewerNode: "another-typo"},
+			{Requester: "worker", Label: "diagnostic"}, // no override: must not duplicate the global warning
+		},
+	}
+
+	got := buildCommandApprovalStatus(cfg)
+	if got == nil {
+		t.Fatal("buildCommandApprovalStatus() = nil, want a populated status")
+	}
+	if len(got.UnresolvedReviewers) != 2 {
+		t.Fatalf("UnresolvedReviewers = %#v, want exactly 2 entries", got.UnresolvedReviewers)
+	}
+	wantFields := map[string]bool{
+		"reviewer_node":                     false,
+		"command_approval[0].reviewer_node": false,
+	}
+	for _, entry := range got.UnresolvedReviewers {
+		if _, ok := wantFields[entry.Field]; ok {
+			wantFields[entry.Field] = true
+		}
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("missing UnresolvedReviewers entry for %s in %#v", field, got.UnresolvedReviewers)
+		}
+	}
+}
+
+// TestBuildCommandApprovalStatus_NoUnresolvedReviewers guards against a
+// false-positive marker when reviewer_node resolves cleanly or isn't
+// configured at all.
+func TestBuildCommandApprovalStatus_NoUnresolvedReviewers(t *testing.T) {
+	for _, cfg := range []*config.Config{
+		nil,
+		{},
+		{ReviewerNode: "orchestrator", Nodes: map[string]config.NodeConfig{"orchestrator": {}}},
+	} {
+		if got := buildCommandApprovalStatus(cfg); got != nil {
+			t.Fatalf("buildCommandApprovalStatus(%#v) = %#v, want nil", cfg, got)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	AutoEnableNewSessions *bool                     `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
 	WorkspaceTree         []WorkspaceTreeNodeConfig `toml:"workspace_tree"`           // Optional explicit hierarchy for tree aliases
 	CommandApproval       []CommandApprovalPolicy   `toml:"command_approval"`
-	ReviewerNode          string                    `toml:"reviewer_node"` // Optional default reviewer node for command approval (#626); unset/unresolvable = fail-open
+	CommandApproverNode   string                    `toml:"command_approver_node"` // Optional default reviewer node for command approval (#626); unset/unresolvable = fail-open
 
 	// Node-specific configurations (loaded from [nodename] sections)
 	Nodes map[string]NodeConfig
@@ -90,13 +90,13 @@ type Config struct {
 }
 
 type CommandApprovalPolicy struct {
-	Requester          string  `toml:"requester"`
-	Label              string  `toml:"label"`
-	Category           string  `toml:"category"`
-	Reviewer           string  `toml:"reviewer"`
-	Mode               string  `toml:"mode"`
-	ApprovalTTLSeconds float64 `toml:"approval_ttl_seconds"`
-	ReviewerNode       string  `toml:"reviewer_node"` // Optional per-policy override of the global reviewer_node (#626)
+	Requester           string  `toml:"requester"`
+	Label               string  `toml:"label"`
+	Category            string  `toml:"category"`
+	Reviewer            string  `toml:"reviewer"`
+	Mode                string  `toml:"mode"`
+	ApprovalTTLSeconds  float64 `toml:"approval_ttl_seconds"`
+	CommandApproverNode string  `toml:"command_approver_node"` // Optional per-policy override of the global command_approver_node (#626)
 }
 
 // NodeConfig holds per-node configuration.
@@ -117,20 +117,20 @@ type WorkspaceTreeNodeConfig struct {
 	Order             int    `toml:"order"`
 }
 
-// ResolveReviewerNode resolves the effective reviewer_node for a command
+// ResolveCommandApproverNode resolves the effective command_approver_node for a command
 // approval policy, preferring a per-policy override over the global default
 // (#626). valid reports whether the resolved name matches a node known to
 // this config (the same set edges/workspace_tree validate against). An
 // empty or unresolvable name is never valid — callers MUST fail open in
 // that case rather than treat an invalid name as if it were configured, per
 // the decided unified fail-open rule.
-func (cfg *Config) ResolveReviewerNode(policyOverride string) (name string, valid bool) {
+func (cfg *Config) ResolveCommandApproverNode(policyOverride string) (name string, valid bool) {
 	if cfg == nil {
 		return "", false
 	}
 	name = strings.TrimSpace(policyOverride)
 	if name == "" {
-		name = strings.TrimSpace(cfg.ReviewerNode)
+		name = strings.TrimSpace(cfg.CommandApproverNode)
 	}
 	if name == "" {
 		return "", false
@@ -555,8 +555,8 @@ func mergeConfig(base, override *Config) {
 		base.UINode = override.UINode
 		base.uiNodeSet = base.uiNodeSet || override.uiNodeSet
 	}
-	if override.ReviewerNode != "" {
-		base.ReviewerNode = override.ReviewerNode
+	if override.CommandApproverNode != "" {
+		base.CommandApproverNode = override.CommandApproverNode
 	}
 	// *bool merge: bidirectional override — nil = unset (use base), non-nil = explicit (#219)
 	if override.AutoEnableNewSessions != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	AutoEnableNewSessions *bool                     `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
 	WorkspaceTree         []WorkspaceTreeNodeConfig `toml:"workspace_tree"`           // Optional explicit hierarchy for tree aliases
 	CommandApproval       []CommandApprovalPolicy   `toml:"command_approval"`
+	ReviewerNode          string                    `toml:"reviewer_node"` // Optional default reviewer node for command approval (#626); unset/unresolvable = fail-open
 
 	// Node-specific configurations (loaded from [nodename] sections)
 	Nodes map[string]NodeConfig
@@ -95,6 +96,7 @@ type CommandApprovalPolicy struct {
 	Reviewer           string  `toml:"reviewer"`
 	Mode               string  `toml:"mode"`
 	ApprovalTTLSeconds float64 `toml:"approval_ttl_seconds"`
+	ReviewerNode       string  `toml:"reviewer_node"` // Optional per-policy override of the global reviewer_node (#626)
 }
 
 // NodeConfig holds per-node configuration.
@@ -113,6 +115,28 @@ type WorkspaceTreeNodeConfig struct {
 	ParentSessionName string `toml:"parent"`
 	Representative    string `toml:"representative"`
 	Order             int    `toml:"order"`
+}
+
+// ResolveReviewerNode resolves the effective reviewer_node for a command
+// approval policy, preferring a per-policy override over the global default
+// (#626). valid reports whether the resolved name matches a node known to
+// this config (the same set edges/workspace_tree validate against). An
+// empty or unresolvable name is never valid — callers MUST fail open in
+// that case rather than treat an invalid name as if it were configured, per
+// the decided unified fail-open rule.
+func (cfg *Config) ResolveReviewerNode(policyOverride string) (name string, valid bool) {
+	if cfg == nil {
+		return "", false
+	}
+	name = strings.TrimSpace(policyOverride)
+	if name == "" {
+		name = strings.TrimSpace(cfg.ReviewerNode)
+	}
+	if name == "" {
+		return "", false
+	}
+	_, exists := cfg.Nodes[name]
+	return name, exists
 }
 
 // BoolVal dereferences a *bool with a default fallback (#219).
@@ -530,6 +554,9 @@ func mergeConfig(base, override *Config) {
 	if override.UINode != "" || override.uiNodeSet {
 		base.UINode = override.UINode
 		base.uiNodeSet = base.uiNodeSet || override.uiNodeSet
+	}
+	if override.ReviewerNode != "" {
+		base.ReviewerNode = override.ReviewerNode
 	}
 	// *bool merge: bidirectional override — nil = unset (use base), non-nil = explicit (#219)
 	if override.AutoEnableNewSessions != nil {

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -130,6 +130,22 @@ ui_node = "messenger"            # Optional target filter for startup auto-PING
 auto_enable_new_sessions = false   # Auto-enable sessions with configured node panes (default: false; opt-in per #135)
 # startup_guard_enabled = false    # TUI startup guard toggle; ALWAYS starts false at code level
 #                                  # regardless of this value (Issue #249). Press 'S' in TUI to arm.
+# reviewer_node = "orchestrator"   # Optional default reviewer for execute-bash command approval (Issue #626).
+#                                  # Unset, or set to a node that doesn't resolve, means every command approval
+#                                  # mode fails open (runs, audited as auto_approved_no_reviewer) — including
+#                                  # blocking. Only a VALID reviewer_node makes any mode restrictive. Override
+#                                  # per policy with reviewer_node under [[postman.command_approval]] below.
+
+# Command approval policies for execute-bash (Issue #484/#625/#626). Optional; no policies means every
+# execute-bash invocation uses the advisory default. reviewer_node here overrides the global default above.
+# [[postman.command_approval]]
+# requester = "worker"
+# label = "nix-build"
+# category = "verification"
+# reviewer = "orchestrator"
+# reviewer_node = "orchestrator"
+# mode = "blocking"
+# approval_ttl_seconds = 900
 
 # Common template (prepended to all node templates)
 common_template = ""

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -130,20 +130,20 @@ ui_node = "messenger"            # Optional target filter for startup auto-PING
 auto_enable_new_sessions = false   # Auto-enable sessions with configured node panes (default: false; opt-in per #135)
 # startup_guard_enabled = false    # TUI startup guard toggle; ALWAYS starts false at code level
 #                                  # regardless of this value (Issue #249). Press 'S' in TUI to arm.
-# reviewer_node = "orchestrator"   # Optional default reviewer for execute-bash command approval (Issue #626).
+# command_approver_node = "orchestrator"   # Optional default reviewer for execute-bash command approval (Issue #626).
 #                                  # Unset, or set to a node that doesn't resolve, means every command approval
 #                                  # mode fails open (runs, audited as auto_approved_no_reviewer) — including
-#                                  # blocking. Only a VALID reviewer_node makes any mode restrictive. Override
-#                                  # per policy with reviewer_node under [[postman.command_approval]] below.
+#                                  # blocking. Only a VALID command_approver_node makes any mode restrictive. Override
+#                                  # per policy with command_approver_node under [[postman.command_approval]] below.
 
 # Command approval policies for execute-bash (Issue #484/#625/#626). Optional; no policies means every
-# execute-bash invocation uses the advisory default. reviewer_node here overrides the global default above.
+# execute-bash invocation uses the advisory default. command_approver_node here overrides the global default above.
 # [[postman.command_approval]]
 # requester = "worker"
 # label = "nix-build"
 # category = "verification"
 # reviewer = "orchestrator"
-# reviewer_node = "orchestrator"
+# command_approver_node = "orchestrator"
 # mode = "blocking"
 # approval_ttl_seconds = 900
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -153,29 +153,29 @@ func ValidateConfig(cfg *Config) []ValidationError {
 		}
 	}
 
-	// Rule 5: reviewer_node resolvability check (severity: warning, #626).
-	// An unresolvable reviewer_node is never a load error — the unified
+	// Rule 5: command_approver_node resolvability check (severity: warning, #626).
+	// An unresolvable command_approver_node is never a load error — the unified
 	// fail-open rule means command approval simply stays permissive in that
 	// case — but it MUST be loud (a typo here silently disables blocking
 	// mode otherwise) and auditable, per the decided requirements.
-	if name := strings.TrimSpace(cfg.ReviewerNode); name != "" {
+	if name := strings.TrimSpace(cfg.CommandApproverNode); name != "" {
 		if _, exists := cfg.Nodes[name]; !exists {
 			errors = append(errors, ValidationError{
-				Field:    "reviewer_node",
-				Message:  fmt.Sprintf("reviewer_node %q does not match any configured node; command approval will fail open until this is fixed", name),
+				Field:    "command_approver_node",
+				Message:  fmt.Sprintf("command_approver_node %q does not match any configured node; command approval will fail open until this is fixed", name),
 				Severity: "warning",
 			})
 		}
 	}
 	for i, policy := range cfg.CommandApproval {
-		name := strings.TrimSpace(policy.ReviewerNode)
+		name := strings.TrimSpace(policy.CommandApproverNode)
 		if name == "" {
 			continue
 		}
 		if _, exists := cfg.Nodes[name]; !exists {
 			errors = append(errors, ValidationError{
-				Field:    fmt.Sprintf("command_approval[%d].reviewer_node", i),
-				Message:  fmt.Sprintf("reviewer_node %q does not match any configured node; this policy will fail open until this is fixed", name),
+				Field:    fmt.Sprintf("command_approval[%d].command_approver_node", i),
+				Message:  fmt.Sprintf("command_approver_node %q does not match any configured node; this policy will fail open until this is fixed", name),
 				Severity: "warning",
 			})
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -153,6 +153,34 @@ func ValidateConfig(cfg *Config) []ValidationError {
 		}
 	}
 
+	// Rule 5: reviewer_node resolvability check (severity: warning, #626).
+	// An unresolvable reviewer_node is never a load error — the unified
+	// fail-open rule means command approval simply stays permissive in that
+	// case — but it MUST be loud (a typo here silently disables blocking
+	// mode otherwise) and auditable, per the decided requirements.
+	if name := strings.TrimSpace(cfg.ReviewerNode); name != "" {
+		if _, exists := cfg.Nodes[name]; !exists {
+			errors = append(errors, ValidationError{
+				Field:    "reviewer_node",
+				Message:  fmt.Sprintf("reviewer_node %q does not match any configured node; command approval will fail open until this is fixed", name),
+				Severity: "warning",
+			})
+		}
+	}
+	for i, policy := range cfg.CommandApproval {
+		name := strings.TrimSpace(policy.ReviewerNode)
+		if name == "" {
+			continue
+		}
+		if _, exists := cfg.Nodes[name]; !exists {
+			errors = append(errors, ValidationError{
+				Field:    fmt.Sprintf("command_approval[%d].reviewer_node", i),
+				Message:  fmt.Sprintf("reviewer_node %q does not match any configured node; this policy will fail open until this is fixed", name),
+				Severity: "warning",
+			})
+		}
+	}
+
 	return errors
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -287,28 +287,28 @@ func TestValidateConfig_WorkspaceTree(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_ReviewerNodeUnresolvable guards #626's decided
+// TestValidateConfig_CommandApproverNodeUnresolvable guards #626's decided
 // requirement 2 (foot-gun mitigation): a configured-but-unresolvable
-// reviewer_node must produce a load-time WARNING, never an error — the
+// command_approver_node must produce a load-time WARNING, never an error — the
 // unified fail-open rule means command approval still runs, but the
 // misconfiguration must be loud and auditable.
-func TestValidateConfig_ReviewerNodeUnresolvable(t *testing.T) {
+func TestValidateConfig_CommandApproverNodeUnresolvable(t *testing.T) {
 	cfg := &Config{
 		Edges: []string{"worker --- orchestrator"},
 		Nodes: map[string]NodeConfig{
 			"worker":       {},
 			"orchestrator": {},
 		},
-		ReviewerNode: "typo-reviewer",
+		CommandApproverNode: "typo-reviewer",
 		CommandApproval: []CommandApprovalPolicy{
-			{Requester: "worker", Label: "deploy", ReviewerNode: "another-typo"},
+			{Requester: "worker", Label: "deploy", CommandApproverNode: "another-typo"},
 		},
 	}
 
 	errors := ValidateConfig(cfg)
 	wantFields := map[string]bool{
-		"reviewer_node":                     false,
-		"command_approval[0].reviewer_node": false,
+		"command_approver_node":                     false,
+		"command_approval[0].command_approver_node": false,
 	}
 	for _, err := range errors {
 		if _, ok := wantFields[err.Field]; ok {
@@ -320,48 +320,48 @@ func TestValidateConfig_ReviewerNodeUnresolvable(t *testing.T) {
 	}
 	for field, found := range wantFields {
 		if !found {
-			t.Fatalf("missing reviewer_node validation warning for %s in %#v", field, errors)
+			t.Fatalf("missing command_approver_node validation warning for %s in %#v", field, errors)
 		}
 	}
 }
 
-// TestValidateConfig_ReviewerNodeResolvable guards against a false-positive
-// warning when reviewer_node correctly names a configured node.
-func TestValidateConfig_ReviewerNodeResolvable(t *testing.T) {
+// TestValidateConfig_CommandApproverNodeResolvable guards against a false-positive
+// warning when command_approver_node correctly names a configured node.
+func TestValidateConfig_CommandApproverNodeResolvable(t *testing.T) {
 	cfg := &Config{
 		Edges: []string{"worker --- orchestrator"},
 		Nodes: map[string]NodeConfig{
 			"worker":       {},
 			"orchestrator": {},
 		},
-		ReviewerNode: "orchestrator",
+		CommandApproverNode: "orchestrator",
 	}
 
 	for _, err := range ValidateConfig(cfg) {
-		if err.Field == "reviewer_node" {
-			t.Fatalf("unexpected reviewer_node validation error for a resolvable name: %#v", err)
+		if err.Field == "command_approver_node" {
+			t.Fatalf("unexpected command_approver_node validation error for a resolvable name: %#v", err)
 		}
 	}
 }
 
-func TestResolveReviewerNode(t *testing.T) {
+func TestResolveCommandApproverNode(t *testing.T) {
 	cfg := &Config{
-		ReviewerNode: "orchestrator",
+		CommandApproverNode: "orchestrator",
 		Nodes: map[string]NodeConfig{
 			"orchestrator": {},
 		},
 	}
 
-	if name, valid := cfg.ResolveReviewerNode(""); name != "orchestrator" || !valid {
-		t.Fatalf("ResolveReviewerNode(\"\") = (%q, %v), want (orchestrator, true)", name, valid)
+	if name, valid := cfg.ResolveCommandApproverNode(""); name != "orchestrator" || !valid {
+		t.Fatalf("ResolveCommandApproverNode(\"\") = (%q, %v), want (orchestrator, true)", name, valid)
 	}
-	if name, valid := cfg.ResolveReviewerNode("worker"); name != "worker" || valid {
-		t.Fatalf("ResolveReviewerNode(\"worker\") = (%q, %v), want (worker, false) — override names an unconfigured node", name, valid)
+	if name, valid := cfg.ResolveCommandApproverNode("worker"); name != "worker" || valid {
+		t.Fatalf("ResolveCommandApproverNode(\"worker\") = (%q, %v), want (worker, false) — override names an unconfigured node", name, valid)
 	}
-	if name, valid := (&Config{}).ResolveReviewerNode(""); name != "" || valid {
-		t.Fatalf("ResolveReviewerNode on an unconfigured Config = (%q, %v), want (\"\", false)", name, valid)
+	if name, valid := (&Config{}).ResolveCommandApproverNode(""); name != "" || valid {
+		t.Fatalf("ResolveCommandApproverNode on an unconfigured Config = (%q, %v), want (\"\", false)", name, valid)
 	}
-	if name, valid := (*Config)(nil).ResolveReviewerNode("orchestrator"); name != "" || valid {
-		t.Fatalf("ResolveReviewerNode on a nil Config = (%q, %v), want (\"\", false)", name, valid)
+	if name, valid := (*Config)(nil).ResolveCommandApproverNode("orchestrator"); name != "" || valid {
+		t.Fatalf("ResolveCommandApproverNode on a nil Config = (%q, %v), want (\"\", false)", name, valid)
 	}
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -286,3 +286,82 @@ func TestValidateConfig_WorkspaceTree(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateConfig_ReviewerNodeUnresolvable guards #626's decided
+// requirement 2 (foot-gun mitigation): a configured-but-unresolvable
+// reviewer_node must produce a load-time WARNING, never an error — the
+// unified fail-open rule means command approval still runs, but the
+// misconfiguration must be loud and auditable.
+func TestValidateConfig_ReviewerNodeUnresolvable(t *testing.T) {
+	cfg := &Config{
+		Edges: []string{"worker --- orchestrator"},
+		Nodes: map[string]NodeConfig{
+			"worker":       {},
+			"orchestrator": {},
+		},
+		ReviewerNode: "typo-reviewer",
+		CommandApproval: []CommandApprovalPolicy{
+			{Requester: "worker", Label: "deploy", ReviewerNode: "another-typo"},
+		},
+	}
+
+	errors := ValidateConfig(cfg)
+	wantFields := map[string]bool{
+		"reviewer_node":                     false,
+		"command_approval[0].reviewer_node": false,
+	}
+	for _, err := range errors {
+		if _, ok := wantFields[err.Field]; ok {
+			if err.Severity != "warning" {
+				t.Fatalf("field %s severity = %q, want warning (fail-open, never error)", err.Field, err.Severity)
+			}
+			wantFields[err.Field] = true
+		}
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("missing reviewer_node validation warning for %s in %#v", field, errors)
+		}
+	}
+}
+
+// TestValidateConfig_ReviewerNodeResolvable guards against a false-positive
+// warning when reviewer_node correctly names a configured node.
+func TestValidateConfig_ReviewerNodeResolvable(t *testing.T) {
+	cfg := &Config{
+		Edges: []string{"worker --- orchestrator"},
+		Nodes: map[string]NodeConfig{
+			"worker":       {},
+			"orchestrator": {},
+		},
+		ReviewerNode: "orchestrator",
+	}
+
+	for _, err := range ValidateConfig(cfg) {
+		if err.Field == "reviewer_node" {
+			t.Fatalf("unexpected reviewer_node validation error for a resolvable name: %#v", err)
+		}
+	}
+}
+
+func TestResolveReviewerNode(t *testing.T) {
+	cfg := &Config{
+		ReviewerNode: "orchestrator",
+		Nodes: map[string]NodeConfig{
+			"orchestrator": {},
+		},
+	}
+
+	if name, valid := cfg.ResolveReviewerNode(""); name != "orchestrator" || !valid {
+		t.Fatalf("ResolveReviewerNode(\"\") = (%q, %v), want (orchestrator, true)", name, valid)
+	}
+	if name, valid := cfg.ResolveReviewerNode("worker"); name != "worker" || valid {
+		t.Fatalf("ResolveReviewerNode(\"worker\") = (%q, %v), want (worker, false) — override names an unconfigured node", name, valid)
+	}
+	if name, valid := (&Config{}).ResolveReviewerNode(""); name != "" || valid {
+		t.Fatalf("ResolveReviewerNode on an unconfigured Config = (%q, %v), want (\"\", false)", name, valid)
+	}
+	if name, valid := (*Config)(nil).ResolveReviewerNode("orchestrator"); name != "" || valid {
+		t.Fatalf("ResolveReviewerNode on a nil Config = (%q, %v), want (\"\", false)", name, valid)
+	}
+}

--- a/internal/journal/command_approval_event.go
+++ b/internal/journal/command_approval_event.go
@@ -17,6 +17,12 @@ type CommandApprovalRequestPayload struct {
 	Reason      string `json:"reason,omitempty"`
 	ExpiresAt   string `json:"expires_at,omitempty"`
 	CommandText string `json:"command_text,omitempty"`
+	// ReviewerNode is the config-resolved, validated reviewer_node (#626) at
+	// the moment this request was created — never requester-controlled,
+	// unlike Reviewer above (a plain policy-matched audit label). Decisions
+	// MUST be validated against this field, not Reviewer, or the requester
+	// can self-approve by controlling both sides of the comparison.
+	ReviewerNode string `json:"reviewer_node,omitempty"`
 }
 
 type CommandApprovalDecisionPayload struct {

--- a/internal/journal/command_approval_event.go
+++ b/internal/journal/command_approval_event.go
@@ -17,12 +17,12 @@ type CommandApprovalRequestPayload struct {
 	Reason      string `json:"reason,omitempty"`
 	ExpiresAt   string `json:"expires_at,omitempty"`
 	CommandText string `json:"command_text,omitempty"`
-	// ReviewerNode is the config-resolved, validated reviewer_node (#626) at
+	// CommandApproverNode is the config-resolved, validated command_approver_node (#626) at
 	// the moment this request was created — never requester-controlled,
 	// unlike Reviewer above (a plain policy-matched audit label). Decisions
 	// MUST be validated against this field, not Reviewer, or the requester
 	// can self-approve by controlling both sides of the comparison.
-	ReviewerNode string `json:"reviewer_node,omitempty"`
+	CommandApproverNode string `json:"command_approver_node,omitempty"`
 }
 
 type CommandApprovalDecisionPayload struct {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -266,6 +266,26 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 			},
 			ThreadID: threadID,
 		}, true
+	case strings.HasPrefix(threadID, "command-approval-"):
+		// #626: a reply to a reviewer_node-delivered command approval
+		// request (execute-bash mints this exact thread id prefix via
+		// commandApprovalThreadID). Reuses the same APPROVED:/NOT
+		// APPROVED: body-prefix convention as the orchestrator/critic case
+		// above, but records via #625's own CommandApproval* event types,
+		// never the older ApprovalDecidedEventType/ApprovalDecisionPayload
+		// pair used by that unrelated hardcoded flow.
+		decision, ok := approvalDecisionFromContent(content)
+		if !ok {
+			return approvalDeliveryEvent{}, false
+		}
+		return approvalDeliveryEvent{
+			EventType: journal.CommandApprovalDecidedEventType,
+			Payload: journal.CommandApprovalDecisionPayload{
+				Reviewer: sender,
+				Decision: decision,
+			},
+			ThreadID: threadID,
+		}, true
 	default:
 		return approvalDeliveryEvent{}, false
 	}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -276,6 +276,7 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 		// pair used by that unrelated hardcoded flow.
 		decision, ok := approvalDecisionFromContent(content)
 		if !ok {
+			log.Printf("postman: WARNING: message %s on command approval thread %s did not start with APPROVED:/NOT APPROVED: — not recorded as a decision\n", messageID, threadID)
 			return approvalDeliveryEvent{}, false
 		}
 		return approvalDeliveryEvent{

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -267,7 +267,7 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 			ThreadID: threadID,
 		}, true
 	case strings.HasPrefix(threadID, "command-approval-"):
-		// #626: a reply to a reviewer_node-delivered command approval
+		// #626: a reply to a command_approver_node-delivered command approval
 		// request (execute-bash mints this exact thread id prefix via
 		// commandApprovalThreadID). Reuses the same APPROVED:/NOT
 		// APPROVED: body-prefix convention as the orchestrator/critic case

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1589,6 +1589,163 @@ func TestDeliverMessage_AppendsReplayableApprovalEventsForCrossSessionThread(t *
 	}
 }
 
+// seedCommandApprovalRequest writes a command_approval_requested journal
+// event directly into requesterSessionDir, mirroring what
+// recordCommandApprovalRequest in internal/cli/execute_bash.go does. Test
+// helper for the #626 B1 message-package coverage below.
+func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, sessionName, threadID, requester, reviewerNode string, now time.Time) {
+	t.Helper()
+	writer, err := journal.OpenCurrentWriter(requesterSessionDir)
+	if err != nil {
+		writer, err = journal.OpenShadowWriter(requesterSessionDir, contextID, sessionName, os.Getpid(), now)
+		if err != nil {
+			t.Fatalf("OpenShadowWriter() error = %v", err)
+		}
+	}
+	_, err = writer.AppendEventWithOptions(
+		journal.CommandApprovalRequestedEventType,
+		journal.VisibilityOperatorVisible,
+		journal.CommandApprovalRequestPayload{
+			Requester:    requester,
+			Reviewer:     "unassigned",
+			ReviewerNode: reviewerNode,
+			Mode:         "blocking",
+			Label:        "protected",
+			CommandHash:  "sha256:deadbeef",
+		},
+		journal.AppendOptions{ThreadID: threadID},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("AppendEventWithOptions(request) error = %v", err)
+	}
+}
+
+// TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval
+// guards #626 B1 at the message-package layer: a reply whose sender matches
+// the request's trusted, config-resolved ReviewerNode, starting the body
+// with APPROVED:, must be recorded as an approved decision through the real
+// DeliverMessage path (not a synthetic call to the unexported hook), the
+// same way the pre-existing orchestrator/critic flow is tested above.
+func TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval(t *testing.T) {
+	requesterSessionDir := filepath.Join(t.TempDir(), "requester-session")
+	if err := config.CreateSessionDirs(requesterSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(requester) failed: %v", err)
+	}
+	reviewerSessionDir := filepath.Join(t.TempDir(), "reviewer-session")
+	if err := config.CreateSessionDirs(reviewerSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(reviewer) failed: %v", err)
+	}
+
+	manager := journal.NewManager("test-ctx-626", 31338)
+	journal.InstallProcessManager(manager)
+	t.Cleanup(journal.ClearProcessManager)
+
+	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
+	threadID := "command-approval-aabbccddeeff0011"
+	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626", "requester-session", threadID, "worker", "orchestrator", now)
+
+	nodes := map[string]discovery.NodeInfo{
+		"requester-session:worker":      {PaneID: "%1", SessionName: "requester-session", SessionDir: requesterSessionDir},
+		"reviewer-session:orchestrator": {PaneID: "%2", SessionName: "reviewer-session", SessionDir: reviewerSessionDir},
+	}
+	adjacency := map[string][]string{
+		"worker":                        {"reviewer-session:orchestrator"},
+		"reviewer-session:orchestrator": {"requester-session:worker"},
+	}
+	cfg := &config.Config{}
+
+	replyFilename := "20260708-010001-r0001-from-reviewer-session:orchestrator-to-requester-session:worker.md"
+	replyPath := filepath.Join(reviewerSessionDir, "post", replyFilename)
+	replyContent := "---\nparams:\n  contextId: test-ctx-626\n  from: reviewer-session:orchestrator\n  to: requester-session:worker\n  thread_id: " + threadID + "\n  timestamp: 2026-07-08T01:00:01Z\n---\n\nAPPROVED: digest reviewed.\n"
+	if err := os.WriteFile(replyPath, []byte(replyContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(replyPath) failed: %v", err)
+	}
+
+	if err := DeliverMessage(replyPath, "test-ctx-626", nodes, adjacency, cfg, func(string) bool { return true }, nil, idle.NewIdleTracker(), ""); err != nil {
+		t.Fatalf("DeliverMessage(reply) failed: %v", err)
+	}
+
+	state, ok, err := projection.ProjectCommandApprovalState(requesterSessionDir, now)
+	if err != nil {
+		t.Fatalf("ProjectCommandApprovalState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectCommandApprovalState() ok = false, want true")
+	}
+	thread, found := state.Threads[threadID]
+	if !found {
+		t.Fatalf("missing thread %q in %#v", threadID, state.Threads)
+	}
+	if thread.Status != projection.CommandApprovalStatusApproved {
+		t.Fatalf("thread status = %q, want %q", thread.Status, projection.CommandApprovalStatusApproved)
+	}
+}
+
+// TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected is the
+// negative counterpart: a reply claiming to be a decision on the same
+// thread, but sent by a node other than the request's trusted
+// ReviewerNode, must be rejected as wrong_reviewer, not silently accepted.
+// This is the same B1 self-approval class guardian flagged, exercised
+// through the real message delivery path instead of the CLI.
+func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing.T) {
+	requesterSessionDir := filepath.Join(t.TempDir(), "requester-session")
+	if err := config.CreateSessionDirs(requesterSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(requester) failed: %v", err)
+	}
+	attackerSessionDir := filepath.Join(t.TempDir(), "attacker-session")
+	if err := config.CreateSessionDirs(attackerSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(attacker) failed: %v", err)
+	}
+
+	manager := journal.NewManager("test-ctx-626b", 31339)
+	journal.InstallProcessManager(manager)
+	t.Cleanup(journal.ClearProcessManager)
+
+	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
+	threadID := "command-approval-1122334455667788"
+	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626b", "requester-session", threadID, "worker", "orchestrator", now)
+
+	nodes := map[string]discovery.NodeInfo{
+		"requester-session:worker": {PaneID: "%1", SessionName: "requester-session", SessionDir: requesterSessionDir},
+		"attacker-session:worker":  {PaneID: "%2", SessionName: "attacker-session", SessionDir: attackerSessionDir},
+	}
+	adjacency := map[string][]string{
+		"worker":                  {"attacker-session:worker"},
+		"attacker-session:worker": {"requester-session:worker"},
+	}
+	cfg := &config.Config{}
+
+	// The attacker replies claiming to be "worker" (matching the requester's
+	// own policy.Reviewer label in a self-approval attempt), not the real
+	// reviewer_node "orchestrator".
+	replyFilename := "20260708-010001-r0002-from-attacker-session:worker-to-requester-session:worker.md"
+	replyPath := filepath.Join(attackerSessionDir, "post", replyFilename)
+	replyContent := "---\nparams:\n  contextId: test-ctx-626b\n  from: attacker-session:worker\n  to: requester-session:worker\n  thread_id: " + threadID + "\n  timestamp: 2026-07-08T01:00:01Z\n---\n\nAPPROVED: trust me.\n"
+	if err := os.WriteFile(replyPath, []byte(replyContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(replyPath) failed: %v", err)
+	}
+
+	if err := DeliverMessage(replyPath, "test-ctx-626b", nodes, adjacency, cfg, func(string) bool { return true }, nil, idle.NewIdleTracker(), ""); err != nil {
+		t.Fatalf("DeliverMessage(reply) failed: %v", err)
+	}
+
+	state, ok, err := projection.ProjectCommandApprovalState(requesterSessionDir, now)
+	if err != nil {
+		t.Fatalf("ProjectCommandApprovalState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectCommandApprovalState() ok = false, want true")
+	}
+	thread, found := state.Threads[threadID]
+	if !found {
+		t.Fatalf("missing thread %q in %#v", threadID, state.Threads)
+	}
+	if thread.Status != projection.CommandApprovalStatusWrongReviewer {
+		t.Fatalf("thread status = %q, want %q (self-approval by a non-reviewer_node sender must never be accepted)", thread.Status, projection.CommandApprovalStatusWrongReviewer)
+	}
+}
+
 // TestDeliverNotificationWithRetry_RetryUsesRefreshedPaneID verifies that when
 // the first delivery attempt fails and knownNodes has a fresh PaneID, the retry
 // uses the refreshed PaneID.

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1593,7 +1593,14 @@ func TestDeliverMessage_AppendsReplayableApprovalEventsForCrossSessionThread(t *
 // event directly into requesterSessionDir, mirroring what
 // recordCommandApprovalRequest in internal/cli/execute_bash.go does. Test
 // helper for the #626 B1 message-package coverage below.
-func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, sessionName, threadID, requester, reviewerNode string, now time.Time) {
+// seedCommandApprovalRequest journals a command approval request.
+// reviewerLabel seeds thread.Reviewer (the plain, requester-influenceable
+// audit label) independently of reviewerNode (the trusted, config-resolved
+// field #626 B1 requires decisions to be checked against) — callers that
+// need to prove a test is actually diagnostic of the ReviewerNode binding,
+// rather than incidentally passing because Reviewer happens to differ too,
+// should set reviewerLabel to something Reviewer alone would have accepted.
+func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, sessionName, threadID, requester, reviewerLabel, reviewerNode string, now time.Time) {
 	t.Helper()
 	writer, err := journal.OpenCurrentWriter(requesterSessionDir)
 	if err != nil {
@@ -1607,7 +1614,7 @@ func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, se
 		journal.VisibilityOperatorVisible,
 		journal.CommandApprovalRequestPayload{
 			Requester:    requester,
-			Reviewer:     "unassigned",
+			Reviewer:     reviewerLabel,
 			ReviewerNode: reviewerNode,
 			Mode:         "blocking",
 			Label:        "protected",
@@ -1643,7 +1650,7 @@ func TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval(
 
 	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
 	threadID := "command-approval-aabbccddeeff0011"
-	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626", "requester-session", threadID, "worker", "orchestrator", now)
+	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626", "requester-session", threadID, "worker", "unassigned", "orchestrator", now)
 
 	nodes := map[string]discovery.NodeInfo{
 		"requester-session:worker":      {PaneID: "%1", SessionName: "requester-session", SessionDir: requesterSessionDir},
@@ -1704,7 +1711,16 @@ func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing
 
 	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
 	threadID := "command-approval-1122334455667788"
-	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626b", "requester-session", threadID, "worker", "orchestrator", now)
+	// thread.Reviewer is deliberately seeded to "worker" — the exact
+	// identity the attacker's reply claims to be from — so this test is
+	// only diagnostic of the ReviewerNode binding (#626 B1): under the old,
+	// vulnerable Reviewer-based check this reply would have matched and
+	// been accepted; only checking against the differing ReviewerNode
+	// ("orchestrator") catches it. Guardian's QA found the prior version of
+	// this test (seeded with Reviewer: "unassigned") passed identically
+	// whether or not the ReviewerNode fix was in place, since "unassigned"
+	// never matched the attacker's claimed identity under either check.
+	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626b", "requester-session", threadID, "worker", "worker", "orchestrator", now)
 
 	nodes := map[string]discovery.NodeInfo{
 		"requester-session:worker": {PaneID: "%1", SessionName: "requester-session", SessionDir: requesterSessionDir},

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1595,12 +1595,12 @@ func TestDeliverMessage_AppendsReplayableApprovalEventsForCrossSessionThread(t *
 // helper for the #626 B1 message-package coverage below.
 // seedCommandApprovalRequest journals a command approval request.
 // reviewerLabel seeds thread.Reviewer (the plain, requester-influenceable
-// audit label) independently of reviewerNode (the trusted, config-resolved
+// audit label) independently of commandApproverNode (the trusted, config-resolved
 // field #626 B1 requires decisions to be checked against) — callers that
-// need to prove a test is actually diagnostic of the ReviewerNode binding,
+// need to prove a test is actually diagnostic of the CommandApproverNode binding,
 // rather than incidentally passing because Reviewer happens to differ too,
 // should set reviewerLabel to something Reviewer alone would have accepted.
-func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, sessionName, threadID, requester, reviewerLabel, reviewerNode string, now time.Time) {
+func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, sessionName, threadID, requester, reviewerLabel, commandApproverNode string, now time.Time) {
 	t.Helper()
 	writer, err := journal.OpenCurrentWriter(requesterSessionDir)
 	if err != nil {
@@ -1613,12 +1613,12 @@ func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, se
 		journal.CommandApprovalRequestedEventType,
 		journal.VisibilityOperatorVisible,
 		journal.CommandApprovalRequestPayload{
-			Requester:    requester,
-			Reviewer:     reviewerLabel,
-			ReviewerNode: reviewerNode,
-			Mode:         "blocking",
-			Label:        "protected",
-			CommandHash:  "sha256:deadbeef",
+			Requester:           requester,
+			Reviewer:            reviewerLabel,
+			CommandApproverNode: commandApproverNode,
+			Mode:                "blocking",
+			Label:               "protected",
+			CommandHash:         "sha256:deadbeef",
 		},
 		journal.AppendOptions{ThreadID: threadID},
 		now,
@@ -1628,13 +1628,13 @@ func seedCommandApprovalRequest(t *testing.T, requesterSessionDir, contextID, se
 	}
 }
 
-// TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval
+// TestDeliverMessage_CommandApprovalReplyFromRealCommandApproverNodeRecordsApproval
 // guards #626 B1 at the message-package layer: a reply whose sender matches
-// the request's trusted, config-resolved ReviewerNode, starting the body
+// the request's trusted, config-resolved CommandApproverNode, starting the body
 // with APPROVED:, must be recorded as an approved decision through the real
 // DeliverMessage path (not a synthetic call to the unexported hook), the
 // same way the pre-existing orchestrator/critic flow is tested above.
-func TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval(t *testing.T) {
+func TestDeliverMessage_CommandApprovalReplyFromRealCommandApproverNodeRecordsApproval(t *testing.T) {
 	requesterSessionDir := filepath.Join(t.TempDir(), "requester-session")
 	if err := config.CreateSessionDirs(requesterSessionDir); err != nil {
 		t.Fatalf("config.CreateSessionDirs(requester) failed: %v", err)
@@ -1692,7 +1692,7 @@ func TestDeliverMessage_CommandApprovalReplyFromRealReviewerNodeRecordsApproval(
 // TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected is the
 // negative counterpart: a reply claiming to be a decision on the same
 // thread, but sent by a node other than the request's trusted
-// ReviewerNode, must be rejected as wrong_reviewer, not silently accepted.
+// CommandApproverNode, must be rejected as wrong_reviewer, not silently accepted.
 // This is the same B1 self-approval class guardian flagged, exercised
 // through the real message delivery path instead of the CLI.
 func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing.T) {
@@ -1713,12 +1713,12 @@ func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing
 	threadID := "command-approval-1122334455667788"
 	// thread.Reviewer is deliberately seeded to "worker" — the exact
 	// identity the attacker's reply claims to be from — so this test is
-	// only diagnostic of the ReviewerNode binding (#626 B1): under the old,
+	// only diagnostic of the CommandApproverNode binding (#626 B1): under the old,
 	// vulnerable Reviewer-based check this reply would have matched and
-	// been accepted; only checking against the differing ReviewerNode
+	// been accepted; only checking against the differing CommandApproverNode
 	// ("orchestrator") catches it. Guardian's QA found the prior version of
 	// this test (seeded with Reviewer: "unassigned") passed identically
-	// whether or not the ReviewerNode fix was in place, since "unassigned"
+	// whether or not the CommandApproverNode fix was in place, since "unassigned"
 	// never matched the attacker's claimed identity under either check.
 	seedCommandApprovalRequest(t, requesterSessionDir, "test-ctx-626b", "requester-session", threadID, "worker", "worker", "orchestrator", now)
 
@@ -1734,7 +1734,7 @@ func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing
 
 	// The attacker replies claiming to be "worker" (matching the requester's
 	// own policy.Reviewer label in a self-approval attempt), not the real
-	// reviewer_node "orchestrator".
+	// command_approver_node "orchestrator".
 	replyFilename := "20260708-010001-r0002-from-attacker-session:worker-to-requester-session:worker.md"
 	replyPath := filepath.Join(attackerSessionDir, "post", replyFilename)
 	replyContent := "---\nparams:\n  contextId: test-ctx-626b\n  from: attacker-session:worker\n  to: requester-session:worker\n  thread_id: " + threadID + "\n  timestamp: 2026-07-08T01:00:01Z\n---\n\nAPPROVED: trust me.\n"
@@ -1758,7 +1758,7 @@ func TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected(t *testing
 		t.Fatalf("missing thread %q in %#v", threadID, state.Threads)
 	}
 	if thread.Status != projection.CommandApprovalStatusWrongReviewer {
-		t.Fatalf("thread status = %q, want %q (self-approval by a non-reviewer_node sender must never be accepted)", thread.Status, projection.CommandApprovalStatusWrongReviewer)
+		t.Fatalf("thread status = %q, want %q (self-approval by a non-command_approver_node sender must never be accepted)", thread.Status, projection.CommandApprovalStatusWrongReviewer)
 	}
 }
 

--- a/internal/projection/command_approval.go
+++ b/internal/projection/command_approval.go
@@ -23,21 +23,21 @@ type CommandApprovalThread struct {
 	ThreadID  string `json:"thread_id"`
 	Requester string `json:"requester,omitempty"`
 	Reviewer  string `json:"reviewer,omitempty"`
-	// ReviewerNode is the config-resolved, validated reviewer_node captured
+	// CommandApproverNode is the config-resolved, validated command_approver_node captured
 	// at request time (#626). Decision validation MUST compare against this
 	// field, never Reviewer (a requester-influenceable audit label) — see
 	// applyCommandApprovalDecision.
-	ReviewerNode      string                `json:"reviewer_node,omitempty"`
-	Mode              string                `json:"mode,omitempty"`
-	Label             string                `json:"label,omitempty"`
-	Category          string                `json:"category,omitempty"`
-	CommandHash       string                `json:"command_hash,omitempty"`
-	Status            CommandApprovalStatus `json:"status"`
-	Reason            string                `json:"reason,omitempty"`
-	RequestedAt       string                `json:"requested_at,omitempty"`
-	ExpiresAt         string                `json:"expires_at,omitempty"`
-	DecidedAt         string                `json:"decided_at,omitempty"`
-	DecisionMessageID string                `json:"decision_message_id,omitempty"`
+	CommandApproverNode string                `json:"command_approver_node,omitempty"`
+	Mode                string                `json:"mode,omitempty"`
+	Label               string                `json:"label,omitempty"`
+	Category            string                `json:"category,omitempty"`
+	CommandHash         string                `json:"command_hash,omitempty"`
+	Status              CommandApprovalStatus `json:"status"`
+	Reason              string                `json:"reason,omitempty"`
+	RequestedAt         string                `json:"requested_at,omitempty"`
+	ExpiresAt           string                `json:"expires_at,omitempty"`
+	DecidedAt           string                `json:"decided_at,omitempty"`
+	DecisionMessageID   string                `json:"decision_message_id,omitempty"`
 }
 
 type CommandApprovalState struct {
@@ -112,18 +112,18 @@ func applyCommandApprovalRequest(threads map[string]CommandApprovalThread, event
 	}
 
 	threads[event.ThreadID] = CommandApprovalThread{
-		ThreadID:     event.ThreadID,
-		Requester:    payload.Requester,
-		Reviewer:     payload.Reviewer,
-		ReviewerNode: payload.ReviewerNode,
-		Mode:         payload.Mode,
-		Label:        payload.Label,
-		Category:     payload.Category,
-		CommandHash:  payload.CommandHash,
-		Status:       CommandApprovalStatusPending,
-		Reason:       payload.Reason,
-		RequestedAt:  event.OccurredAt,
-		ExpiresAt:    payload.ExpiresAt,
+		ThreadID:            event.ThreadID,
+		Requester:           payload.Requester,
+		Reviewer:            payload.Reviewer,
+		CommandApproverNode: payload.CommandApproverNode,
+		Mode:                payload.Mode,
+		Label:               payload.Label,
+		Category:            payload.Category,
+		CommandHash:         payload.CommandHash,
+		Status:              CommandApprovalStatusPending,
+		Reason:              payload.Reason,
+		RequestedAt:         event.OccurredAt,
+		ExpiresAt:           payload.ExpiresAt,
 	}
 	return nil
 }
@@ -151,17 +151,17 @@ func applyCommandApprovalDecision(threads map[string]CommandApprovalThread, even
 		}
 		return nil
 	}
-	// #626 B1: validate against thread.ReviewerNode (the config-resolved,
-	// validated reviewer_node captured at request time), never
+	// #626 B1: validate against thread.CommandApproverNode (the config-resolved,
+	// validated command_approver_node captured at request time), never
 	// thread.Reviewer (a plain requester-influenceable audit label). Both
 	// sides of the old thread.Reviewer comparison were requester-controlled
 	// — the requester's own policy match set thread.Reviewer, and the
 	// requester's own --record-decision/--reviewer or reply "from" set
 	// payload.Reviewer — making self-approval trivial. An empty
-	// thread.ReviewerNode (no valid reviewer_node was configured for this
+	// thread.CommandApproverNode (no valid command_approver_node was configured for this
 	// request) must never be treated as a match; it means this thread was
 	// created without a real reviewer, so no decision on it can be trusted.
-	if thread.ReviewerNode == "" || payload.Reviewer != thread.ReviewerNode {
+	if thread.CommandApproverNode == "" || payload.Reviewer != thread.CommandApproverNode {
 		thread.Status = CommandApprovalStatusWrongReviewer
 		thread.Reason = payload.Reason
 		thread.DecidedAt = event.OccurredAt

--- a/internal/projection/command_approval.go
+++ b/internal/projection/command_approval.go
@@ -20,9 +20,14 @@ const (
 )
 
 type CommandApprovalThread struct {
-	ThreadID          string                `json:"thread_id"`
-	Requester         string                `json:"requester,omitempty"`
-	Reviewer          string                `json:"reviewer,omitempty"`
+	ThreadID  string `json:"thread_id"`
+	Requester string `json:"requester,omitempty"`
+	Reviewer  string `json:"reviewer,omitempty"`
+	// ReviewerNode is the config-resolved, validated reviewer_node captured
+	// at request time (#626). Decision validation MUST compare against this
+	// field, never Reviewer (a requester-influenceable audit label) — see
+	// applyCommandApprovalDecision.
+	ReviewerNode      string                `json:"reviewer_node,omitempty"`
 	Mode              string                `json:"mode,omitempty"`
 	Label             string                `json:"label,omitempty"`
 	Category          string                `json:"category,omitempty"`
@@ -107,17 +112,18 @@ func applyCommandApprovalRequest(threads map[string]CommandApprovalThread, event
 	}
 
 	threads[event.ThreadID] = CommandApprovalThread{
-		ThreadID:    event.ThreadID,
-		Requester:   payload.Requester,
-		Reviewer:    payload.Reviewer,
-		Mode:        payload.Mode,
-		Label:       payload.Label,
-		Category:    payload.Category,
-		CommandHash: payload.CommandHash,
-		Status:      CommandApprovalStatusPending,
-		Reason:      payload.Reason,
-		RequestedAt: event.OccurredAt,
-		ExpiresAt:   payload.ExpiresAt,
+		ThreadID:     event.ThreadID,
+		Requester:    payload.Requester,
+		Reviewer:     payload.Reviewer,
+		ReviewerNode: payload.ReviewerNode,
+		Mode:         payload.Mode,
+		Label:        payload.Label,
+		Category:     payload.Category,
+		CommandHash:  payload.CommandHash,
+		Status:       CommandApprovalStatusPending,
+		Reason:       payload.Reason,
+		RequestedAt:  event.OccurredAt,
+		ExpiresAt:    payload.ExpiresAt,
 	}
 	return nil
 }
@@ -145,7 +151,17 @@ func applyCommandApprovalDecision(threads map[string]CommandApprovalThread, even
 		}
 		return nil
 	}
-	if payload.Reviewer != thread.Reviewer {
+	// #626 B1: validate against thread.ReviewerNode (the config-resolved,
+	// validated reviewer_node captured at request time), never
+	// thread.Reviewer (a plain requester-influenceable audit label). Both
+	// sides of the old thread.Reviewer comparison were requester-controlled
+	// — the requester's own policy match set thread.Reviewer, and the
+	// requester's own --record-decision/--reviewer or reply "from" set
+	// payload.Reviewer — making self-approval trivial. An empty
+	// thread.ReviewerNode (no valid reviewer_node was configured for this
+	// request) must never be treated as a match; it means this thread was
+	// created without a real reviewer, so no decision on it can be trusted.
+	if thread.ReviewerNode == "" || payload.Reviewer != thread.ReviewerNode {
 		thread.Status = CommandApprovalStatusWrongReviewer
 		thread.Reason = payload.Reason
 		thread.DecidedAt = event.OccurredAt

--- a/internal/projection/command_approval_test.go
+++ b/internal/projection/command_approval_test.go
@@ -95,14 +95,20 @@ func appendCommandApprovalRequestForTest(t *testing.T, writer *journal.Writer, t
 		journal.CommandApprovalRequestedEventType,
 		journal.VisibilityOperatorVisible,
 		journal.CommandApprovalRequestPayload{
-			Requester:   "worker",
-			Reviewer:    reviewer,
-			Mode:        "blocking",
-			Label:       "nix-build",
-			Category:    "verification",
-			CommandHash: "sha256:test",
-			Reason:      "verify build",
-			ExpiresAt:   expiresAt.Format(time.RFC3339Nano),
+			Requester: "worker",
+			Reviewer:  reviewer,
+			// #626 B1: ReviewerNode is the trusted field decisions are
+			// actually validated against now; mirroring the plain Reviewer
+			// label here keeps this test's existing approved/wrong-reviewer
+			// intent intact (a decision claiming to be "orchestrator"
+			// matches, "critic" does not).
+			ReviewerNode: reviewer,
+			Mode:         "blocking",
+			Label:        "nix-build",
+			Category:     "verification",
+			CommandHash:  "sha256:test",
+			Reason:       "verify build",
+			ExpiresAt:    expiresAt.Format(time.RFC3339Nano),
 		},
 		journal.AppendOptions{ThreadID: threadID},
 		now,

--- a/internal/projection/command_approval_test.go
+++ b/internal/projection/command_approval_test.go
@@ -97,18 +97,18 @@ func appendCommandApprovalRequestForTest(t *testing.T, writer *journal.Writer, t
 		journal.CommandApprovalRequestPayload{
 			Requester: "worker",
 			Reviewer:  reviewer,
-			// #626 B1: ReviewerNode is the trusted field decisions are
+			// #626 B1: CommandApproverNode is the trusted field decisions are
 			// actually validated against now; mirroring the plain Reviewer
 			// label here keeps this test's existing approved/wrong-reviewer
 			// intent intact (a decision claiming to be "orchestrator"
 			// matches, "critic" does not).
-			ReviewerNode: reviewer,
-			Mode:         "blocking",
-			Label:        "nix-build",
-			Category:     "verification",
-			CommandHash:  "sha256:test",
-			Reason:       "verify build",
-			ExpiresAt:    expiresAt.Format(time.RFC3339Nano),
+			CommandApproverNode: reviewer,
+			Mode:                "blocking",
+			Label:               "nix-build",
+			Category:            "verification",
+			CommandHash:         "sha256:test",
+			Reason:              "verify build",
+			ExpiresAt:           expiresAt.Format(time.RFC3339Nano),
 		},
 		journal.AppendOptions{ThreadID: threadID},
 		now,

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -164,24 +164,38 @@ type WorkspaceTreeStatus struct {
 	Diagnostics []WorkspaceTreeDiagnostic `json:"diagnostics,omitempty"`
 }
 
+// CommandApprovalUnresolvedReviewer surfaces a configured-but-unresolvable
+// reviewer_node so a typo that silently disables blocking mode (#626's fail
+// open rule) is loud and auditable rather than a silent no-op.
+type CommandApprovalUnresolvedReviewer struct {
+	Field   string `json:"field"`
+	Value   string `json:"value"`
+	Message string `json:"message"`
+}
+
+type CommandApprovalStatus struct {
+	UnresolvedReviewers []CommandApprovalUnresolvedReviewer `json:"unresolved_reviewers,omitempty"`
+}
+
 type SessionStatus struct {
-	SchemaVersion      int                  `json:"schema_version"`
-	ContextID          string               `json:"context_id"`
-	SessionName        string               `json:"session_name"`
-	NodeCount          int                  `json:"node_count"`
-	VisibleState       string               `json:"visible_state"`
-	Severity           string               `json:"severity,omitempty"`
-	SeveritySource     string               `json:"severity_source,omitempty"`
-	SeverityReason     string               `json:"severity_reason,omitempty"`
-	Compact            string               `json:"compact"`
-	CompactSeverity    string               `json:"compact_severity,omitempty"`
-	Queues             SessionQueues        `json:"queues"`
-	Delivery           *DeliveryStatus      `json:"delivery,omitempty"`
-	RuntimeDiagnostics *RuntimeDiagnostics  `json:"runtime_diagnostics,omitempty"`
-	Tasks              []TaskRunProjection  `json:"tasks,omitempty"`
-	WorkspaceTree      *WorkspaceTreeStatus `json:"workspace_tree,omitempty"`
-	Nodes              []NodeStatus         `json:"nodes"`
-	Windows            []SessionWindow      `json:"windows"`
+	SchemaVersion      int                    `json:"schema_version"`
+	ContextID          string                 `json:"context_id"`
+	SessionName        string                 `json:"session_name"`
+	NodeCount          int                    `json:"node_count"`
+	VisibleState       string                 `json:"visible_state"`
+	Severity           string                 `json:"severity,omitempty"`
+	SeveritySource     string                 `json:"severity_source,omitempty"`
+	SeverityReason     string                 `json:"severity_reason,omitempty"`
+	Compact            string                 `json:"compact"`
+	CompactSeverity    string                 `json:"compact_severity,omitempty"`
+	Queues             SessionQueues          `json:"queues"`
+	Delivery           *DeliveryStatus        `json:"delivery,omitempty"`
+	RuntimeDiagnostics *RuntimeDiagnostics    `json:"runtime_diagnostics,omitempty"`
+	Tasks              []TaskRunProjection    `json:"tasks,omitempty"`
+	WorkspaceTree      *WorkspaceTreeStatus   `json:"workspace_tree,omitempty"`
+	CommandApproval    *CommandApprovalStatus `json:"command_approval,omitempty"`
+	Nodes              []NodeStatus           `json:"nodes"`
+	Windows            []SessionWindow        `json:"windows"`
 }
 
 type TaskRunProjection struct {

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -164,17 +164,17 @@ type WorkspaceTreeStatus struct {
 	Diagnostics []WorkspaceTreeDiagnostic `json:"diagnostics,omitempty"`
 }
 
-// CommandApprovalUnresolvedReviewer surfaces a configured-but-unresolvable
-// reviewer_node so a typo that silently disables blocking mode (#626's fail
+// CommandApprovalUnresolvedApprover surfaces a configured-but-unresolvable
+// command_approver_node so a typo that silently disables blocking mode (#626's fail
 // open rule) is loud and auditable rather than a silent no-op.
-type CommandApprovalUnresolvedReviewer struct {
+type CommandApprovalUnresolvedApprover struct {
 	Field   string `json:"field"`
 	Value   string `json:"value"`
 	Message string `json:"message"`
 }
 
 type CommandApprovalStatus struct {
-	UnresolvedReviewers []CommandApprovalUnresolvedReviewer `json:"unresolved_reviewers,omitempty"`
+	UnresolvedCommandApprovers []CommandApprovalUnresolvedApprover `json:"unresolved_command_approvers,omitempty"`
 }
 
 type SessionStatus struct {


### PR DESCRIPTION
## Summary

Adds `reviewer_node` config (`ui_node`-style: global under `[postman]`, or per-policy override under `[[postman.command_approval]]`), the trusted node an approval decision is checked against.

## Behavior

- Fail-open across every mode (advisory/warn-only/blocking) until a VALID `reviewer_node` is configured — unset or unresolvable (typo) both auto-approve, recorded distinctly as `auto_approved_no_reviewer`. An unresolvable `reviewer_node` also produces a load-time warning and a visible `get-status` marker.
- When a valid `reviewer_node` is configured, `execute-bash` delivers the approval request to it directly as a reply-required message; a reply body starting `APPROVED:`/`NOT APPROVED:` records the decision automatically.
- Decision validation is bound to the trusted, config-resolved `reviewer_node` captured at request time — never the plain, requester-influenceable `reviewer` audit label — on both the message-reply path and the `--record-decision` CLI path. On the CLI path specifically, the decision's reviewer identity always comes from the calling process's own authenticated tmux pane identity, never a flag; a caller whose pane isn't the configured `reviewer_node` is refused outright, with no decision recorded.
- `--thread-id` is validated against a safe charset before being interpolated into hand-built message frontmatter.

## Docs

`docs/command-approvals.md` and the `execute-bash --help` text are updated to describe the fail-open rule, delivery behavior, and the authenticated-caller decision requirement.

## Verification

Full `go test ./...`, `go test -race` (clean aside from a pre-existing, unrelated race in `TestRunStop_StopsDaemonOwnerSession`), `nix flake check`, and `nix build` all pass.

Closes #626.