### PR TITLE
feat(config): move command approver to Mermaid class (#629)

### DIFF
--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -14,7 +14,6 @@ requester = "worker"
 label = "nix-build"
 category = "verification"
 reviewer = "orchestrator"
-command_approver_node = "orchestrator"
 mode = "blocking"
 approval_ttl_seconds = 900
 ```
@@ -24,15 +23,38 @@ match any value. CLI flags may override `reviewer`, `mode`, and expiry for a
 single command.
 
 `reviewer` is a plain audit label with no topology meaning.
-`command_approver_node` is different: it names a real, configured node (same
-family as `ui_node`), either globally under `[postman]` or per policy here,
-overriding the global default. It is what makes a mode restrictive at all — see
-the fail-open rule below.
+`command_approver_node` is different: it names one real, configured node (same
+family as `ui_node`) by marking that node in the `postman.md` Mermaid graph:
+
+````markdown
+## `edges`
+
+```mermaid
+graph LR
+    worker --- orchestrator
+    class orchestrator command_approver_node
+```
+````
+
+It is global for the whole configuration and is what makes a mode restrictive
+at all — see the fail-open rule below. Per-policy approver routing is not
+supported; every execute-bash policy shares the single class-designated
+approver.
+
+Migration note: legacy `[postman] command_approver_node` and
+`[[postman.command_approval]] command_approver_node` keys in `postman.toml` are
+ignored with a deprecation warning. Move the approver marker to `postman.md`
+before relying on `blocking`; until the Mermaid class resolves to a configured
+node, command approval intentionally fails open and records
+`auto_approved_no_reviewer`. `get-status` also reports ignored legacy TOML
+approver keys under `command_approval.deprecated_command_approvers`; a migration
+is complete only when both `command_approval.unresolved_command_approvers` and
+`command_approval.deprecated_command_approvers` are absent.
 
 ### 1.1. Fail-open rule (#626)
 
-Unless a VALID `command_approver_node` is configured — the field set AND
-resolving to a node that actually exists in this config — every command is
+Unless a VALID `command_approver_node` is configured — the Mermaid class is set
+AND resolves to a node that actually exists in this config — every command is
 treated as approved, in every mode, including `blocking`. This covers both an
 unconfigured `command_approver_node` and one that names a node that doesn't
 exist (a typo). Approval only becomes restrictive once a valid
@@ -44,6 +66,12 @@ two. A configured-but-unresolvable `command_approver_node` also produces a
 load-time warning and a visible `command_approval.unresolved_command_approvers`
 marker in `get-status`, so a typo that silently disables blocking mode is loud
 rather than a silent no-op.
+
+Ignored legacy TOML `command_approver_node` values produce
+`command_approval.deprecated_command_approvers` markers in `get-status`. Treat
+that status field as a migration failure: the TOML key is ignored, and approval
+remains fail-open unless the Mermaid `command_approver_node` resolves to a
+configured node.
 
 ## 2. Running Commands
 

--- a/docs/design/config-ssot.md
+++ b/docs/design/config-ssot.md
@@ -17,6 +17,11 @@ defaults.
 - The explicit human-facing startup PING target should normally be marked in
   Mermaid with the `ui_node` class, keeping topology-facing settings in one
   diagram.
+- The execute-bash command approver should be marked in Mermaid with the
+  `command_approver_node` class. This is a singleton topology-facing
+  designation like `ui_node`; `[postman] command_approver_node` and per-policy
+  `command_approver_node` keys in `postman.toml` are no longer user-facing
+  config surfaces.
 - `postman.md` frontmatter may set `skill_path` to generate an agent skill
   catalog from selected `SKILL.md` frontmatter without inlining skill bodies.
   Entries with omitted `inject` are appended to normal role context and remain
@@ -82,11 +87,37 @@ graph LR
     orchestrator --- worker
     orchestrator --- critic
     class messenger ui_node
+    class orchestrator command_approver_node
     classDef ui_node fill:#e0f2fe
+    classDef command_approver_node fill:#fef3c7
 ```
 ````
 
 This creates `messenger`, `orchestrator`, `worker`, and `critic` nodes even
 when no `[messenger]`, `[orchestrator]`, `[worker]`, or `[critic]` TOML sections
 exist. The `ui_node` class explicitly marks `messenger` as the startup
-auto-PING target.
+auto-PING target. The `command_approver_node` class marks `orchestrator` as the
+single execute-bash approver for all command approval policies.
+
+## 5. Command Approver Migration
+
+Legacy TOML-only command approver configs intentionally downgrade to fail-open
+until migrated. During load, `command_approver_node` in `postman.toml` emits a
+deprecation warning and is ignored. Because execute-bash only becomes
+restrictive when a valid Mermaid `command_approver_node` resolves to a
+configured node, blocking policies without the new class record
+`auto_approved_no_reviewer` and run.
+
+To migrate, move the approver designation into the `postman.md` Mermaid graph:
+
+```mermaid
+graph LR
+    worker --- orchestrator
+    class orchestrator command_approver_node
+```
+
+Restart the daemon after editing `postman.md`, then confirm `get-status` has no
+`command_approval.unresolved_command_approvers` marker and no
+`command_approval.deprecated_command_approvers` marker. The deprecated marker
+lists ignored legacy TOML approver keys; its presence means stale TOML remains
+in the effective config and the migration is not complete.

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -55,13 +55,12 @@ func (e commandExitError) ExitCode() int {
 }
 
 type resolvedCommandApprovalPolicy struct {
-	Requester                   string
-	Reviewer                    string
-	Mode                        string
-	Label                       string
-	Category                    string
-	TTL                         time.Duration
-	CommandApproverNodeOverride string // per-policy command_approver_node override, if any (#626)
+	Requester string
+	Reviewer  string
+	Mode      string
+	Label     string
+	Category  string
+	TTL       time.Duration
 }
 
 type commandApprovalEvaluation struct {
@@ -158,7 +157,7 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 		resolvedThreadID = commandApprovalThreadID(policy, commandHash)
 	}
 	expiresAt := ctx.now().Add(policy.TTL).UTC().Format(time.RFC3339Nano)
-	commandApproverNode, validReviewer := cfg.ResolveCommandApproverNode(policy.CommandApproverNodeOverride)
+	commandApproverNode, validReviewer := cfg.ResolveCommandApproverNode()
 
 	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, validReviewer, ctx.now())
 	if err != nil {
@@ -372,7 +371,6 @@ func resolveCommandApprovalPolicy(cfg *config.Config, requester, label, category
 		if candidate.ApprovalTTLSeconds > 0 {
 			policy.TTL = time.Duration(candidate.ApprovalTTLSeconds * float64(time.Second))
 		}
-		policy.CommandApproverNodeOverride = strings.TrimSpace(candidate.CommandApproverNode)
 		break
 	}
 	if strings.TrimSpace(reviewerFlag) != "" {

--- a/internal/cli/helptext/config.txt
+++ b/internal/cli/helptext/config.txt
@@ -8,7 +8,8 @@ Primary files:
 postman.toml is optional. Embedded defaults from postman.default.toml are used
 when no user TOML exists. A minimal postman.md can contain only Mermaid edges;
 nodes referenced by those edges are materialized automatically. Mark the
-human-facing startup PING target with the Mermaid ui_node class.
+human-facing startup PING target with the Mermaid ui_node class. Mark the
+execute-bash approver with the Mermaid command_approver_node class.
 Public defaults are owned by postman.default.toml; DefaultConfig only
 initializes structural containers.
 Global config is read once at daemon startup. Restart the daemon after editing
@@ -28,6 +29,7 @@ Quick reading guide:
 Core config:
   edges                            Bidirectional routes between nodes
   ui_node                          Optional target filter for startup auto-PING; prefer Mermaid class <node> ui_node
+  command_approver_node            Mermaid-only singleton: class <node> command_approver_node in postman.md
   auto_enable_new_sessions         Auto-enable sessions with configured node panes (default: true)
   message_footer                   Header guidance before the sender body separator
   draft_template                   Structured envelope for stored send-heredoc Markdown
@@ -54,6 +56,21 @@ Edge syntax:
     "node-a --- node-b",   # bidirectional: a<->b
     "node-b --- node-c",   # bidirectional: b<->c
   ]
+
+Mermaid node designation:
+  class messenger ui_node
+  class orchestrator command_approver_node
+
+Migration note:
+  [postman] command_approver_node and per-policy command_approver_node keys in
+  postman.toml are ignored with a deprecation warning. Move the approver to
+  postman.md. Until a valid Mermaid command_approver_node resolves to a
+  configured node, every execute-bash mode, including blocking, fails open and
+  records auto_approved_no_reviewer.
+  get-status reports stale ignored TOML approver keys under
+  command_approval.deprecated_command_approvers. Migration is complete only
+  when command_approval.unresolved_command_approvers and
+  command_approval.deprecated_command_approvers are both absent.
 
 Command approval policy:
   [[postman.command_approval]]

--- a/internal/cli/helptext/execute-bash.txt
+++ b/internal/cli/helptext/execute-bash.txt
@@ -34,10 +34,10 @@ Modes:
 
 Fail-open rule (command_approver_node):
   Every mode above, including blocking, only becomes restrictive once a VALID
-  command_approver_node is configured (postman.toml [postman] command_approver_node, or a
-  per-policy command_approver_node override under [[postman.command_approval]] —
-  naming a real, configured node, same family as ui_node). Unset, or set to a
-  node name that does not resolve, means every command runs, recorded
+  command_approver_node is configured by marking one real node in postman.md
+  Mermaid edges with class <node> command_approver_node, same family as ui_node.
+  The approver is global; per-policy approver routing is not supported. Unset,
+  or set to a node name that does not resolve, means every command runs, recorded
   distinctly as auto_approved_no_reviewer rather than a real approval. An
   unresolvable command_approver_node also produces a load-time warning and a visible
   marker in get-status, so a typo never silently disables blocking mode.

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -215,34 +215,36 @@ func buildWorkspaceTreeStatus(cfg *config.Config, sessionName string) *status.Wo
 }
 
 // buildCommandApprovalStatus surfaces any configured-but-unresolvable
