### PR TITLE
refactor(multiplexer): abstract interactive pane delivery (#657)

### DIFF
--- a/docs/design/multiplexer-backend-contract.md
+++ b/docs/design/multiplexer-backend-contract.md
@@ -24,9 +24,10 @@ parse native IDs directly.
 - `Kind`: resource category such as `pane`, `session`, or `node`.
 - `Native`: the backend-owned identifier, such as a tmux `%NN` pane ID.
 
-Existing `discovery.NodeInfo.PaneID` remains a string for compatibility in this
-issue. New backend-facing code converts it at the boundary with
-`multiplexer.TmuxPaneID`.
+Existing `discovery.NodeInfo.PaneID` and `TMUX_PANE` values remain strings for
+compatibility in this issue. Backend-facing identity code converts them at the
+tmux compatibility boundary with `multiplexer.TmuxPaneID` and passes
+`multiplexer.IdentityTarget` values rather than raw native strings.
 
 ## 4. Capture Boundary
 
@@ -41,10 +42,42 @@ The tmux backend preserves existing capture forms:
 The public `paneutil.Capture*` functions remain unchanged and delegate to the
 tmux backend.
 
-## 5. Current Context Boundary
+## 5. Current Identity Boundary
 
-This issue does not move current context resolution. Later work should use this
-contract to separate:
+Current identity is represented by `multiplexer.CurrentIdentity`:
+
+- `Backend`: the source backend, currently `tmux`.
+- `SessionName`: the logical postman session scope.
+- `NodeName`: the logical postman node name.
+- `Pane`: the backend-neutral pane resource ID.
+- `NativeIDs`: backend-native evidence, such as tmux pane ID, session name, and
+  pane title.
+
+The tmux backend preserves existing lookup behavior:
+
+- `TMUX_PANE` targets session-name and pane-title lookups only when it is a
+  canonical tmux pane ID token, `%[0-9]+`.
+- Untargeted `display-message` remains the fallback when `TMUX_PANE` is absent.
+- `TMUX_PANE` itself remains the current pane ID when present.
+- Invalid `TMUX_PANE` values fail closed with identity lookup errors instead of
+  falling back to focused-pane discovery; this prevents generic tmux `-t` target
+  expressions from forging sender or receiver runtime identity.
+- Lookup failures are explicit `IdentityError` values at the backend boundary.
+  Blank `pane_id`, `session_name`, and `pane_title` outputs are lookup failures.
+  Compatibility wrappers still return empty strings to preserve existing CLI
+  behavior.
+- Production runtime-context send/pop paths consume one `CurrentIdentity`
+  resolver so pane, session, and node fields do not drift across independent
+  tmux lookups. CLI tests may still inject legacy tmux-named hooks; that seam is
+  compatibility-only and should not be used for new backend code.
+
+Herdr support should keep the same logical `session:node` address shape while
+resolving internally through Herdr named session, workspace ID, tab ID, and pane
+ID. Herdr labels are display/fallback information, not authoritative identity.
+
+## 6. Current Context Boundary
+
+Current context resolution must stay separated from current identity lookup:
 
 - current identity lookup: backend kind, pane ID, session ID/name, node name;
 - ownership/context checks: `ContextOwnsSession`, `FindSessionOwner`, and
@@ -53,7 +86,7 @@ contract to separate:
 Ownership-dependent behavior belongs to #656 before #654 generalizes current
 context resolution.
 
-## 6. Layout And Status Boundary
+## 7. Layout And Status Boundary
 
 Issue #655 owns structural layout/status projection. This issue only records
 that backend-neutral status should not require callers to parse tmux window or
@@ -62,7 +95,40 @@ pane command output directly.
 Compatibility requirements for #655 include existing status JSON,
 `SessionStatus.Compact`, and `get-status-oneline`.
 
-## 7. Herdr Gates
+Issue #655 adds a backend-owned `SessionLayout` contract with ordered layout
+groups and items. For tmux, those groups are tmux windows and the items are
+panes. The public status payload keeps the legacy `windows` projection for
+existing tmux JSON/TUI consumers and adds `layout_groups` as the backend-neutral
+structural view. `SessionStatus.Compact` and `get-status-oneline` continue to
+derive from the same ordered tmux-compatible pane projection, so their semantics
+do not change here.
+
+First-phase Herdr support should omit tmux-style `windows` as an authoritative
+native shape. After #660 allows Herdr reads, #658 may populate
+`layout_groups` from Herdr workspace/tab/pane layout data and may optionally
+derive compatibility `windows` groups for existing UI consumers. That projection
+must stay clearly marked as compatibility output and must not introduce pane
+state precedence changes before #639 resolves the semantic model.
+
+## 8. Interactive Delivery Boundary
+
+Issue #657 separates interactive pane input from filesystem mailbox delivery.
+
+- Interactive delivery is represented by
+  `controlplane.InteractiveDeliveryAdapter`. The tmux implementation keeps using
+  tmux pane input through `notification.PaneSender`, which preserves the
+  existing set-buffer, paste-buffer, C-m timing, cooldown, retry, and
+  sanitization behavior.
+- Filesystem inbox writes and mailbox projection sync are represented by
+  `controlplane.SystemMessageDeliveryAdapter` and the backend-neutral
+  `controlplane.FilesystemSystemMessageAdapter`.
+- The legacy `controlplane.HandAdapter` interface embeds both contracts for
+  compatibility while call sites are split over later issues.
+
+Herdr interactive delivery stays out of scope until #660 defines read/write
+security gates and #658 validates read-only Herdr behavior.
+
+## 9. Herdr Gates
 
 Herdr access remains blocked:
 

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -102,15 +102,24 @@ type SystemMessageResult struct {
 	Delivered bool
 }
 
-type HandAdapter interface {
+type InteractiveDeliveryAdapter interface {
 	Kind() HandKind
 	Deliver(target Target, delivery PaneDelivery) error
+}
+
+type SystemMessageDeliveryAdapter interface {
 	DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error)
+}
+
+type HandAdapter interface {
+	InteractiveDeliveryAdapter
+	SystemMessageDeliveryAdapter
 }
 
 type TmuxHandAdapter struct {
 	ProbeRuntime func(paneID string) (string, error)
 	SendToPane   func(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error
+	PaneSender   notification.PaneSender
 	Backend      multiplexer.PaneBackend
 }
 
@@ -119,6 +128,25 @@ func (TmuxHandAdapter) Kind() HandKind {
 }
 
 func (a TmuxHandAdapter) Deliver(target Target, delivery PaneDelivery) error {
+	return TmuxInteractiveDeliveryAdapter(a).Deliver(target, delivery)
+}
+
+func (a TmuxHandAdapter) DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error) {
+	return (FilesystemSystemMessageAdapter{}).DeliverSystemMessage(target, delivery)
+}
+
+type TmuxInteractiveDeliveryAdapter struct {
+	ProbeRuntime func(paneID string) (string, error)
+	SendToPane   func(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error
+	PaneSender   notification.PaneSender
+	Backend      multiplexer.PaneBackend
+}
+
+func (TmuxInteractiveDeliveryAdapter) Kind() HandKind {
+	return HandKindTmux
+}
+
+func (a TmuxInteractiveDeliveryAdapter) Deliver(target Target, delivery PaneDelivery) error {
 	if target.Hand.Kind != HandKindTmux {
 		return fmt.Errorf("tmux hand adapter cannot deliver to %q", target.Hand.Kind)
 	}
@@ -145,19 +173,37 @@ func (a TmuxHandAdapter) Deliver(target Target, delivery PaneDelivery) error {
 		return probeRuntime(target.Hand.Address)
 	})
 
-	return sendToPane(
-		target.Hand.Address,
-		delivery.Content,
-		delivery.EnterDelay,
-		delivery.TmuxTimeout,
-		enterCount,
-		delivery.BypassCooldown,
-		delivery.VerifyDelay,
-		delivery.MaxRetries,
-	)
+	paneSender := a.PaneSender
+	if paneSender == nil {
+		paneSender = notification.PaneSenderFunc(func(paneDelivery notification.PaneDelivery) error {
+			return sendToPane(
+				paneDelivery.PaneID,
+				paneDelivery.Message,
+				paneDelivery.EnterDelay,
+				paneDelivery.TmuxTimeout,
+				paneDelivery.EnterCount,
+				paneDelivery.BypassCooldown,
+				paneDelivery.VerifyDelay,
+				paneDelivery.MaxRetries,
+			)
+		})
+	}
+
+	return paneSender.DeliverPane(notification.PaneDelivery{
+		PaneID:         target.Hand.Address,
+		Message:        delivery.Content,
+		EnterDelay:     delivery.EnterDelay,
+		TmuxTimeout:    delivery.TmuxTimeout,
+		EnterCount:     enterCount,
+		BypassCooldown: delivery.BypassCooldown,
+		VerifyDelay:    delivery.VerifyDelay,
+		MaxRetries:     delivery.MaxRetries,
+	})
 }
 
-func (TmuxHandAdapter) DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error) {
+type FilesystemSystemMessageAdapter struct{}
+
+func (FilesystemSystemMessageAdapter) DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error) {
 	recipientInbox := target.InboxDir()
 	if err := os.MkdirAll(recipientInbox, 0o700); err != nil {
 		return SystemMessageResult{}, fmt.Errorf("creating recipient inbox: %w", err)

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/notification"
 )
 
 func TestTargetForNodeSeparatesActorRunBrainAndHand(t *testing.T) {
@@ -124,6 +125,75 @@ func TestTmuxHandAdapterDeliverUsesHandAttachment(t *testing.T) {
 	}
 }
 
+func TestTmuxInteractiveDeliveryAdapterUsesPaneSender(t *testing.T) {
+	var (
+		gotDelivery notification.PaneDelivery
+		probeCalls  int
+	)
+
+	adapter := TmuxInteractiveDeliveryAdapter{
+		ProbeRuntime: func(paneID string) (string, error) {
+			probeCalls++
+			if paneID != "%99" {
+				t.Fatalf("ProbeRuntime paneID = %q, want %q", paneID, "%99")
+			}
+			return "codex", nil
+		},
+		PaneSender: notification.PaneSenderFunc(func(delivery notification.PaneDelivery) error {
+			gotDelivery = delivery
+			return nil
+		}),
+	}
+
+	err := adapter.Deliver(Target{
+		ActorID:     "worker",
+		RunID:       "notify-session:worker",
+		SessionName: "notify-session",
+		SessionDir:  t.TempDir(),
+		Brain:       Brain{Runtime: BrainRuntimeUnknown},
+		Hand:        HandAttachment{Kind: HandKindTmux, Address: "%99"},
+	}, PaneDelivery{
+		Content:        "notice worker",
+		EnterDelay:     5 * time.Millisecond,
+		TmuxTimeout:    1 * time.Second,
+		EnterCount:     0,
+		BypassCooldown: true,
+		VerifyDelay:    7 * time.Millisecond,
+		MaxRetries:     3,
+	})
+	if err != nil {
+		t.Fatalf("Deliver() error = %v", err)
+	}
+
+	if gotDelivery.PaneID != "%99" {
+		t.Fatalf("PaneDelivery.PaneID = %q, want %q", gotDelivery.PaneID, "%99")
+	}
+	if gotDelivery.Message != "notice worker" {
+		t.Fatalf("PaneDelivery.Message = %q, want %q", gotDelivery.Message, "notice worker")
+	}
+	if gotDelivery.EnterCount != 2 {
+		t.Fatalf("PaneDelivery.EnterCount = %d, want %d", gotDelivery.EnterCount, 2)
+	}
+	if gotDelivery.EnterDelay != 5*time.Millisecond {
+		t.Fatalf("PaneDelivery.EnterDelay = %s, want %s", gotDelivery.EnterDelay, 5*time.Millisecond)
+	}
+	if gotDelivery.TmuxTimeout != 1*time.Second {
+		t.Fatalf("PaneDelivery.TmuxTimeout = %s, want %s", gotDelivery.TmuxTimeout, 1*time.Second)
+	}
+	if !gotDelivery.BypassCooldown {
+		t.Fatal("PaneDelivery.BypassCooldown = false, want true")
+	}
+	if gotDelivery.VerifyDelay != 7*time.Millisecond {
+		t.Fatalf("PaneDelivery.VerifyDelay = %s, want %s", gotDelivery.VerifyDelay, 7*time.Millisecond)
+	}
+	if gotDelivery.MaxRetries != 3 {
+		t.Fatalf("PaneDelivery.MaxRetries = %d, want %d", gotDelivery.MaxRetries, 3)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("ProbeRuntime calls = %d, want %d", probeCalls, 1)
+	}
+}
+
 func TestTmuxHandAdapterDeliverSystemMessageWritesInbox(t *testing.T) {
 	sessionDir := filepath.Join(t.TempDir(), "review-session")
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
@@ -144,6 +214,41 @@ func TestTmuxHandAdapterDeliverSystemMessageWritesInbox(t *testing.T) {
 		Content:         "system delivery",
 		QueueCap:        20,
 		QueueFullSuffix: "-dl-queue-full",
+	})
+	if err != nil {
+		t.Fatalf("DeliverSystemMessage() error = %v", err)
+	}
+	if !result.Delivered {
+		t.Fatal("DeliverSystemMessage() delivered = false, want true")
+	}
+
+	body, err := os.ReadFile(filepath.Join(sessionDir, "inbox", "worker", "20260414-120000-r1234-from-postman-to-worker.md"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(body) != "system delivery" {
+		t.Fatalf("inbox body = %q, want %q", string(body), "system delivery")
+	}
+}
+
+func TestFilesystemSystemMessageAdapterWritesInbox(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "review-session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	target := Target{
+		ActorID:     "worker",
+		RunID:       "review-session:worker",
+		SessionName: "review-session",
+		SessionDir:  sessionDir,
+	}
+
+	result, err := (FilesystemSystemMessageAdapter{}).DeliverSystemMessage(target, SystemMessageDelivery{
+		Filename: "20260414-120000-r1234-from-postman-to-worker.md",
+		Sender:   "postman",
+		Content:  "system delivery",
+		QueueCap: 20,
 	})
 	if err != nil {
 		t.Fatalf("DeliverSystemMessage() error = %v", err)

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -40,6 +40,48 @@ type PaneNotifier struct {
 	stderr  io.Writer
 }
 
+type PaneDelivery struct {
+	PaneID         string
+	Message        string
+	EnterDelay     time.Duration
+	TmuxTimeout    time.Duration
+	EnterCount     int
+	BypassCooldown bool
+	VerifyDelay    time.Duration
+	MaxRetries     int
+}
+
+type PaneSender interface {
+	DeliverPane(delivery PaneDelivery) error
+}
+
+type PaneSenderFunc func(delivery PaneDelivery) error
+
+func (f PaneSenderFunc) DeliverPane(delivery PaneDelivery) error {
+	return f(delivery)
+}
+
+type TmuxPaneSender struct {
+	Notifier *PaneNotifier
+}
+
+func (s TmuxPaneSender) DeliverPane(delivery PaneDelivery) error {
+	notifier := s.Notifier
+	if notifier == nil {
+		notifier = defaultPaneNotifier
+	}
+	return notifier.SendToPane(
+		delivery.PaneID,
+		delivery.Message,
+		delivery.EnterDelay,
+		delivery.TmuxTimeout,
+		delivery.EnterCount,
+		delivery.BypassCooldown,
+		delivery.VerifyDelay,
+		delivery.MaxRetries,
+	)
+}
+
 // NewPaneNotifier creates a pane notifier with the given per-pane cooldown.
 func NewPaneNotifier(cooldown time.Duration) *PaneNotifier {
 	return &PaneNotifier{
@@ -78,7 +120,16 @@ func BuildNotification(cfg *config.Config, adjacency map[string][]string, nodes 
 // verifyDelay > 0 enables post-Enter capture comparison: after C-m, waits verifyDelay,
 // captures pane, waits again, captures again; if identical, retries C-m up to maxRetries.
 func SendToPane(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error {
-	return defaultPaneNotifier.SendToPane(paneID, message, enterDelay, tmuxTimeout, enterCount, bypassCooldown, verifyDelay, maxRetries)
+	return TmuxPaneSender{}.DeliverPane(PaneDelivery{
+		PaneID:         paneID,
+		Message:        message,
+		EnterDelay:     enterDelay,
+		TmuxTimeout:    tmuxTimeout,
+		EnterCount:     enterCount,
+		BypassCooldown: bypassCooldown,
+		VerifyDelay:    verifyDelay,
+		MaxRetries:     maxRetries,
+	})
 }
 
 // SendToPane sends a message to a tmux pane using this notifier's dependencies and cooldown state.

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -423,6 +423,52 @@ func TestSendToPane_RejectsEmptyNotificationBody(t *testing.T) {
 	}
 }
 
+func TestTmuxPaneSenderSanitizesInteractiveDelivery(t *testing.T) {
+	var setBuffer string
+	notifier := NewPaneNotifier(0)
+	notifier.sleep = func(time.Duration) {}
+	notifier.runTmux = func(args ...string) error {
+		switch args[0] {
+		case "set-buffer":
+			setBuffer = args[1]
+		case "paste-buffer":
+			if args[1] != "-t" || args[2] != "%99" {
+				t.Fatalf("paste-buffer args = %#v, want target %%99", args)
+			}
+		case "send-keys":
+			if args[1] != "-t" || args[2] != "%99" || args[3] != "C-m" {
+				t.Fatalf("send-keys args = %#v, want C-m to %%99", args)
+			}
+		default:
+			t.Fatalf("unexpected tmux command args = %#v", args)
+		}
+		return nil
+	}
+
+	err := (TmuxPaneSender{Notifier: notifier}).DeliverPane(PaneDelivery{
+		PaneID:         "%99",
+		Message:        "hello \x1b[31mred\x1b[0m",
+		EnterCount:     1,
+		BypassCooldown: true,
+	})
+	if err != nil {
+		t.Fatalf("DeliverPane() error = %v", err)
+	}
+
+	if strings.Contains(setBuffer, "\x1b") {
+		t.Fatalf("set-buffer contained raw escape sequence: %q", setBuffer)
+	}
+	if !strings.Contains(setBuffer, "hello red") {
+		t.Fatalf("set-buffer = %q, want stripped message text", setBuffer)
+	}
+	if !strings.HasPrefix(setBuffer, "<!-- message start -->\n") {
+		t.Fatalf("set-buffer missing start sentinel: %q", setBuffer)
+	}
+	if !strings.HasSuffix(setBuffer, "\n<!-- end of message -->") {
+		t.Fatalf("set-buffer missing end sentinel: %q", setBuffer)
+	}
+}
+
 func TestPaneNotifierCooldownIsInstanceScoped(t *testing.T) {
 	now := time.Date(2026, time.June, 1, 1, 0, 0, 0, time.UTC)
 	notifierA, callsA := paneNotifierForTest(now, time.Minute)


### PR DESCRIPTION
## Summary

Abstracts interactive pane delivery behind the multiplexer backend while leaving filesystem/projection delivery backend-neutral.

This is the standalone #657 layer after #666 landed on `main`. The PR scope is limited to:

- `docs/design/multiplexer-backend-contract.md`
- `internal/controlplane/controlplane.go`
- `internal/controlplane/controlplane_test.go`
- `internal/notification/notification.go`
- `internal/notification/notification_test.go`

Part of parent issue #652. Review order: #653, #656, #654, #655, #657, #660, #658, #659.

## Validation

- Focused controlplane and notification tests
- `go test ./...`
- `nix flake check`
- `nix build`
- `git diff --check`
- Conflict-marker scan
- Deprecated-reference scan

Closes #657
