### PR TITLE
refactor(multiplexer): add tmux backend contract (#653)

### DIFF
--- a/docs/design/multiplexer-backend-contract.md
+++ b/docs/design/multiplexer-backend-contract.md
@@ -1,0 +1,76 @@
+# Multiplexer Backend Contract
+
+Issue: #653.
+
+## 1. Purpose
+
+This contract defines the first behavior-preserving backend seam for the
+existing tmux implementation. The current product still supports only tmux; the
+new types keep backend identity, native resource IDs, pane capture, and runtime
+probing from spreading backend-specific parsing into higher-level call sites.
+
+## 2. Current Backend
+
+- `tmux` is the default and only active backend.
+- Existing tmux command arguments, timing, and error behavior remain compatible.
+- Herdr is not a runtime dependency for this issue.
+
+## 3. Backend-Neutral IDs
+
+Backend-neutral code should pass `multiplexer.ResourceID` values rather than
+parse native IDs directly.
+
+- `Backend`: the multiplexer implementation, currently `tmux`.
+- `Kind`: resource category such as `pane`, `session`, or `node`.
+- `Native`: the backend-owned identifier, such as a tmux `%NN` pane ID.
+
+Existing `discovery.NodeInfo.PaneID` remains a string for compatibility in this
+issue. New backend-facing code converts it at the boundary with
+`multiplexer.TmuxPaneID`.
+
+## 4. Capture Boundary
+
+Pane capture is represented by `multiplexer.PaneBackend.CapturePane`.
+
+The tmux backend preserves existing capture forms:
+
+- visible pane: `tmux capture-pane -p -t <pane>`
+- recent scrollback: `tmux capture-pane -p -t <pane> -S -<tailLines>`
+- retained history: `tmux capture-pane -p -t <pane> -S -`
+
+The public `paneutil.Capture*` functions remain unchanged and delegate to the
+tmux backend.
+
+## 5. Current Context Boundary
+
+This issue does not move current context resolution. Later work should use this
+contract to separate:
+
+- current identity lookup: backend kind, pane ID, session ID/name, node name;
+- ownership/context checks: `ContextOwnsSession`, `FindSessionOwner`, and
+  canonical status ownership.
+
+Ownership-dependent behavior belongs to #656 before #654 generalizes current
+context resolution.
+
+## 6. Layout And Status Boundary
+
+Issue #655 owns structural layout/status projection. This issue only records
+that backend-neutral status should not require callers to parse tmux window or
+pane command output directly.
+
+Compatibility requirements for #655 include existing status JSON,
+`SessionStatus.Compact`, and `get-status-oneline`.
+
+## 7. Herdr Gates
+
+Herdr access remains blocked:
+
+- #660 must define read/write security gates, allowlists, protocol/schema
+  checks, no-server error normalization, and licensing/compliance decisions.
+- #658 may add read-only Herdr behavior only after the #660 read gate.
+- #659 may add Herdr write/mutation only after #658 and #660.
+
+Herdr read/write paths should include a pre-flight guard or equivalent
+mechanical check so explicit issue-body blockers are enforced in code or local
+workflow before activation.

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -1,10 +1,10 @@
 package controlplane
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -12,6 +12,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/agentruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr"
 	"github.com/i9wa4/tmux-a2a-postman/internal/notification"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
@@ -110,6 +111,7 @@ type HandAdapter interface {
 type TmuxHandAdapter struct {
 	ProbeRuntime func(paneID string) (string, error)
 	SendToPane   func(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error
+	Backend      multiplexer.PaneBackend
 }
 
 func (TmuxHandAdapter) Kind() HandKind {
@@ -123,9 +125,12 @@ func (a TmuxHandAdapter) Deliver(target Target, delivery PaneDelivery) error {
 
 	probeRuntime := a.ProbeRuntime
 	if probeRuntime == nil {
+		backend := a.Backend
+		if backend == nil {
+			backend = multiplexer.TmuxBackend{}
+		}
 		probeRuntime = func(paneID string) (string, error) {
-			out, err := exec.Command("tmux", "display-message", "-t", paneID, "-p", "#{pane_current_command}").Output()
-			return strings.TrimSpace(string(out)), err
+			return backend.PaneCurrentCommand(context.Background(), multiplexer.TmuxPaneID(paneID))
 		}
 	}
 	sendToPane := a.SendToPane

--- a/internal/multiplexer/backend.go
+++ b/internal/multiplexer/backend.go
@@ -1,0 +1,72 @@
+package multiplexer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxrunner"
+)
+
+type BackendKind string
+
+const (
+	BackendKindTmux BackendKind = "tmux"
+)
+
+type ResourceKind string
+
+const (
+	ResourceKindPane    ResourceKind = "pane"
+	ResourceKindSession ResourceKind = "session"
+	ResourceKindNode    ResourceKind = "node"
+)
+
+type ResourceID struct {
+	Backend BackendKind
+	Kind    ResourceKind
+	Native  string
+}
+
+func TmuxPaneID(paneID string) ResourceID {
+	return ResourceID{Backend: BackendKindTmux, Kind: ResourceKindPane, Native: paneID}
+}
+
+type CaptureOptions struct {
+	TailLines int
+	History   bool
+}
+
+type PaneBackend interface {
+	Kind() BackendKind
+	CapturePane(ctx context.Context, pane ResourceID, opts CaptureOptions) (string, error)
+	PaneCurrentCommand(ctx context.Context, pane ResourceID) (string, error)
+}
+
+type TmuxBackend struct {
+	Runner tmuxrunner.Command
+}
+
+func (TmuxBackend) Kind() BackendKind {
+	return BackendKindTmux
+}
+
+func (b TmuxBackend) CapturePane(_ context.Context, pane ResourceID, opts CaptureOptions) (string, error) {
+	args := []string{"capture-pane", "-p", "-t", pane.Native}
+	switch {
+	case opts.History:
+		args = append(args, "-S", "-")
+	case opts.TailLines > 0:
+		args = append(args, "-S", fmt.Sprintf("-%d", opts.TailLines))
+	}
+	out, err := b.Runner.CombinedOutput(args...)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func (b TmuxBackend) PaneCurrentCommand(_ context.Context, pane ResourceID) (string, error) {
+	out, err := b.Runner.Output("display-message", "-t", pane.Native, "-p", "#{pane_current_command}")
+	return strings.TrimSpace(string(out)), err
+}

--- a/internal/multiplexer/backend_test.go
+++ b/internal/multiplexer/backend_test.go
@@ -1,0 +1,88 @@
+package multiplexer
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxtest"
+)
+
+func TestTmuxBackendCapturePaneUsesVisibleCaptureArgs(t *testing.T) {
+	fake := tmuxtest.Install(t, tmuxtest.WithCommand(tmuxtest.Command{
+		Args:   []string{"capture-pane", "-p", "-t", "%11"},
+		Stdout: "pane content",
+	}))
+
+	got, err := (TmuxBackend{}).CapturePane(context.Background(), TmuxPaneID("%11"), CaptureOptions{})
+	if err != nil {
+		t.Fatalf("CapturePane() error = %v", err)
+	}
+	if got != "pane content" {
+		t.Fatalf("CapturePane() = %q, want %q", got, "pane content")
+	}
+	if gotArgs := fake.Invocations(); !reflect.DeepEqual(gotArgs, []string{"capture-pane -p -t %11"}) {
+		t.Fatalf("invocations = %#v", gotArgs)
+	}
+}
+
+func TestTmuxBackendCapturePaneUsesTailAndHistoryArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		opts CaptureOptions
+		want string
+	}{
+		{name: "tail", opts: CaptureOptions{TailLines: 100}, want: "capture-pane -p -t %11 -S -100"},
+		{name: "history", opts: CaptureOptions{History: true}, want: "capture-pane -p -t %11 -S -"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := tmuxtest.Install(t, tmuxtest.WithCommand(tmuxtest.Command{
+				Args: []string{"capture-pane", "-p", "-t", "%11", "-S", lastField(tt.want)},
+			}))
+
+			if _, err := (TmuxBackend{}).CapturePane(context.Background(), TmuxPaneID("%11"), tt.opts); err != nil {
+				t.Fatalf("CapturePane() error = %v", err)
+			}
+			if got := fake.Invocations(); !reflect.DeepEqual(got, []string{tt.want}) {
+				t.Fatalf("invocations = %#v, want %#v", got, []string{tt.want})
+			}
+		})
+	}
+}
+
+func TestTmuxBackendPaneCurrentCommandTrimsOutput(t *testing.T) {
+	tmuxtest.Install(t, tmuxtest.WithCommand(tmuxtest.Command{
+		Args:   []string{"display-message", "-t", "%11", "-p", "#{pane_current_command}"},
+		Stdout: "codex\n",
+	}))
+
+	got, err := (TmuxBackend{}).PaneCurrentCommand(context.Background(), TmuxPaneID("%11"))
+	if err != nil {
+		t.Fatalf("PaneCurrentCommand() error = %v", err)
+	}
+	if got != "codex" {
+		t.Fatalf("PaneCurrentCommand() = %q, want codex", got)
+	}
+}
+
+func TestTmuxBackendCapturePanePropagatesTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := (TmuxBackend{}).CapturePane(ctx, TmuxPaneID("%11"), CaptureOptions{})
+	if err == nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatal("CapturePane() error = nil after context deadline")
+	}
+}
+
+func lastField(s string) string {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == ' ' {
+			return s[i+1:]
+		}
+	}
+	return s
+}

