### PR TITLE
fix(store): plan pop receipt paths separately (#468)

### DIFF
--- a/internal/cli/pop.go
+++ b/internal/cli/pop.go
@@ -18,6 +18,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/runtimecontext"
+	"github.com/i9wa4/tmux-a2a-postman/internal/store"
 	"gopkg.in/yaml.v3"
 )
 
@@ -198,6 +199,20 @@ func writeEmptyPopOutput(stdout io.Writer, diagnostics *popSessionDiagnostics, s
 }
 
 func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics, submitPath projection.SubmitPath, receiverOptions popReceiverContextOptions) error {
+	return writePopMessageOutputWithOps(stdout, content, filename, markdownPath, unreadBefore, remaining, runtimeContextMode, diagnostics, submitPath, receiverOptions, osPopReceiptFileOps)
+}
+
+type popReceiptFileOps struct {
+	mkdirAll  func(string, os.FileMode) error
+	writeFile func(string, []byte, os.FileMode) error
+}
+
+var osPopReceiptFileOps = popReceiptFileOps{
+	mkdirAll:  os.MkdirAll,
+	writeFile: os.WriteFile,
+}
+
+func writePopMessageOutputWithOps(stdout io.Writer, content, filename, markdownPath string, unreadBefore, remaining *int, runtimeContextMode string, diagnostics *popSessionDiagnostics, submitPath projection.SubmitPath, receiverOptions popReceiverContextOptions, receiptOps popReceiptFileOps) error {
 	output := parseMessageContent(content, filename)
 	output.MarkdownPath = displayMarkdownPath(markdownPath)
 	if output.MarkdownPath != markdownPath {
@@ -213,10 +228,8 @@ func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath str
 	output.ArchivedBodyReadInstruction = archivedBodyReadInstruction
 	output.SessionDiagnostics = diagnostics
 	output.SubmitPath = submitPath
-	receiptPath, err := popReceiptPath(markdownPath)
-	if err != nil {
-		return err
-	}
+	receiptPlan := store.PlanPopReceipt(markdownPath)
+	receiptPath := receiptPlan.ReceiptPath
 	if receiptPath != "" {
 		output.PopReceiptPath = displayMarkdownPath(receiptPath)
 		if output.PopReceiptPath != receiptPath {
@@ -229,12 +242,22 @@ func writePopMessageOutput(stdout io.Writer, content, filename, markdownPath str
 	}
 	payload = append(payload, '\n')
 	if receiptPath != "" {
-		if err := os.WriteFile(receiptPath, payload, 0o600); err != nil {
+		if err := writePopReceipt(receiptPlan, payload, receiptOps); err != nil {
 			return fmt.Errorf("writing pop receipt: %w", err)
 		}
 	}
 	_, err = stdout.Write(payload)
 	return err
+}
+
+func writePopReceipt(plan store.PopReceiptPlan, payload []byte, ops popReceiptFileOps) error {
+	if plan.ReceiptPath == "" {
+		return nil
+	}
+	if err := ops.mkdirAll(plan.ReadDir, 0o700); err != nil {
+		return fmt.Errorf("creating pop receipt directory: %w", err)
+	}
+	return ops.writeFile(plan.ReceiptPath, payload, 0o600)
 }
 
 func popSessionDiagnosticsForSession(sessionDir string) *popSessionDiagnostics {
@@ -378,26 +401,6 @@ func sessionDirFromArchivedMarkdownPath(markdownPath string) string {
 		return ""
 	}
 	return filepath.Dir(filepath.Dir(markdownPath))
-}
-
-func popReceiptPath(markdownPath string) (string, error) {
-	if markdownPath == "" {
-		return "", nil
-	}
-	dir := filepath.Dir(markdownPath)
-	if filepath.Base(dir) != "read" {
-		return "", nil
-	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("creating pop receipt directory: %w", err)
-	}
-	filename := filepath.Base(markdownPath)
-	ext := filepath.Ext(filename)
-	stem := strings.TrimSuffix(filename, ext)
-	if stem == "" {
-		stem = filename
-	}
-	return filepath.Join(dir, stem+".pop.json"), nil
 }
 
 func displayMarkdownPath(markdownPath string) string {

--- a/internal/cli/pop_test.go
+++ b/internal/cli/pop_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,6 +111,51 @@ func TestRunPopWithContextWritesJSONToConfiguredStdout(t *testing.T) {
 	}
 	if !strings.Contains(readPopArchiveForTest(t, payload), "context stdout payload") {
 		t.Fatalf("archived body missing expected payload")
+	}
+}
+
+func TestWritePopMessageOutputReturnsReceiptWriteError(t *testing.T) {
+	tmpDir := t.TempDir()
+	readDir := filepath.Join(tmpDir, "ctx", "review", "read")
+	markdownPath := filepath.Join(readDir, "20260414-032800-from-orchestrator-to-worker.md")
+	writeErr := errors.New("write receipt failed")
+
+	var stdout bytes.Buffer
+	err := writePopMessageOutputWithOps(&stdout,
+		messageFixture("orchestrator", "worker", "payload"),
+		filepath.Base(markdownPath),
+		markdownPath,
+		intPtr(1),
+		intPtr(0),
+		"none",
+		nil,
+		projection.SubmitPathPost,
+		popReceiverContextOptions{},
+		popReceiptFileOps{
+			mkdirAll: func(path string, perm os.FileMode) error {
+				if path != readDir {
+					t.Fatalf("mkdirAll path = %q, want %q", path, readDir)
+				}
+				return nil
+			},
+			writeFile: func(path string, data []byte, perm os.FileMode) error {
+				if path != filepath.Join(readDir, "20260414-032800-from-orchestrator-to-worker.pop.json") {
+					t.Fatalf("writeFile path = %q", path)
+				}
+				if perm != 0o600 {
+					t.Fatalf("writeFile perm = %o, want 600", perm)
+				}
+				if !bytes.Contains(data, []byte(`"pop_receipt_path"`)) {
+					t.Fatalf("receipt payload missing pop_receipt_path: %s", data)
+				}
+				return writeErr
+			},
+		})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("writePopMessageOutputWithOps() error = %v, want %v", err, writeErr)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when receipt write fails", stdout.String())
 	}
 }
 

--- a/internal/store/mailbox_store.go
+++ b/internal/store/mailbox_store.go
@@ -224,3 +224,32 @@ func archiveInboxMessageWithOps(plan InboxArchivePlan, ops archiveFileOps) (stri
 	}
 	return plan.ReadPath, nil
 }
+
+// PopReceiptPlan is the pure path plan for writing a pop receipt next to a read/ archive.
+type PopReceiptPlan struct {
+	MarkdownPath string
+	ReadDir      string
+	ReceiptPath  string
+}
+
+// PlanPopReceipt derives the pop receipt path without touching the filesystem.
+func PlanPopReceipt(markdownPath string) PopReceiptPlan {
+	if markdownPath == "" {
+		return PopReceiptPlan{}
+	}
+	readDir := filepath.Dir(markdownPath)
+	if filepath.Base(readDir) != "read" {
+		return PopReceiptPlan{MarkdownPath: markdownPath}
+	}
+	filename := filepath.Base(markdownPath)
+	ext := filepath.Ext(filename)
+	stem := strings.TrimSuffix(filename, ext)
+	if stem == "" {
+		stem = filename
+	}
+	return PopReceiptPlan{
+		MarkdownPath: markdownPath,
+		ReadDir:      readDir,
+		ReceiptPath:  filepath.Join(readDir, stem+".pop.json"),
+	}
+}

--- a/internal/store/mailbox_store_test.go
+++ b/internal/store/mailbox_store_test.go
@@ -243,3 +243,34 @@ func TestArchiveInboxMessageFailedRenamePreservesOriginalContent(t *testing.T) {
 		t.Fatalf("source content changed: %q", got)
 	}
 }
+
+func TestPlanPopReceipt(t *testing.T) {
+	tmpDir := t.TempDir()
+	readDir := filepath.Join(tmpDir, "ctx", "review", "read")
+	markdownPath := filepath.Join(readDir, "20260502-120000-r1111-from-a-to-b.md")
+
+	plan := PlanPopReceipt(markdownPath)
+	if plan.MarkdownPath != markdownPath {
+		t.Fatalf("MarkdownPath = %q, want %q", plan.MarkdownPath, markdownPath)
+	}
+	if plan.ReadDir != readDir {
+		t.Fatalf("ReadDir = %q, want %q", plan.ReadDir, readDir)
+	}
+	if plan.ReceiptPath != filepath.Join(readDir, "20260502-120000-r1111-from-a-to-b.pop.json") {
+		t.Fatalf("ReceiptPath = %q", plan.ReceiptPath)
+	}
+	if _, err := os.Stat(readDir); !os.IsNotExist(err) {
+		t.Fatalf("plan created read dir or wrong error: %v", err)
+	}
+}
+
+func TestPlanPopReceiptIgnoresNonReadArchivePath(t *testing.T) {
+	markdownPath := filepath.Join(t.TempDir(), "ctx", "review", "inbox", "worker", "message.md")
+	plan := PlanPopReceipt(markdownPath)
+	if plan.MarkdownPath != markdownPath {
+		t.Fatalf("MarkdownPath = %q, want %q", plan.MarkdownPath, markdownPath)
+	}
+	if plan.ReadDir != "" || plan.ReceiptPath != "" {
+		t.Fatalf("plan = %#v, want no receipt for non-read path", plan)
+	}
+}


### PR DESCRIPTION
Draft PR for issue #468. Branch is clean and pushed; this captures the mailbox/archive planning split from filesystem effects.