### PR TITLE
fix(projection): stop mailbox-projection body files from truncating (#633)

### DIFF
--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -113,6 +113,101 @@ func TestRunPopWithContextWritesJSONToConfiguredStdout(t *testing.T) {
 	}
 }
 
+// TestRunPop_ForeignContextDirectPopSurvivesRacyEmptyShadowRead exercises
+// the non-owner (contextOwnsSession=false, SubmitPathPost) direct-pop
+// branch end to end against the #633 regression found in review: this
+// branch archives the message via a raw filesystem rename with no
+// known-good content journaled at pop time (unlike the daemon-submit
+// path's recordDaemonSubmitPopRead). Its only content-recording path is
+// the filesystem-watcher-driven shadow recorder, which can race and
+// record an empty first read event. Simulating exactly that here must
+// leave the archived message visible after a projection sync, not delete
+// it outright.
+func TestRunPop_ForeignContextDirectPopSurvivesRacyEmptyShadowRead(t *testing.T) {
+	tmpDir := t.TempDir()
+	contextID := "ctx-pop-foreign"
+	sessionName := "test-session"
+	sessionDir := filepath.Join(tmpDir, contextID, sessionName)
+	inboxDir := filepath.Join(sessionDir, "inbox", "guardian")
+	filename := "20260710-154500-s7c1c-rforeign-from-orchestrator-to-guardian.md"
+	inboxPath := filepath.Join(inboxDir, filename)
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll inbox: %v", err)
+	}
+	body := "foreign-context direct pop payload"
+	if err := os.WriteFile(inboxPath, []byte(messageFixture("orchestrator", "guardian", body)), 0o600); err != nil {
+		t.Fatalf("WriteFile inbox: %v", err)
+	}
+
+	// Also record the delivery in the journal so ProjectMailboxProjection
+	// has a valid session (lease/resolution) to replay against.
+	now := time.Date(2026, time.July, 10, 15, 45, 0, 0, time.UTC)
+	writer, err := journal.OpenShadowWriter(sessionDir, contextID, sessionName, 1, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+	if _, err := writer.AppendEvent(projection.MailboxProjectionDeliveredEventType, journal.VisibilityMailboxProjection, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      filepath.Join("inbox", "guardian", filename),
+		Content:   messageFixture("orchestrator", "guardian", body),
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("AppendEvent(delivered): %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = runPopWithContext(commandContext{
+		stdout: &stdout,
+		resolveInboxPath: func(args []string) (string, error) {
+			return inboxDir, nil
+		},
+		loadConfig: func(path string) (*config.Config, error) {
+			return config.DefaultConfig(), nil
+		},
+		contextOwnsSession: func(baseDir, resolvedContextID, name string) bool {
+			return false
+		},
+	}, []string{"--context-id", contextID})
+	if err != nil {
+		t.Fatalf("runPopWithContext: %v", err)
+	}
+	payload := decodePopMessageOutputForTest(t, stdout.String())
+	if payload.SubmitPath != projection.SubmitPathPost {
+		t.Fatalf("SubmitPath = %q, want %q (non-owner direct fallback)", payload.SubmitPath, projection.SubmitPathPost)
+	}
+	readPath := filepath.Join(sessionDir, "read", filename)
+	if _, err := os.Stat(readPath); err != nil {
+		t.Fatalf("archived file missing after direct pop: %v", err)
+	}
+
+	// Simulate the racy shadow-recorder observation: the first (and, for
+	// this test, only) read event for this message carries empty content.
+	if _, err := writer.AppendEvent(projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      filepath.Join("read", filename),
+		Content:   "",
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("AppendEvent(empty read): %v", err)
+	}
+
+	if err := projection.SyncMailboxProjection(sessionDir); err != nil {
+		t.Fatalf("SyncMailboxProjection: %v", err)
+	}
+
+	// The archived message must still be reachable through the derived
+	// projection: either the read file survives, or -- since no genuine
+	// read has completed yet -- the message stays visible via inbox
+	// instead of vanishing from both projections and being deleted.
+	_, readErr := os.Stat(readPath)
+	_, inboxErr := os.Stat(filepath.Join(sessionDir, "inbox", "guardian", filename))
+	if os.IsNotExist(readErr) && os.IsNotExist(inboxErr) {
+		t.Fatal("message disappeared from both read and inbox after racy empty shadow read: data loss regression")
+	}
+}
+
 func TestRunPopWithContextUsesDaemonSubmitDependencyWithoutDaemon(t *testing.T) {
 	tmpDir := t.TempDir()
 	contextID := "ctx-pop-submit-context"

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -115,14 +115,18 @@ func TestRunPopWithContextWritesJSONToConfiguredStdout(t *testing.T) {
 
 // TestRunPop_ForeignContextDirectPopSurvivesRacyEmptyShadowRead exercises
 // the non-owner (contextOwnsSession=false, SubmitPathPost) direct-pop
-// branch end to end against the #633 regression found in review: this
-// branch archives the message via a raw filesystem rename with no
-// known-good content journaled at pop time (unlike the daemon-submit
-// path's recordDaemonSubmitPopRead). Its only content-recording path is
-// the filesystem-watcher-driven shadow recorder, which can race and
-// record an empty first read event. Simulating exactly that here must
-// leave the archived message visible after a projection sync, not delete
-// it outright.
+// branch end to end against the #633 regressions found across two rounds
+// of review: this branch archives the message via a raw filesystem rename
+// with no known-good content journaled at pop time (unlike the
+// daemon-submit path's recordDaemonSubmitPopRead). Its only
+// content-recording path is the filesystem-watcher-driven shadow
+// recorder, which can race and record an empty first read event.
+// Simulating exactly that here must enforce the actual invariant: the
+// archived message survives specifically at read/ with its correct body
+// content (not merely "some path exists"), and it must NOT be resurrected
+// back into inbox/ where it would become re-consumable -- a
+// duplicate-processing hazard found in review of the first attempt at
+// this fix.
 func TestRunPop_ForeignContextDirectPopSurvivesRacyEmptyShadowRead(t *testing.T) {
 	tmpDir := t.TempDir()
 	contextID := "ctx-pop-foreign"
@@ -197,14 +201,20 @@ func TestRunPop_ForeignContextDirectPopSurvivesRacyEmptyShadowRead(t *testing.T)
 		t.Fatalf("SyncMailboxProjection: %v", err)
 	}
 
-	// The archived message must still be reachable through the derived
-	// projection: either the read file survives, or -- since no genuine
-	// read has completed yet -- the message stays visible via inbox
-	// instead of vanishing from both projections and being deleted.
-	_, readErr := os.Stat(readPath)
-	_, inboxErr := os.Stat(filepath.Join(sessionDir, "inbox", "guardian", filename))
-	if os.IsNotExist(readErr) && os.IsNotExist(inboxErr) {
-		t.Fatal("message disappeared from both read and inbox after racy empty shadow read: data loss regression")
+	// The archived message must survive specifically at read/ with its
+	// correct, original body content -- not merely "some path exists".
+	got, err := os.ReadFile(readPath)
+	if err != nil {
+		t.Fatalf("read file missing after racy empty shadow read: %v (data loss regression)", err)
+	}
+	if !strings.Contains(string(got), body) {
+		t.Fatalf("read file content = %q, want it to contain %q (content lost or corrupted)", string(got), body)
+	}
+
+	// It must NOT be resurrected back into inbox/, where it would become
+	// re-consumable (duplicate-processing hazard found in review).
+	if _, err := os.Stat(filepath.Join(sessionDir, "inbox", "guardian", filename)); !os.IsNotExist(err) {
+		t.Fatalf("message resurrected into inbox/ after racy empty shadow read: err=%v (duplicate-processing hazard)", err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -375,9 +375,17 @@ func writeRuntimeProfileFile(outputPath, requestID string, data []byte, force bo
 }
 
 func recordDaemonSubmitPopRead(sessionDir, readPath, filename, fallbackContent string) {
+	// fallbackContent was read directly from the inbox message before it was
+	// archived to readPath, so it is already known-good. Re-reading readPath
+	// here served no purpose and could observe a torn/truncated file if a
+	// concurrent projection sync was rewriting the same path (issue #633);
+	// only fall back to a disk read if fallbackContent is unexpectedly
+	// empty, and never let an empty disk read clobber known-good content.
 	content := fallbackContent
-	if readContent, err := os.ReadFile(readPath); err == nil {
-		content = string(readContent)
+	if content == "" {
+		if readContent, err := os.ReadFile(readPath); err == nil && len(readContent) > 0 {
+			content = string(readContent)
+		}
 	}
 	recordMailboxProjectionPayload(sessionDir, filepath.Base(sessionDir), projection.MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, mailboxProjectionPayloadForFile(
 		filename,

--- a/internal/daemon/daemon_submit_test.go
+++ b/internal/daemon/daemon_submit_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"log"
 	"os"
 	"path/filepath"
@@ -635,5 +636,49 @@ func TestProcessDaemonSubmitRequest_RuntimeProfileFileForceOverwrites(t *testing
 	}
 	if len(written) == 0 {
 		t.Fatal("overwritten profile is empty")
+	}
+}
+
+// TestRecordDaemonSubmitPopRead_PrefersFallbackOverTruncatedReadPath
+// reproduces the #633 race: readPath is caught mid-truncation (0 bytes) by
+// a concurrent projection sync at the exact moment the pop path records its
+// read event. The known-good content read from the inbox message before
+// archiving (fallbackContent) must win instead of the torn on-disk read.
+func TestRecordDaemonSubmitPopRead_PrefersFallbackOverTruncatedReadPath(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	now := time.Date(2026, time.July, 10, 15, 2, 6, 0, time.UTC)
+	installShadowJournalManager(sessionDir, "ctx-main", "review-session", now)
+	t.Cleanup(journal.ClearProcessManager)
+
+	filename := "20260710-000149-s7c1c-ra364-from-orchestrator-to-guardian.md"
+	readPath := filepath.Join(sessionDir, "read", filename)
+	if err := os.MkdirAll(filepath.Dir(readPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(read): %v", err)
+	}
+	// Simulate the torn/truncated file a racing projection sync can leave
+	// visible mid-rewrite: present on disk, but 0 bytes.
+	if err := os.WriteFile(readPath, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile(truncated readPath): %v", err)
+	}
+
+	recordDaemonSubmitPopRead(sessionDir, readPath, filename, "full correct body")
+
+	events, err := journal.Replay(sessionDir)
+	if err != nil {
+		t.Fatalf("journal.Replay() error = %v", err)
+	}
+	last := events[len(events)-1]
+	if last.Type != projection.MailboxProjectionReadEventType {
+		t.Fatalf("last event type = %q, want %s", last.Type, projection.MailboxProjectionReadEventType)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload): %v", err)
+	}
+	if payload["content"] != "full correct body" {
+		t.Fatalf("recorded read content = %q, want full correct body (torn read must not win)", payload["content"])
 	}
 }

--- a/internal/projection/mailbox_projection.go
+++ b/internal/projection/mailbox_projection.go
@@ -100,20 +100,29 @@ func ProjectMailboxProjection(sessionDir string) (MailboxProjection, bool, error
 				return MailboxProjection{}, false, fmt.Errorf("invalid inbox path for %q", payload.MessageID)
 			}
 		case MailboxProjectionReadEventType:
-			delete(projected.Inbox, inboxPathFromPayload(payload, state.TmuxSessionName))
+			inboxKey := inboxPathFromPayload(payload, state.TmuxSessionName)
 			if payload.Content == "" {
 				// A read event can carry empty content when its shadow
 				// recorder raced a concurrent projection sync writing the
-				// same path (see issue #633). Validate the path but keep
-				// whatever content is already projected rather than
-				// truncating it: the next non-empty read event (if any)
-				// still wins, and an already-corrupted on-disk file
-				// self-heals the moment the journal is replayed again.
+				// same path, or observed the file before a first-ever read
+				// established any content yet (see issue #633). Validate
+				// the path, but only treat this as a completed read -- and
+				// drop the inbox entry -- once a real, non-empty read has
+				// actually set content for this path. Otherwise leave the
+				// inbox entry (if any) untouched: unconditionally deleting
+				// it here would drop the message from both inbox and read
+				// projections at once, and the cleanup pass in
+				// syncDesiredMailboxFiles would then remove its on-disk
+				// file entirely instead of merely truncating it.
 				if !isAllowedProjectionPath(payload.Path) {
 					return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
 				}
+				if _, exists := projected.Read[pathKey(payload.Path)]; exists {
+					delete(projected.Inbox, inboxKey)
+				}
 				continue
 			}
+			delete(projected.Inbox, inboxKey)
 			if !setProjectedFile(projected.Read, payload.Path, payload.Content) {
 				return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
 			}

--- a/internal/projection/mailbox_projection.go
+++ b/internal/projection/mailbox_projection.go
@@ -101,6 +101,19 @@ func ProjectMailboxProjection(sessionDir string) (MailboxProjection, bool, error
 			}
 		case MailboxProjectionReadEventType:
 			delete(projected.Inbox, inboxPathFromPayload(payload, state.TmuxSessionName))
+			if payload.Content == "" {
+				// A read event can carry empty content when its shadow
+				// recorder raced a concurrent projection sync writing the
+				// same path (see issue #633). Validate the path but keep
+				// whatever content is already projected rather than
+				// truncating it: the next non-empty read event (if any)
+				// still wins, and an already-corrupted on-disk file
+				// self-heals the moment the journal is replayed again.
+				if !isAllowedProjectionPath(payload.Path) {
+					return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
+				}
+				continue
+			}
 			if !setProjectedFile(projected.Read, payload.Path, payload.Content) {
 				return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
 			}
@@ -253,7 +266,7 @@ func syncDesiredMailboxFiles(sessionDir string, desired map[string]string, manag
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("reading existing projection file %s: %w", relativePath, err)
 		}
-		if err := os.WriteFile(absPath, []byte(content), 0o600); err != nil {
+		if err := writeFileAtomic(absPath, []byte(content), 0o600); err != nil {
 			return fmt.Errorf("writing projection file %s: %w", relativePath, err)
 		}
 	}
@@ -398,4 +411,31 @@ func ensureMailboxDir(path string) error {
 		return err
 	}
 	return os.Chmod(path, 0o700)
+}
+
+// writeFileAtomic writes content to a temp file in path's directory, then
+// renames it into place. A concurrent reader of path (for example the
+// daemon's read-event shadow recorder) can then never observe a partially
+// written or truncated file: os.Rename atomically swaps the previous
+// complete content for the new complete content. See issue #633.
+func writeFileAtomic(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".mailbox-projection-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/internal/projection/mailbox_projection.go
+++ b/internal/projection/mailbox_projection.go
@@ -18,11 +18,12 @@ type ProjectedFile struct {
 }
 
 type MailboxProjection struct {
-	Post        map[string]ProjectedFile
-	Inbox       map[string]ProjectedFile
-	Read        map[string]ProjectedFile
-	DeadLetter  map[string]ProjectedFile
-	managedPost map[string]bool
+	Post           map[string]ProjectedFile
+	Inbox          map[string]ProjectedFile
+	Read           map[string]ProjectedFile
+	DeadLetter     map[string]ProjectedFile
+	managedPost    map[string]bool
+	tombstonedRead map[string]bool
 }
 
 type mailboxProjectionMarker struct {
@@ -56,11 +57,12 @@ func ProjectMailboxProjection(sessionDir string) (MailboxProjection, bool, error
 	}
 
 	projected := MailboxProjection{
-		Post:        make(map[string]ProjectedFile),
-		Inbox:       make(map[string]ProjectedFile),
-		Read:        make(map[string]ProjectedFile),
-		DeadLetter:  make(map[string]ProjectedFile),
-		managedPost: make(map[string]bool),
+		Post:           make(map[string]ProjectedFile),
+		Inbox:          make(map[string]ProjectedFile),
+		Read:           make(map[string]ProjectedFile),
+		DeadLetter:     make(map[string]ProjectedFile),
+		managedPost:    make(map[string]bool),
+		tombstonedRead: make(map[string]bool),
 	}
 	sawLease := false
 	sawResolution := false
@@ -106,23 +108,45 @@ func ProjectMailboxProjection(sessionDir string) (MailboxProjection, bool, error
 				// recorder raced a concurrent projection sync writing the
 				// same path, or observed the file before a first-ever read
 				// established any content yet (see issue #633). Validate
-				// the path, but only treat this as a completed read -- and
-				// drop the inbox entry -- once a real, non-empty read has
-				// actually set content for this path. Otherwise leave the
-				// inbox entry (if any) untouched: unconditionally deleting
-				// it here would drop the message from both inbox and read
-				// projections at once, and the cleanup pass in
-				// syncDesiredMailboxFiles would then remove its on-disk
-				// file entirely instead of merely truncating it.
+				// the path first.
 				if !isAllowedProjectionPath(payload.Path) {
 					return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
 				}
-				if _, exists := projected.Read[pathKey(payload.Path)]; exists {
+				readKey := pathKey(payload.Path)
+				if _, exists := projected.Read[readKey]; exists {
+					// A genuine, non-empty read already completed this
+					// transition earlier; this is a later racy re-render.
+					// Keep the good content (untouched) and finish
+					// removing the inbox entry as normal.
 					delete(projected.Inbox, inboxKey)
+					continue
 				}
+				// First-ever read for this message carries no usable
+				// content. The message has still left inbox -- for the
+				// non-owner direct-pop path in particular,
+				// ArchiveInboxMessage already moved it to read/ via a raw
+				// rename before any journal event exists for it -- so the
+				// inbox entry no longer reflects reality and must be
+				// removed. Leaving it in place would make
+				// syncDesiredMailboxFiles write the message back into
+				// inbox/, resurrecting an already-archived message as
+				// unread and re-consumable (found in review of the prior
+				// fix). But we must not fabricate an empty Read entry
+				// either (the original #633 truncation bug), and we must
+				// not let the cleanup pass delete whatever real file is
+				// already sitting at this read path just because this
+				// replay has no content for it. Tombstone the path
+				// instead: syncDesiredMailboxFiles preserves an existing
+				// on-disk file there (like the managedPost exception for
+				// post/) rather than deleting or resurrecting it. A
+				// subsequent genuine, non-empty read event still
+				// completes the transition normally.
+				delete(projected.Inbox, inboxKey)
+				projected.tombstonedRead[readKey] = true
 				continue
 			}
 			delete(projected.Inbox, inboxKey)
+			delete(projected.tombstonedRead, pathKey(payload.Path))
 			if !setProjectedFile(projected.Read, payload.Path, payload.Content) {
 				return MailboxProjection{}, false, fmt.Errorf("invalid read path %q", payload.Path)
 			}
@@ -178,7 +202,7 @@ func SyncMailboxProjection(sessionDir string) error {
 			return fmt.Errorf("ensuring %s dir: %w", root, err)
 		}
 	}
-	if err := syncDesiredMailboxFiles(sessionDir, desired, projected.managedPost); err != nil {
+	if err := syncDesiredMailboxFiles(sessionDir, desired, projected.managedPost, projected.tombstonedRead); err != nil {
 		return err
 	}
 	return writeMailboxProjectionMarker(sessionDir, mailboxProjectionMarker{
@@ -259,7 +283,7 @@ func isAllowedProjectionPath(relativePath string) bool {
 	return false
 }
 
-func syncDesiredMailboxFiles(sessionDir string, desired map[string]string, managedPost map[string]bool) error {
+func syncDesiredMailboxFiles(sessionDir string, desired map[string]string, managedPost map[string]bool, tombstonedRead map[string]bool) error {
 	for relativePath, content := range desired {
 		if !isAllowedProjectionPath(relativePath) {
 			return fmt.Errorf("invalid desired projection path %q", relativePath)
@@ -299,6 +323,16 @@ func syncDesiredMailboxFiles(sessionDir string, desired map[string]string, manag
 			}
 			if strings.HasPrefix(rel, "post"+string(filepath.Separator)) {
 				if !managedPost[rel] {
+					return nil
+				}
+			}
+			if strings.HasPrefix(rel, "read"+string(filepath.Separator)) {
+				// A tombstoned path had its only read event recorded with
+				// empty content (see issue #633 follow-up): preserve
+				// whatever is already on disk here instead of deleting it
+				// -- the file may be a legitimately archived message
+				// whose content this replay simply doesn't have.
+				if tombstonedRead[rel] {
 					return nil
 				}
 			}

--- a/internal/projection/mailbox_projection_test.go
+++ b/internal/projection/mailbox_projection_test.go
@@ -304,6 +304,87 @@ func TestProjectMailboxProjection_IgnoresEmptyContentReadEvent(t *testing.T) {
 	}
 }
 
+// TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage guards
+// against a regression found in review of the #633 fix: when the FIRST-ever
+// read event for a message carries empty content (no prior non-empty read
+// entry exists yet), the message must not vanish from both the inbox and
+// read projections at once. Doing so left it absent from `desired`
+// entirely, so the cleanup pass in syncDesiredMailboxFiles deleted its
+// on-disk file outright -- worse than the original #633 bug, which at
+// least left a visible (if 0-byte) file. A subsequent genuine, non-empty
+// read event must still complete the transition normally.
+func TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 15, 40, 0, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+
+	filename := "20260710-154000-s7c1c-rfirst-from-orchestrator-to-guardian.md"
+	inboxRel := filepath.Join("inbox", "guardian", filename)
+	readRel := filepath.Join("read", filename)
+	appendMailboxEventForTest(t, writer, MailboxProjectionDeliveredEventType, journal.VisibilityMailboxProjection, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      inboxRel,
+		Content:   "delivered body",
+	}, now.Add(time.Second))
+
+	// First-ever read event for this message: content is empty (e.g. a
+	// racy shadow-recorder observation), with no prior non-empty read.
+	appendMailboxEventForTest(t, writer, MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      readRel,
+		Content:   "",
+	}, now.Add(2*time.Second))
+
+	projected, ok, err := ProjectMailboxProjection(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectMailboxProjection() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectMailboxProjection() ok = false, want true")
+	}
+	if got := projected.Inbox[pathKey(inboxRel)]; got.Content != "delivered body" {
+		t.Fatalf("inbox projection after first empty read = %#v, want delivered body preserved (message must not disappear)", got)
+	}
+	if _, exists := projected.Read[pathKey(readRel)]; exists {
+		t.Fatalf("read projection created from empty first read event: %#v", projected.Read[pathKey(readRel)])
+	}
+
+	if err := SyncMailboxProjection(sessionDir); err != nil {
+		t.Fatalf("SyncMailboxProjection(after first empty read) error = %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(sessionDir, inboxRel)); err != nil || string(got) != "delivered body" {
+		t.Fatalf("inbox file after first empty read = %q, %v; message was dropped instead of staying visible", string(got), err)
+	}
+
+	// A genuine, non-empty read event now arrives and must complete the
+	// transition normally: inbox entry removed, read entry populated.
+	appendMailboxEventForTest(t, writer, MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      readRel,
+		Content:   "delivered body",
+	}, now.Add(3*time.Second))
+
+	if err := SyncMailboxProjection(sessionDir); err != nil {
+		t.Fatalf("SyncMailboxProjection(after real read) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessionDir, inboxRel)); !os.IsNotExist(err) {
+		t.Fatalf("inbox file still present after genuine read completed: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(sessionDir, readRel)); err != nil || string(got) != "delivered body" {
+		t.Fatalf("read file after genuine read = %q, %v; want delivered body", string(got), err)
+	}
+}
+
 // TestWriteFileAtomic_NeverLeavesTruncatedFileVisible guards against
 // regressing to a truncate-in-place write for projected mailbox files: a
 // concurrent reader must always see either the full old content or the

--- a/internal/projection/mailbox_projection_test.go
+++ b/internal/projection/mailbox_projection_test.go
@@ -305,14 +305,27 @@ func TestProjectMailboxProjection_IgnoresEmptyContentReadEvent(t *testing.T) {
 }
 
 // TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage guards
-// against a regression found in review of the #633 fix: when the FIRST-ever
-// read event for a message carries empty content (no prior non-empty read
-// entry exists yet), the message must not vanish from both the inbox and
-// read projections at once. Doing so left it absent from `desired`
-// entirely, so the cleanup pass in syncDesiredMailboxFiles deleted its
-// on-disk file outright -- worse than the original #633 bug, which at
-// least left a visible (if 0-byte) file. A subsequent genuine, non-empty
-// read event must still complete the transition normally.
+// against two regressions found across two rounds of review of the #633
+// fix:
+//  1. (round 2) When the FIRST-ever read event for a message carries empty
+//     content, unconditionally deleting the inbox entry dropped the message
+//     from both inbox and read projections at once, so the cleanup pass in
+//     syncDesiredMailboxFiles deleted its on-disk file outright -- worse
+//     than the original #633 bug, which at least left a visible (if
+//     0-byte) file.
+//  2. (round 3) Fixing #1 by simply leaving the inbox entry untouched
+//     instead introduced a NEW hazard: on the non-owner direct-pop path,
+//     ArchiveInboxMessage already moves the message to read/ via a raw
+//     rename before any journal event exists for it. Leaving the stale
+//     inbox entry in `desired` made syncDesiredMailboxFiles write the
+//     message back into inbox/, resurrecting an already-archived message
+//     as unread and re-consumable -- a duplicate-processing hazard.
+//
+// The correct behavior (tombstoning): the inbox entry is removed (no
+// resurrection), no bogus empty Read entry is fabricated, and whatever
+// real file already exists at the read path is left untouched by the
+// cleanup pass rather than deleted. A subsequent genuine, non-empty read
+// event must still complete the transition normally.
 func TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage(t *testing.T) {
 	sessionDir := t.TempDir()
 	now := time.Date(2026, time.July, 10, 15, 40, 0, 0, time.UTC)
@@ -332,6 +345,23 @@ func TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage(t *testi
 		Path:      inboxRel,
 		Content:   "delivered body",
 	}, now.Add(time.Second))
+	if err := SyncMailboxProjection(sessionDir); err != nil {
+		t.Fatalf("SyncMailboxProjection(after delivered) error = %v", err)
+	}
+
+	// Simulate the non-owner direct-pop path: the message has already been
+	// archived via a raw filesystem rename (ArchiveInboxMessage) before any
+	// journal read event exists for it. The physical inbox file is gone;
+	// the physical read file holds the real, correct content.
+	if err := os.Remove(filepath.Join(sessionDir, inboxRel)); err != nil {
+		t.Fatalf("simulate raw archive rename (remove inbox file): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sessionDir, "read"), 0o700); err != nil {
+		t.Fatalf("MkdirAll(read): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, readRel), []byte("delivered body"), 0o600); err != nil {
+		t.Fatalf("simulate raw archive rename (write read file): %v", err)
+	}
 
 	// First-ever read event for this message: content is empty (e.g. a
 	// racy shadow-recorder observation), with no prior non-empty read.
@@ -350,22 +380,25 @@ func TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage(t *testi
 	if !ok {
 		t.Fatal("ProjectMailboxProjection() ok = false, want true")
 	}
-	if got := projected.Inbox[pathKey(inboxRel)]; got.Content != "delivered body" {
-		t.Fatalf("inbox projection after first empty read = %#v, want delivered body preserved (message must not disappear)", got)
+	if _, exists := projected.Inbox[pathKey(inboxRel)]; exists {
+		t.Fatalf("inbox projection resurrected after first empty read: %#v", projected.Inbox[pathKey(inboxRel)])
 	}
 	if _, exists := projected.Read[pathKey(readRel)]; exists {
-		t.Fatalf("read projection created from empty first read event: %#v", projected.Read[pathKey(readRel)])
+		t.Fatalf("read projection fabricated from empty first read event: %#v", projected.Read[pathKey(readRel)])
 	}
 
 	if err := SyncMailboxProjection(sessionDir); err != nil {
 		t.Fatalf("SyncMailboxProjection(after first empty read) error = %v", err)
 	}
-	if got, err := os.ReadFile(filepath.Join(sessionDir, inboxRel)); err != nil || string(got) != "delivered body" {
-		t.Fatalf("inbox file after first empty read = %q, %v; message was dropped instead of staying visible", string(got), err)
+	if _, err := os.Stat(filepath.Join(sessionDir, inboxRel)); !os.IsNotExist(err) {
+		t.Fatalf("inbox file resurrected after first empty read: err=%v (message re-consumable, duplicate-processing hazard)", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(sessionDir, readRel)); err != nil || string(got) != "delivered body" {
+		t.Fatalf("read file after first empty read = %q, %v; want delivered body preserved (tombstoned, not deleted)", string(got), err)
 	}
 
 	// A genuine, non-empty read event now arrives and must complete the
-	// transition normally: inbox entry removed, read entry populated.
+	// transition normally: read entry populated from the journal as usual.
 	appendMailboxEventForTest(t, writer, MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
 		MessageID: filename,
 		From:      "orchestrator",
@@ -378,7 +411,7 @@ func TestProjectMailboxProjection_FirstEmptyReadEventDoesNotDropMessage(t *testi
 		t.Fatalf("SyncMailboxProjection(after real read) error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(sessionDir, inboxRel)); !os.IsNotExist(err) {
-		t.Fatalf("inbox file still present after genuine read completed: %v", err)
+		t.Fatalf("inbox file present after genuine read completed: %v", err)
 	}
 	if got, err := os.ReadFile(filepath.Join(sessionDir, readRel)); err != nil || string(got) != "delivered body" {
 		t.Fatalf("read file after genuine read = %q, %v; want delivered body", string(got), err)

--- a/internal/projection/mailbox_projection_test.go
+++ b/internal/projection/mailbox_projection_test.go
@@ -246,6 +246,117 @@ func TestSyncMailboxProjection_RemovesConsumedProjectedPostFiles(t *testing.T) {
 	}
 }
 
+// TestProjectMailboxProjection_IgnoresEmptyContentReadEvent reproduces the
+// #633 root cause: a burst of racy mailbox_projection_read events for the
+// same message_id, where a later event's payload carries empty content
+// (e.g. its shadow recorder observed a torn/truncated file mid rewrite).
+// Replaying such a journal must not let the empty read permanently zero
+// out the projected body.
+func TestProjectMailboxProjection_IgnoresEmptyContentReadEvent(t *testing.T) {
+	sessionDir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 15, 1, 50, 0, time.UTC)
+
+	writer, err := journal.OpenShadowWriter(sessionDir, "ctx-main", "review", 101, now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+
+	filename := "20260710-000149-s7c1c-ra364-from-orchestrator-to-guardian.md"
+	readRel := filepath.Join("read", filename)
+	appendMailboxEventForTest(t, writer, MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
+		MessageID: filename,
+		From:      "orchestrator",
+		To:        "guardian",
+		Path:      readRel,
+		Content:   "full correct body",
+	}, now.Add(16*time.Second))
+
+	for i := 0; i < 4; i++ {
+		appendMailboxEventForTest(t, writer, MailboxProjectionReadEventType, journal.VisibilityOperatorVisible, journal.MailboxEventPayload{
+			MessageID: filename,
+			From:      "orchestrator",
+			To:        "guardian",
+			Path:      readRel,
+			Content:   "",
+		}, now.Add(time.Duration(20+i)*time.Second))
+	}
+
+	projected, ok, err := ProjectMailboxProjection(sessionDir)
+	if err != nil {
+		t.Fatalf("ProjectMailboxProjection() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectMailboxProjection() ok = false, want true")
+	}
+	if got := projected.Read[pathKey(readRel)]; got.Content != "full correct body" {
+		t.Fatalf("read projection content = %q, want full correct body (empty read events must not clobber it)", got.Content)
+	}
+
+	if err := SyncMailboxProjection(sessionDir); err != nil {
+		t.Fatalf("SyncMailboxProjection() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(sessionDir, readRel))
+	if err != nil {
+		t.Fatalf("ReadFile(projected read file): %v", err)
+	}
+	if string(got) != "full correct body" {
+		t.Fatalf("projected read file content = %q, want full correct body", string(got))
+	}
+}
+
+// TestWriteFileAtomic_NeverLeavesTruncatedFileVisible guards against
+// regressing to a truncate-in-place write for projected mailbox files: a
+// concurrent reader must always see either the full old content or the
+// full new content on the target path, never an empty/partial write.
+func TestWriteFileAtomic_NeverLeavesTruncatedFileVisible(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "read", "20260710-000149-s7c1c-ra364-from-orchestrator-to-guardian.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := writeFileAtomic(path, []byte("first version"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic(first): %v", err)
+	}
+
+	stop := make(chan struct{})
+	sawTruncated := make(chan bool, 1)
+	go func() {
+		defer close(sawTruncated)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				content, err := os.ReadFile(path)
+				if err == nil && len(content) == 0 {
+					sawTruncated <- true
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if err := writeFileAtomic(path, []byte("rewritten version"), 0o600); err != nil {
+			t.Fatalf("writeFileAtomic(rewrite %d): %v", i, err)
+		}
+	}
+	close(stop)
+	if truncated, ok := <-sawTruncated; ok && truncated {
+		t.Fatal("concurrent reader observed a 0-byte file during atomic rewrite")
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != filepath.Base(path) {
+			t.Fatalf("leftover temp file after atomic write: %s", entry.Name())
+		}
+	}
+}
+
 func appendMailboxEventForTest(t *testing.T, writer *journal.Writer, eventType string, visibility journal.Visibility, payload journal.MailboxEventPayload, now time.Time) {
 	t.Helper()
 	if _, err := writer.AppendEvent(eventType, visibility, payload, now); err != nil {


### PR DESCRIPTION
## Summary

Fixes #633: a burst of near-simultaneous `mailbox_projection_read` events
for the same `message_id` could permanently zero out a projected mailbox
body file (`post`/`inbox`/`read`/`dead-letter`). The journal itself always
kept the correct content — only the derived `.md` file was affected.

## Background

`syncDesiredMailboxFiles` (`internal/projection/mailbox_projection.go`)
wrote projected files via a non-atomic `os.WriteFile` (truncate-then-write
in place). Two independent call sites — `recordDaemonSubmitPopRead`
(`internal/daemon/daemon.go`, the synchronous pop path) and
`recordShadowMailboxPathEvent` (`internal/daemon/journal_shadow.go`, driven
by the filesystem watcher) — each read that same live path directly from
disk to build a *new* `mailbox_projection_read` journal event, with no
atomicity or empty-content guard on the read side for that event type. A
reader could observe the file mid-truncate (0 bytes, `err == nil`), and
that empty content got journaled as a legitimate, permanent read event.
Since `ProjectMailboxProjection` replay keeps only the last read event's
content per path (map overwrite), one racy empty read poisoned the derived
file forever.

`SyncMailboxProjection` re-renders were already debounced/coalesced per
session directory (pre-existing `scheduleMailboxProjectionSync` in
`internal/daemon/runtime.go`), so the race was **not** sync-vs-sync — it
was the (already-serialized) writer vs. two unrelated, unguarded direct
reads.

## Changes

- `internal/projection/mailbox_projection.go`: write projected files via a
  new `writeFileAtomic` helper (temp file in the same directory +
  `os.Rename`) instead of `os.WriteFile`, so a concurrent reader can never
  observe a truncated intermediate state.
- `internal/projection/mailbox_projection.go`: when replaying a read event
  whose payload content is empty, keep whatever content is already
  projected for that path instead of overwriting it with empty (path
  validation is preserved). This is self-healing: replaying the original
  bug report's own corrupted journal trace (`seq` 6138→6147, empty from
  6143 onward) through this fixed code now reconstructs the correct
  content instead of 0 bytes — no daemon restart or manual recovery
  required.
- `internal/daemon/daemon.go`: `recordDaemonSubmitPopRead` now prefers the
  already-known-good `fallbackContent` (read from the inbox message before
  it was archived) over an unconditional re-read of the archived path,
  only falling back to disk (and only accepting a non-empty result) if
  `fallbackContent` is itself empty.

Deliberately unchanged: `recordShadowMailboxPathEvent` still records read
events even when the file is momentarily missing/empty — an existing test
(`TestRecordShadowMailboxPathEvent_AppendsOperatorVisibleRead`) depends on
that for liveness/observability purposes (idle tracker, msgtrace) even
without file content. The projection-layer guard above covers correctness
instead, so this behavior didn't need to change.

Out of scope (per task instruction): the `late_response` reap secondary
finding also noted in #633 is a separate, lower-severity leak and is not
addressed here.

## Verification

- `go build ./...` — clean
- `go test ./...` — all packages `ok`, no regressions
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `nix flake check` — all checks passed
- `nix build` — exit 0, `result/bin/tmux-a2a-postman` present

New tests, all passing:
- `TestProjectMailboxProjection_IgnoresEmptyContentReadEvent` — reproduces
  the exact message_id/journal-timing shape from #633 and asserts the
  derived file keeps its correct content.
- `TestWriteFileAtomic_NeverLeavesTruncatedFileVisible` — a concurrent
  reader never observes a 0-byte file across repeated atomic rewrites, and
  no temp file is left behind.
- `TestRecordDaemonSubmitPopRead_PrefersFallbackOverTruncatedReadPath` —
  a torn (0-byte) `readPath` at call time must not clobber the known-good
  `fallbackContent`.