--- a/internal/paneutil/pane.go
+++ b/internal/paneutil/pane.go
@@ -5,14 +5,9 @@ import (
 	"fmt"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
-	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxrunner"
 )
 
 type tmuxCombinedOutputFunc func(args ...string) ([]byte, error)
-
-func runTmuxCombinedOutput(args ...string) ([]byte, error) {
-	return tmuxrunner.CombinedOutput(args...)
-}
 
 // CaptureContent captures the visible content of a tmux pane.
 // Returns the content as a string, or empty string on error.

--- a/internal/paneutil/pane.go
+++ b/internal/paneutil/pane.go
@@ -1,30 +1,44 @@
 package paneutil
 
 import (
+	"context"
 	"fmt"
-	"os/exec"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxrunner"
 )
 
 type tmuxCombinedOutputFunc func(args ...string) ([]byte, error)
 
 func runTmuxCombinedOutput(args ...string) ([]byte, error) {
-	return exec.Command("tmux", args...).CombinedOutput()
+	return tmuxrunner.CombinedOutput(args...)
 }
 
 // CaptureContent captures the visible content of a tmux pane.
 // Returns the content as a string, or empty string on error.
 func CaptureContent(paneID string) (string, error) {
-	return captureContent(paneID, 0, runTmuxCombinedOutput)
+	return captureContentWithBackend(multiplexer.TmuxBackend{}, paneID, multiplexer.CaptureOptions{})
 }
 
 // CaptureRecentContent captures visible content plus recent scrollback lines.
 func CaptureRecentContent(paneID string, tailLines int) (string, error) {
-	return captureContent(paneID, tailLines, runTmuxCombinedOutput)
+	return captureContentWithBackend(multiplexer.TmuxBackend{}, paneID, multiplexer.CaptureOptions{TailLines: tailLines})
 }
 
 // CaptureHistoryContent captures visible content plus all retained scrollback.
 func CaptureHistoryContent(paneID string) (string, error) {
-	return captureHistoryContent(paneID, runTmuxCombinedOutput)
+	return captureContentWithBackend(multiplexer.TmuxBackend{}, paneID, multiplexer.CaptureOptions{History: true})
+}
+
+func captureContentWithBackend(backend multiplexer.PaneBackend, paneID string, opts multiplexer.CaptureOptions) (string, error) {
+	content, err := backend.CapturePane(context.Background(), multiplexer.TmuxPaneID(paneID), opts)
+	if err != nil {
+		if opts.History {
+			return "", fmt.Errorf("capturing pane %s history: %w", paneID, err)
+		}
+		return "", fmt.Errorf("capturing pane %s: %w", paneID, err)
+	}
+	return content, nil
 }
 
 func captureContent(paneID string, tailLines int, run tmuxCombinedOutputFunc) (string, error) {

--- a/internal/tmuxrunner/runner.go
+++ b/internal/tmuxrunner/runner.go
@@ -22,6 +22,11 @@ func CombinedOutput(args ...string) ([]byte, error) {
 	return Command{}.CombinedOutput(args...)
 }
 
+// Output executes tmux with the given arguments and returns stdout only.
+func Output(args ...string) ([]byte, error) {
+	return Command{}.Output(args...)
+}
+
 // CombinedOutput executes the configured tmux command with the given arguments.
 func (c Command) CombinedOutput(args ...string) ([]byte, error) {
 	binary := c.Binary
@@ -37,6 +42,28 @@ func (c Command) CombinedOutput(args ...string) ([]byte, error) {
 	defer cancel()
 
 	out, err := exec.CommandContext(ctx, binary, args...).CombinedOutput()
+	if ctx.Err() != nil {
+		return out, fmt.Errorf("tmux command timed out after %s: %w", c.Timeout, ctx.Err())
+	}
+	return out, err
+}
+
+// Output executes the configured tmux command with the given arguments and
+// returns stdout only.
+func (c Command) Output(args ...string) ([]byte, error) {
+	binary := c.Binary
+	if binary == "" {
+		binary = "tmux"
+	}
+
+	if c.Timeout <= 0 {
+		return exec.Command(binary, args...).Output()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, binary, args...).Output()
 	if ctx.Err() != nil {
 		return out, fmt.Errorf("tmux command timed out after %s: %w", c.Timeout, ctx.Err())
 	}


### PR DESCRIPTION
## Summary

Adds the behavior-preserving tmux multiplexer backend contract and keeps tmux as the only active backend.

Part of parent issue #652. Review order: #653, #656, #654, #655, #657, #660, #658, #659.

## Validation

Previously verified in the issue worktree with focused Go tests, ok  	github.com/i9wa4/tmux-a2a-postman	0.004s
ok  	github.com/i9wa4/tmux-a2a-postman/e2e	0.105s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/agentruntime	0.002s
?   	github.com/i9wa4/tmux-a2a-postman/internal/autoping	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/binding	0.002s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/cli	7.571s
?   	github.com/i9wa4/tmux-a2a-postman/internal/cliutil	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/config	0.101s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/controlplane	0.014s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/daemon	0.761s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/discovery	0.013s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/envelope	0.013s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/idle	0.280s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/journal	0.180s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/lock	0.016s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/message	0.200s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/msgtrace	0.017s
?   	github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/notification	0.078s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/paneutil	0.017s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/ping	0.174s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/projection	0.164s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/reconciler	0.016s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/router	0.005s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/runtimecontext	0.037s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/runtimeprofile	0.003s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/session	0.007s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/status	0.005s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/store	0.006s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/template	0.003s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/testfixture	0.020s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tmuxrunner	0.033s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tmuxtest	0.019s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tui	0.006s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/uinode	0.002s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/verdictbackfill	0.006s
?   	github.com/i9wa4/tmux-a2a-postman/internal/verdictgate	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/version	0.007s
ok  	github.com/i9wa4/tmux-a2a-postman/internal/workspacetree	0.003s
ok  	github.com/i9wa4/tmux-a2a-postman/scripts/validation	0.005s, , and .

Closes #653