-// command_approver_node (global or per-policy) so get-status makes the fail-open
-// condition visible (#626), mirroring config.ValidateConfig's warning rule
-// without depending on its message wording.
+// command_approver_node so get-status makes the fail-open condition visible
+// (#626/#629), mirroring config.ValidateConfig's warning rule without depending
+// on its message wording.
 func buildCommandApprovalStatus(cfg *config.Config) *status.CommandApprovalStatus {
 	if cfg == nil {
 		return nil
 	}
 	var unresolved []status.CommandApprovalUnresolvedApprover
-	if name, valid := cfg.ResolveCommandApproverNode(""); name != "" && !valid {
+	if name, valid := cfg.ResolveCommandApproverNode(); name != "" && !valid {
 		unresolved = append(unresolved, status.CommandApprovalUnresolvedApprover{
 			Field:   "command_approver_node",
 			Value:   name,
 			Message: fmt.Sprintf("command_approver_node %q does not match any configured node; command approval is failing open", name),
 		})
 	}
-	for i, policy := range cfg.CommandApproval {
-		if name, valid := cfg.ResolveCommandApproverNode(policy.CommandApproverNode); name != "" && !valid && strings.TrimSpace(policy.CommandApproverNode) != "" {
-			unresolved = append(unresolved, status.CommandApprovalUnresolvedApprover{
-				Field:   fmt.Sprintf("command_approval[%d].command_approver_node", i),
-				Value:   name,
-				Message: fmt.Sprintf("command_approver_node %q does not match any configured node; this policy is failing open", name),
-			})
-		}
+	deprecated := make([]status.CommandApprovalDeprecatedApprover, 0, len(cfg.DeprecatedCommandApproverNodes))
+	for _, legacy := range cfg.DeprecatedCommandApproverNodes {
+		deprecated = append(deprecated, status.CommandApprovalDeprecatedApprover{
+			Field:   legacy.Field,
+			Value:   legacy.Value,
+			Message: fmt.Sprintf("legacy TOML %s %q is ignored; move command_approver_node to postman.md Mermaid class or command approval will fail open", legacy.Field, legacy.Value),
+		})
 	}
-	if len(unresolved) == 0 {
+	if len(unresolved) == 0 && len(deprecated) == 0 {
 		return nil
 	}
-	return &status.CommandApprovalStatus{UnresolvedCommandApprovers: unresolved}
+	return &status.CommandApprovalStatus{
+		UnresolvedCommandApprovers: unresolved,
+		DeprecatedCommandApprovers: deprecated,
+	}
 }
 
 func workspaceTreeRef(node workspacetree.Node) *status.WorkspaceTreeRef {

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -1033,30 +1033,24 @@ func TestCollectAllSessionStatus_IncludesSessionsWithoutCanonicalPanesInSessionI
 	}
 }
 
-// TestBuildCommandApprovalStatus_UnresolvedCommandApprovers guards #626 decided
-// requirement 2's get-status marker: both an unresolvable global
-// command_approver_node and an unresolvable per-policy override must surface as
-// distinct UnresolvedCommandApprovers entries.
+// TestBuildCommandApprovalStatus_UnresolvedCommandApprovers guards #626/#629
+// decided requirement 2's get-status marker: an unresolvable global
+// command_approver_node must surface as an UnresolvedCommandApprovers entry.
 func TestBuildCommandApprovalStatus_UnresolvedCommandApprovers(t *testing.T) {
 	cfg := &config.Config{
 		CommandApproverNode: "typo-reviewer",
 		Nodes:               map[string]config.NodeConfig{"orchestrator": {}},
-		CommandApproval: []config.CommandApprovalPolicy{
-			{Requester: "worker", Label: "deploy", CommandApproverNode: "another-typo"},
-			{Requester: "worker", Label: "diagnostic"}, // no override: must not duplicate the global warning
-		},
 	}
 
 	got := buildCommandApprovalStatus(cfg)
 	if got == nil {
 		t.Fatal("buildCommandApprovalStatus() = nil, want a populated status")
 	}
-	if len(got.UnresolvedCommandApprovers) != 2 {
-		t.Fatalf("UnresolvedCommandApprovers = %#v, want exactly 2 entries", got.UnresolvedCommandApprovers)
+	if len(got.UnresolvedCommandApprovers) != 1 {
+		t.Fatalf("UnresolvedCommandApprovers = %#v, want exactly 1 entry", got.UnresolvedCommandApprovers)
 	}
 	wantFields := map[string]bool{
-		"command_approver_node":                     false,
-		"command_approval[0].command_approver_node": false,
+		"command_approver_node": false,
 	}
 	for _, entry := range got.UnresolvedCommandApprovers {
 		if _, ok := wantFields[entry.Field]; ok {
@@ -1081,6 +1075,29 @@ func TestBuildCommandApprovalStatus_NoUnresolvedCommandApprovers(t *testing.T) {
 	} {
 		if got := buildCommandApprovalStatus(cfg); got != nil {
 			t.Fatalf("buildCommandApprovalStatus(%#v) = %#v, want nil", cfg, got)
+		}
+	}
+}
+
+func TestBuildCommandApprovalStatus_DeprecatedCommandApprovers(t *testing.T) {
+	cfg := &config.Config{
+		Nodes: map[string]config.NodeConfig{"orchestrator": {}},
+		DeprecatedCommandApproverNodes: []config.DeprecatedCommandApproverNode{
+			{Field: "command_approver_node", Value: "orchestrator"},
+			{Field: "command_approval[0].command_approver_node", Value: "reviewer"},
+		},
+	}
+
+	got := buildCommandApprovalStatus(cfg)
+	if got == nil {
+		t.Fatal("buildCommandApprovalStatus() = nil, want deprecated command approver markers")
+	}
+	if len(got.DeprecatedCommandApprovers) != 2 {
+		t.Fatalf("DeprecatedCommandApprovers = %#v, want 2 entries", got.DeprecatedCommandApprovers)
+	}
+	for _, entry := range got.DeprecatedCommandApprovers {
+		if !strings.Contains(entry.Message, "ignored") || !strings.Contains(entry.Message, "fail open") {
+			t.Fatalf("deprecated command approver message = %q, want ignored/fail-open guidance", entry.Message)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,13 +66,14 @@ type Config struct {
 	MessageFooter                string            `toml:"message_footer"`                  // Footer appended to outgoing messages by `send` after message content
 
 	// Global settings
-	Edges                 []string                  `toml:"edges"`
-	ReplyCommand          string                    `toml:"reply_command"`
-	UINode                string                    `toml:"ui_node"`                  // Optional target filter for startup auto-PING
-	AutoEnableNewSessions *bool                     `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
-	WorkspaceTree         []WorkspaceTreeNodeConfig `toml:"workspace_tree"`           // Optional explicit hierarchy for tree aliases
-	CommandApproval       []CommandApprovalPolicy   `toml:"command_approval"`
-	CommandApproverNode   string                    `toml:"command_approver_node"` // Optional default reviewer node for command approval (#626); unset/unresolvable = fail-open
+	Edges                          []string                        `toml:"edges"`
+	ReplyCommand                   string                          `toml:"reply_command"`
+	UINode                         string                          `toml:"ui_node"`                  // Optional target filter for startup auto-PING
+	AutoEnableNewSessions          *bool                           `toml:"auto_enable_new_sessions"` // nil = use default (false); opt-in per #135
+	WorkspaceTree                  []WorkspaceTreeNodeConfig       `toml:"workspace_tree"`           // Optional explicit hierarchy for tree aliases
+	CommandApproval                []CommandApprovalPolicy         `toml:"command_approval"`
+	CommandApproverNode            string                          `toml:"-"` // Mermaid-sourced reviewer node for command approval; unset/unresolvable = fail-open
+	DeprecatedCommandApproverNodes []DeprecatedCommandApproverNode `toml:"-"` // Ignored legacy TOML approver keys surfaced in get-status
 
 	// Node-specific configurations (loaded from [nodename] sections)
 	Nodes map[string]NodeConfig
@@ -90,13 +91,17 @@ type Config struct {
 }
 
 type CommandApprovalPolicy struct {
-	Requester           string  `toml:"requester"`
-	Label               string  `toml:"label"`
-	Category            string  `toml:"category"`
-	Reviewer            string  `toml:"reviewer"`
-	Mode                string  `toml:"mode"`
-	ApprovalTTLSeconds  float64 `toml:"approval_ttl_seconds"`
-	CommandApproverNode string  `toml:"command_approver_node"` // Optional per-policy override of the global command_approver_node (#626)
+	Requester          string  `toml:"requester"`
+	Label              string  `toml:"label"`
+	Category           string  `toml:"category"`
+	Reviewer           string  `toml:"reviewer"`
+	Mode               string  `toml:"mode"`
+	ApprovalTTLSeconds float64 `toml:"approval_ttl_seconds"`
+}
+
+type DeprecatedCommandApproverNode struct {
+	Field string
+	Value string
 }
 
 // NodeConfig holds per-node configuration.
@@ -117,21 +122,17 @@ type WorkspaceTreeNodeConfig struct {
 	Order             int    `toml:"order"`
 }
 
-// ResolveCommandApproverNode resolves the effective command_approver_node for a command
-// approval policy, preferring a per-policy override over the global default
-// (#626). valid reports whether the resolved name matches a node known to
-// this config (the same set edges/workspace_tree validate against). An
-// empty or unresolvable name is never valid — callers MUST fail open in
-// that case rather than treat an invalid name as if it were configured, per
-// the decided unified fail-open rule.
-func (cfg *Config) ResolveCommandApproverNode(policyOverride string) (name string, valid bool) {
+// ResolveCommandApproverNode resolves the globally designated command_approver_node
+// (#626/#629). valid reports whether the resolved name matches a node known to
+// this config (the same set edges/workspace_tree validate against). An empty or
+// unresolvable name is never valid — callers MUST fail open in that case rather
+// than treat an invalid name as if it were configured, per the decided unified
+// fail-open rule.
+func (cfg *Config) ResolveCommandApproverNode() (name string, valid bool) {
 	if cfg == nil {
 		return "", false
 	}
-	name = strings.TrimSpace(policyOverride)
-	if name == "" {
-		name = strings.TrimSpace(cfg.CommandApproverNode)
-	}
+	name = strings.TrimSpace(cfg.CommandApproverNode)
 	if name == "" {
 		return "", false
 	}
@@ -215,6 +216,36 @@ func tomlHasField(md toml.MetaData, section, field string) bool {
 		}
 	}
 	return false
+}
+
+func deprecatedCommandApproverNodes(postmanPrim toml.Primitive, md toml.MetaData) []DeprecatedCommandApproverNode {
+	type deprecatedPolicy struct {
+		CommandApproverNode string `toml:"command_approver_node"`
+	}
+	var decoded struct {
+		CommandApproverNode string             `toml:"command_approver_node"`
+		CommandApproval     []deprecatedPolicy `toml:"command_approval"`
+	}
+	if err := md.PrimitiveDecode(postmanPrim, &decoded); err != nil {
+		return nil
+	}
+	var deprecated []DeprecatedCommandApproverNode
+	if strings.TrimSpace(decoded.CommandApproverNode) != "" {
+		deprecated = append(deprecated, DeprecatedCommandApproverNode{
+			Field: "command_approver_node",
+			Value: strings.TrimSpace(decoded.CommandApproverNode),
+		})
+	}
+	for i, policy := range decoded.CommandApproval {
+		if strings.TrimSpace(policy.CommandApproverNode) == "" {
+			continue
+		}
+		deprecated = append(deprecated, DeprecatedCommandApproverNode{
+			Field: fmt.Sprintf("command_approval[%d].command_approver_node", i),
+			Value: strings.TrimSpace(policy.CommandApproverNode),
+		})
+	}
+	return deprecated
 }
 
 func (cfg *Config) recordNodeNames(names ...string) {
@@ -342,6 +373,7 @@ func warnDeprecatedKeys(rawBytes []byte, path string) {
 	deprecated := []string{
 		"startup_delay_seconds",
 		"auto_enable_new_agents",
+		"command_approver_node",
 	}
 	raw := string(rawBytes)
 	for _, key := range deprecated {
@@ -730,6 +762,7 @@ func LoadConfig(path string) (*Config, error) {
 				return nil, fmt.Errorf("decoding [postman] section: %w", err)
 			}
 			cfg.uiNodeSet = tomlHasField(md, "postman", "ui_node")
+			cfg.DeprecatedCommandApproverNodes = deprecatedCommandApproverNodes(postmanPrim, md)
 		}
 
 		// Decode [nodename] sections (everything except reserved sections)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -325,6 +325,52 @@ approval_ttl_seconds = 900
 	}
 }
 
+func TestLoadConfig_TOMLCommandApproverNodeIgnored(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	configPath := filepath.Join(tmpDir, "postman.toml")
+
+	content := `
+[postman]
+edges = ["worker --- orchestrator"]
+command_approver_node = "orchestrator"
+
+[[postman.command_approval]]
+requester = "worker"
+label = "deploy"
+command_approver_node = "orchestrator"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.CommandApproverNode != "" {
+		t.Fatalf("CommandApproverNode = %q, want TOML command_approver_node ignored", cfg.CommandApproverNode)
+	}
+	if len(cfg.DeprecatedCommandApproverNodes) != 2 {
+		t.Fatalf("DeprecatedCommandApproverNodes = %#v, want global and per-policy entries", cfg.DeprecatedCommandApproverNodes)
+	}
+	want := map[string]string{
+		"command_approver_node":                     "orchestrator",
+		"command_approval[0].command_approver_node": "orchestrator",
+	}
+	for _, got := range cfg.DeprecatedCommandApproverNodes {
+		if want[got.Field] != got.Value {
+			t.Fatalf("deprecated command approver entry = %#v, want one of %#v", got, want)
+		}
+		delete(want, got.Field)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing deprecated command approver entries: %#v", want)
+	}
+}
+
 func TestLoadConfig_XDGMarkdownEdgesOnlyMaterializesNodes(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
@@ -1973,6 +2019,11 @@ func TestWarnDeprecatedKeys(t *testing.T) {
 			name:    "auto_enable_new_agents triggers warning",
 			raw:     "auto_enable_new_agents = true\n",
 			wantKey: "auto_enable_new_agents",
+		},
+		{
+			name:    "command_approver_node triggers warning",
+			raw:     "command_approver_node = \"orchestrator\"\n",
+			wantKey: "command_approver_node",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/markdown.go
+++ b/internal/config/markdown.go
@@ -125,16 +125,27 @@ func parseMermaidEdges(mermaidBlock string) []string {
 	return edges
 }
 
-const mermaidUINodeClass = "ui_node"
+const (
+	mermaidUINodeClass              = "ui_node"
+	mermaidCommandApproverNodeClass = "command_approver_node"
+)
 
 func parseMermaidUINode(mermaidBlock string) (string, bool, error) {
+	return parseMermaidDesignatedNode(mermaidBlock, mermaidUINodeClass)
+}
+
+func parseMermaidCommandApproverNode(mermaidBlock string) (string, bool, error) {
+	return parseMermaidDesignatedNode(mermaidBlock, mermaidCommandApproverNodeClass)
+}
+
+func parseMermaidDesignatedNode(mermaidBlock, className string) (string, bool, error) {
 	var found string
 	for _, statement := range mermaidStatements(mermaidBlock) {
 		statement = strings.TrimSpace(statement)
 		if statement == "" {
 			continue
 		}
-		for _, node := range parseMermaidUINodeStatement(statement) {
+		for _, node := range parseMermaidDesignatedNodeStatement(statement, className) {
 			if node == "" {
 				continue
 			}
@@ -143,7 +154,7 @@ func parseMermaidUINode(mermaidBlock string) (string, bool, error) {
 				continue
 			}
 			if found != node {
-				return "", false, fmt.Errorf("multiple Mermaid ui_node declarations: %q and %q", found, node)
+				return "", false, fmt.Errorf("multiple Mermaid %s declarations: %q and %q", className, found, node)
 			}
 		}
 	}
@@ -153,26 +164,33 @@ func parseMermaidUINode(mermaidBlock string) (string, bool, error) {
 	return found, true, nil
 }
 
-func parseMermaidUINodeStatement(statement string) []string {
-	if nodes := parseMermaidClassUINodeStatement(statement); len(nodes) > 0 {
+func parseMermaidDesignatedNodeStatement(statement, className string) []string {
+	if nodes := parseMermaidClassDesignatedNodeStatement(statement, className); len(nodes) > 0 {
 		return nodes
 	}
 	if shouldSkipMermaidStatement(statement) {
 		return nil
 	}
-	return parseMermaidInlineUINodeStatement(statement)
+	return parseMermaidInlineDesignatedNodeStatement(statement, className)
 }
 
-func parseMermaidClassUINodeStatement(statement string) []string {
+func parseMermaidClassDesignatedNodeStatement(statement, className string) []string {
 	fields := strings.Fields(strings.TrimSpace(strings.TrimSuffix(statement, ";")))
 	if len(fields) < 3 || strings.ToLower(fields[0]) != "class" {
 		return nil
 	}
-	if !mermaidClassTokensContain(fields[2:], mermaidUINodeClass) {
+	classStart := -1
+	for i := 2; i < len(fields); i++ {
+		if mermaidClassTokensContain([]string{fields[i]}, className) {
+			classStart = i
+			break
+		}
+	}
+	if classStart == -1 {
 		return nil
 	}
 	nodes := make([]string, 0, 1)
-	for _, rawNode := range strings.Split(fields[1], ",") {
+	for _, rawNode := range strings.Split(strings.Join(fields[1:classStart], " "), ",") {
 		node := normalizeMermaidNodeID(rawNode)
 		if node != "" {
 			nodes = append(nodes, node)
@@ -181,13 +199,19 @@ func parseMermaidClassUINodeStatement(statement string) []string {
 	return nodes
 }
 
-func parseMermaidInlineUINodeStatement(statement string) []string {
-	if !strings.Contains(statement, "---") {
+func parseMermaidInlineDesignatedNodeStatement(statement, className string) []string {
+	parts := []string{statement}
+	switch {
+	case strings.Contains(statement, "---"):
+		parts = strings.Split(statement, "---")
+	case containsUnsupportedMermaidEdgeOperator(statement):
+		return nil
+	case !isMermaidStandaloneNodeStatement(statement):
 		return nil
 	}
 	nodes := make([]string, 0, 1)
-	for _, rawNode := range strings.Split(statement, "---") {
-		if !mermaidNodeHasClass(rawNode, mermaidUINodeClass) {
+	for _, rawNode := range parts {
+		if !mermaidNodeHasClass(rawNode, className) {
 			continue
 		}
 		node := normalizeMermaidNodeID(rawNode)
@@ -196,6 +220,60 @@ func parseMermaidInlineUINodeStatement(statement string) []string {
 		}
 	}
 	return nodes
+}
+
+func isMermaidStandaloneNodeStatement(statement string) bool {
+	statement = strings.TrimSpace(strings.TrimSuffix(statement, ";"))
+	if statement == "" {
+		return false
+	}
+	squareDepth := 0
+	parenDepth := 0
+	braceDepth := 0
+	for i := 0; i < len(statement); i++ {
+		switch statement[i] {
+		case '[':
+			squareDepth++
+		case ']':
+			if squareDepth > 0 {
+				squareDepth--
+			}
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '{':
+			braceDepth++
+		case '}':
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		case ' ', '\t':
+			if squareDepth == 0 && parenDepth == 0 && braceDepth == 0 {
+				return false
+			}
+		}
+	}
+	return squareDepth == 0 && parenDepth == 0 && braceDepth == 0
+}
+
+func containsUnsupportedMermaidEdgeOperator(statement string) bool {
+	operators := []string{
+		"-->",
+		"<--",
+		"==>",
+		"<==",
+		"-.->",
+		"<-.-",
+	}
+	for _, operator := range operators {
+		if strings.Contains(statement, operator) {
+			return true
+		}
+	}
+	return false
 }
 
 func mermaidClassTokensContain(tokens []string, want string) bool {
@@ -211,15 +289,63 @@ func mermaidClassTokensContain(tokens []string, want string) bool {
 }
 
 func mermaidNodeHasClass(rawNode string, want string) bool {
-	idx := strings.Index(rawNode, ":::")
-	if idx < 0 {
+	node := strings.TrimSpace(strings.TrimSuffix(rawNode, ";"))
+	classStart := mermaidInlineClassStart(node)
+	if classStart < 0 {
 		return false
 	}
-	classes := strings.TrimSpace(rawNode[idx+3:])
-	if cut := strings.IndexAny(classes, " \t;"); cut >= 0 {
+	classes := strings.TrimSpace(node[classStart+3:])
+	if cut := mermaidInlineClassSuffixEnd(classes); cut >= 0 {
 		classes = classes[:cut]
 	}
-	return mermaidClassTokensContain([]string{classes}, want)
+	return mermaidClassTokensContain(strings.Split(classes, ":::"), want)
+}
+
+func mermaidInlineClassStart(node string) int {
+	squareDepth := 0
+	parenDepth := 0
+	braceDepth := 0
+	for i := 0; i < len(node); i++ {
+		if squareDepth == 0 && parenDepth == 0 && braceDepth == 0 &&
+			i+3 <= len(node) && node[i:i+3] == ":::" {
+			return i
+		}
+		switch node[i] {
+		case '[':
+			squareDepth++
+		case ']':
+			if squareDepth > 0 {
+				squareDepth--
+			}
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '{':
+			braceDepth++
+		case '}':
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		}
+	}
+	return -1
+}
+
+func mermaidInlineClassSuffixEnd(classes string) int {
+	for i := 0; i < len(classes); i++ {
+		switch classes[i] {
+		case ' ', '\t', ';', '[', '(', '{':
+			return i
+		case '@':
+			if i+1 < len(classes) && classes[i+1] == '{' {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 func mermaidStatements(block string) []string {
@@ -447,7 +573,8 @@ func stripFrontmatter(content string) string {
 // skill_path → generated skill catalog appended to Config.CommonTemplate, or
 // to daemon PING role content when an entry uses inject: ping or inject: compaction_ping.
 // Mermaid edges may mark the UI node with the ui_node class when frontmatter
-// does not override it.
+// does not override it. Mermaid edges may also mark the command approval
+// reviewer with the command_approver_node class.
 // Reserved h2 sections: "## `edges`" → Mermaid edges;
 // "## `common_template`" → Config.CommonTemplate.
 // Node h2 sections: "## `name`" → node template with ### `role` h3 field.
@@ -490,6 +617,13 @@ func loadMarkdownConfig(path string) (*Config, error) {
 				cfg.UINode = uiNode
 				cfg.uiNodeSet = true
 			}
+		}
+		commandApproverNode, ok, err := parseMermaidCommandApproverNode(mermaidBlock)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		if ok {
+			cfg.CommandApproverNode = commandApproverNode
 		}
 	}
 

--- a/internal/config/markdown_test.go
+++ b/internal/config/markdown_test.go
@@ -318,6 +318,62 @@ graph LR
 			wantSet: true,
 		},
 		{
+			name: "inline class after label",
+			input: `
+graph LR
+    messenger["Human"]:::ui_node --- orchestrator
+`,
+			want:    "messenger",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after shape",
+			input: `
+graph LR
+    messenger --- orchestrator
+    messenger{Human?}:::ui_node
+`,
+			want:    "messenger",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after label with spaces",
+			input: `
+graph LR
+    messenger --- orchestrator
+    messenger["Human reviewer"]:::ui_node
+`,
+			want:    "messenger",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after shape with spaces",
+			input: `
+graph LR
+    messenger --- orchestrator
+    messenger{Human reviewer?}:::ui_node
+`,
+			want:    "messenger",
+			wantSet: true,
+		},
+		{
+			name: "label text containing class marker ignored",
+			input: `
+graph LR
+    messenger["note :::ui_node pending"] --- orchestrator
+`,
+			wantSet: false,
+		},
+		{
+			name: "standalone label text containing class marker ignored",
+			input: `
+graph LR
+    messenger --- orchestrator
+    messenger["note :::ui_node pending"]
+`,
+			wantSet: false,
+		},
+		{
 			name: "class statement",
 			input: `
 graph LR
@@ -371,6 +427,249 @@ graph LR
 			}
 			if got != tt.want || gotSet != tt.wantSet {
 				t.Fatalf("parseMermaidUINode() = %q, %v; want %q, %v", got, gotSet, tt.want, tt.wantSet)
+			}
+		})
+	}
+}
+
+func TestParseMermaidCommandApproverNode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantSet bool
+		wantErr bool
+	}{
+		{
+			name: "inline class",
+			input: `
+graph LR
+    worker --- orchestrator:::command_approver_node
+    classDef command_approver_node fill:#fff3bf
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class with hyphenated node",
+			input: `
+graph LR
+    worker --- worker-alt
+    worker-alt:::command_approver_node
+`,
+			want:    "worker-alt",
+			wantSet: true,
+		},
+		{
+			name: "label text containing class marker ignored",
+			input: `
+graph LR
+    worker --- orchestrator["note :::command_approver_node pending"]
+`,
+			wantSet: false,
+		},
+		{
+			name: "inline class after label",
+			input: `
+graph LR
+    worker --- orchestrator["Reviewer"]:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "inline class after classic shape",
+			input: `
+graph LR
+    worker --- orchestrator{Review?}:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after label",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator["Reviewer"]:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after label with spaces",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator["Senior Reviewer"]:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after classic shape",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator{Review?}:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class after classic shape with spaces",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator{Senior reviewer?}:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone label text containing class marker ignored",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator["note :::command_approver_node pending"]
+`,
+			wantSet: false,
+		},
+		{
+			name: "inline class before shape decorator",
+			input: `
+graph LR
+    worker --- orchestrator:::command_approver_node@{shape: rect}
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "standalone inline class before shape decorator",
+			input: `
+graph LR
+    worker --- orchestrator
+    orchestrator:::command_approver_node@{shape:rect}
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "chained inline classes",
+			input: `
+graph LR
+    worker --- orchestrator:::reviewer:::command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "inline class before classic shape",
+			input: `
+graph LR
+    worker --- orchestrator:::command_approver_node{Review?}
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "unsupported arrow with inline class ignored",
+			input: `
+graph LR
+    worker --> orchestrator:::command_approver_node
+`,
+			wantSet: false,
+		},
+		{
+			name: "unsupported thick arrow with inline class ignored",
+			input: `
+graph LR
+    worker ==> orchestrator:::command_approver_node
+`,
+			wantSet: false,
+		},
+		{
+			name: "unsupported dotted arrow with inline class ignored",
+			input: `
+graph LR
+    worker -.-> orchestrator:::command_approver_node
+`,
+			wantSet: false,
+		},
+		{
+			name: "class statement",
+			input: `
+graph LR
+    worker --- orchestrator
+    class orchestrator command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "class statement with spaced comma node list rejects distinct nodes",
+			input: `
+graph LR
+    worker --- orchestrator
+    worker --- reviewer
+    class orchestrator, reviewer command_approver_node
+`,
+			wantErr: true,
+		},
+		{
+			name: "class statement with spaced comma same node allowed",
+			input: `
+graph LR
+    worker --- orchestrator
+    class orchestrator, orchestrator command_approver_node
+`,
+			want:    "orchestrator",
+			wantSet: true,
+		},
+		{
+			name: "non command approver class ignored",
+			input: `
+graph LR
+    worker --- orchestrator
+    class orchestrator ui_node
+`,
+			wantSet: false,
+		},
+		{
+			name: "conflicting command approver nodes rejected",
+			input: `
+graph LR
+    worker --- orchestrator:::command_approver_node
+    class reviewer command_approver_node
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotSet, err := parseMermaidCommandApproverNode(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseMermaidCommandApproverNode() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMermaidCommandApproverNode() error = %v", err)
+			}
+			if got != tt.want || gotSet != tt.wantSet {
+				t.Fatalf("parseMermaidCommandApproverNode() = %q, %v; want %q, %v", got, gotSet, tt.want, tt.wantSet)
 			}
 		})
 	}
@@ -661,6 +960,32 @@ graph LR
 	}
 	if len(cfg.Edges) != 2 {
 		t.Fatalf("Edges: got %v, want 2 edges", cfg.Edges)
+	}
+}
+
+func TestLoadMarkdownConfig_MermaidCommandApproverNode(t *testing.T) {
+	content := `## ` + "`edges`" + `
+
+` + "```mermaid" + `
+graph LR
+    worker --- orchestrator
+    class orchestrator command_approver_node
+    classDef command_approver_node fill:#fff3bf
+` + "```" + `
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "postman.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadMarkdownConfig(path)
+	if err != nil {
+		t.Fatalf("loadMarkdownConfig error: %v", err)
+	}
+	if cfg.CommandApproverNode != "orchestrator" {
+		t.Fatalf("CommandApproverNode: got %q, want %q", cfg.CommandApproverNode, "orchestrator")
 	}
 }
 

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -130,20 +130,20 @@ ui_node = "messenger"            # Optional target filter for startup auto-PING
 auto_enable_new_sessions = false   # Auto-enable sessions with configured node panes (default: false; opt-in per #135)
 # startup_guard_enabled = false    # TUI startup guard toggle; ALWAYS starts false at code level
 #                                  # regardless of this value (Issue #249). Press 'S' in TUI to arm.
-# command_approver_node = "orchestrator"   # Optional default reviewer for execute-bash command approval (Issue #626).
-#                                  # Unset, or set to a node that doesn't resolve, means every command approval
-#                                  # mode fails open (runs, audited as auto_approved_no_reviewer) — including
-#                                  # blocking. Only a VALID command_approver_node makes any mode restrictive. Override
-#                                  # per policy with command_approver_node under [[postman.command_approval]] below.
+# Configure the execute-bash command approver in postman.md by marking exactly
+# one node in the Mermaid edges graph with:
+#   class orchestrator command_approver_node
+# Unset, or set to a node that doesn't resolve, means every command approval
+# mode fails open (runs, audited as auto_approved_no_reviewer) — including
+# blocking. The approver is global; per-policy approver routing is unsupported.
 
-# Command approval policies for execute-bash (Issue #484/#625/#626). Optional; no policies means every
-# execute-bash invocation uses the advisory default. command_approver_node here overrides the global default above.
+# Command approval policies for execute-bash (Issue #484/#625/#626/#629). Optional; no policies means every
+# execute-bash invocation uses the advisory default.
 # [[postman.command_approval]]
 # requester = "worker"
 # label = "nix-build"
 # category = "verification"
 # reviewer = "orchestrator"
-# command_approver_node = "orchestrator"
 # mode = "blocking"
 # approval_ttl_seconds = 900
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -167,20 +167,6 @@ func ValidateConfig(cfg *Config) []ValidationError {
 			})
 		}
 	}
-	for i, policy := range cfg.CommandApproval {
-		name := strings.TrimSpace(policy.CommandApproverNode)
-		if name == "" {
-			continue
-		}
-		if _, exists := cfg.Nodes[name]; !exists {
-			errors = append(errors, ValidationError{
-				Field:    fmt.Sprintf("command_approval[%d].command_approver_node", i),
-				Message:  fmt.Sprintf("command_approver_node %q does not match any configured node; this policy will fail open until this is fixed", name),
-				Severity: "warning",
-			})
-		}
-	}
-
 	return errors
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -287,7 +287,7 @@ func TestValidateConfig_WorkspaceTree(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_CommandApproverNodeUnresolvable guards #626's decided
+// TestValidateConfig_CommandApproverNodeUnresolvable guards #626/#629's decided
 // requirement 2 (foot-gun mitigation): a configured-but-unresolvable
 // command_approver_node must produce a load-time WARNING, never an error — the
 // unified fail-open rule means command approval still runs, but the
@@ -300,15 +300,11 @@ func TestValidateConfig_CommandApproverNodeUnresolvable(t *testing.T) {
 			"orchestrator": {},
 		},
 		CommandApproverNode: "typo-reviewer",
-		CommandApproval: []CommandApprovalPolicy{
-			{Requester: "worker", Label: "deploy", CommandApproverNode: "another-typo"},
-		},
 	}
 
 	errors := ValidateConfig(cfg)
 	wantFields := map[string]bool{
-		"command_approver_node":                     false,
-		"command_approval[0].command_approver_node": false,
+		"command_approver_node": false,
 	}
 	for _, err := range errors {
 		if _, ok := wantFields[err.Field]; ok {
@@ -352,16 +348,13 @@ func TestResolveCommandApproverNode(t *testing.T) {
 		},
 	}
 
-	if name, valid := cfg.ResolveCommandApproverNode(""); name != "orchestrator" || !valid {
-		t.Fatalf("ResolveCommandApproverNode(\"\") = (%q, %v), want (orchestrator, true)", name, valid)
+	if name, valid := cfg.ResolveCommandApproverNode(); name != "orchestrator" || !valid {
+		t.Fatalf("ResolveCommandApproverNode() = (%q, %v), want (orchestrator, true)", name, valid)
 	}
-	if name, valid := cfg.ResolveCommandApproverNode("worker"); name != "worker" || valid {
-		t.Fatalf("ResolveCommandApproverNode(\"worker\") = (%q, %v), want (worker, false) — override names an unconfigured node", name, valid)
-	}
-	if name, valid := (&Config{}).ResolveCommandApproverNode(""); name != "" || valid {
+	if name, valid := (&Config{}).ResolveCommandApproverNode(); name != "" || valid {
 		t.Fatalf("ResolveCommandApproverNode on an unconfigured Config = (%q, %v), want (\"\", false)", name, valid)
 	}
-	if name, valid := (*Config)(nil).ResolveCommandApproverNode("orchestrator"); name != "" || valid {
+	if name, valid := (*Config)(nil).ResolveCommandApproverNode(); name != "" || valid {
 		t.Fatalf("ResolveCommandApproverNode on a nil Config = (%q, %v), want (\"\", false)", name, valid)
 	}
 }

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -173,8 +173,18 @@ type CommandApprovalUnresolvedApprover struct {
 	Message string `json:"message"`
 }
 
+// CommandApprovalDeprecatedApprover surfaces ignored legacy TOML
+// command_approver_node keys so an upgrade cannot silently downgrade blocking
+// command approval to fail-open without a runtime-visible marker.
+type CommandApprovalDeprecatedApprover struct {
+	Field   string `json:"field"`
+	Value   string `json:"value"`
+	Message string `json:"message"`
+}
+
 type CommandApprovalStatus struct {
 	UnresolvedCommandApprovers []CommandApprovalUnresolvedApprover `json:"unresolved_command_approvers,omitempty"`
+	DeprecatedCommandApprovers []CommandApprovalDeprecatedApprover `json:"deprecated_command_approvers,omitempty"`
 }
 
 type SessionStatus struct {

--- a/skills/postman-config-auditor/references/postman-md.md
+++ b/skills/postman-config-auditor/references/postman-md.md
@@ -43,6 +43,14 @@ Rules:
 - Prefer marking the UI node in the Mermaid graph with `class <node> ui_node`.
   Inline `:::ui_node` also works. Frontmatter `ui_node` is still supported as an
   explicit override.
+- Mark the execute-bash command approver in the Mermaid graph with
+  `class <node> command_approver_node`. Inline
+  `<node>:::command_approver_node` also works. Exactly one distinct
+  `command_approver_node` may be marked in the document.
+- Migration checks must confirm `get-status` has neither
+  `command_approval.unresolved_command_approvers` nor
+  `command_approval.deprecated_command_approvers`. The deprecated marker means
+  ignored legacy TOML approver keys are still present.
 - Empty frontmatter `ui_node:` is meaningful and explicitly clears `ui_node`.
 - `skill_path` may be a scalar path or a YAML list of path entries.
 - `skill_path` list items may be scalar paths or mappings with `path`,
@@ -183,7 +191,9 @@ graph LR
     orchestrator --- worker
     orchestrator --- critic
     class messenger ui_node
+    class orchestrator command_approver_node
     classDef ui_node fill:#e0f2fe
+    classDef command_approver_node fill:#fef3c7
 ```
 ````
 
@@ -192,6 +202,10 @@ Edge rules:
 - Only `---` is parsed as an edge operator.
 - The UI node may be marked with a `class messenger ui_node` statement, or with
   inline class syntax such as `messenger:::ui_node`.
+- The command approver node may be marked with a
+  `class orchestrator command_approver_node` statement, or with inline class
+  syntax such as `orchestrator:::command_approver_node`. It is global for all
+  execute-bash policies.
 - `graph`, `flowchart`, `subgraph`, `end`, `direction`, `classDef`, `class`,
   `style`, `click`, `linkStyle`, `accTitle`, and `accDescr` statements are
   skipped.
@@ -292,6 +306,9 @@ Important rules:
 - A Mermaid `ui_node` class in the `edges` graph sets `ui_node` when
   frontmatter does not set it. Frontmatter `ui_node` wins within the same
   Markdown file.
+- A Mermaid `command_approver_node` class in the `edges` graph sets the global
+  execute-bash command approver. There is no TOML or per-policy override for
+  this field.
 - XDG `postman.md` `message_footer` replaces the lower-layer footer.
 - `skill_path` is applied within the Markdown layer that declares it. Entries
   with omitted `inject` append generated catalogs to that layer's


### PR DESCRIPTION
## Summary
- Resolve `command_approver_node` from the `postman.md` Mermaid class instead of TOML.
- Surface ignored legacy TOML approver keys through status markers.
- Update command approval docs, help text, parser tests, config tests, and postman config auditor guidance.

## Verification
- `git diff --check`
- `nix flake check`
- `nix build`

Closes #629