### PR TITLE
fix(multiplexer): preserve rediscovery errors (#659)

### DIFF
--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -40,6 +40,11 @@ Issue #658 may add only read behavior after the read gate passes. Issue #659
 may add write behavior only after #658 validates the read path and the write
 gate passes.
 
+Issue #659 keeps Herdr disabled unless `[postman.herdr]` is explicitly enabled,
+the configured runtime identity passes the read/write gate policy, a Herdr
+client is available, and startup discovery validates the configured workspace
+before registering pane delivery or ownership mutation routes.
+
 ## 3. Mechanical Gate
 
 `multiplexer.ValidateHerdrReadGate` and

--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -150,6 +150,18 @@ configuration still must set `InputSanitizerReady`; otherwise
 `ValidateHerdrWriteGate` returns `sanitizer_missing` before write or mutation
 RPCs are issued.
 
+Production #659 wiring uses Herdr's newline-delimited JSON Unix socket transport
+through a small local client. It calls `session.snapshot`, `pane.read`,
+`pane.process_info`, `pane.send_text`, `pane.send_keys`, and
+`workspace.report_metadata` / `pane.report_metadata`; marker clears report the
+same metadata token with a null value. The client maps Herdr `tokens` into the
+backend metadata view used by ownership marker reads.
+
+Cross-backend duplicate `session:node` keys are reported as collisions and do
+not overwrite the first discovered route. Herdr pane registration is reconciled
+on every snapshot, so panes missing from the latest Herdr discovery are
+unregistered from both direct delivery and ownership mutation routing.
+
 ## 9. Licensing And Compliance
 
 The gate does not make a legal compatibility conclusion. A write-capable path
@@ -174,11 +186,29 @@ The current accepted-path test records the official Herdr LICENSE permalink
 inputs only. This records source provenance without asserting legal
 compatibility.
 
+<<<<<<< HEAD
 The normative freshness boundary is 24 hours after `RevalidatedAt`, inclusive:
 the write gate accepts a record when `now - RevalidatedAt <= 24h` and rejects
 records older than 24 hours or whose revalidation timestamp is in the future.
 The runtime supplies the current time through an injectable policy time source;
 production uses the system clock and tests use a fixed clock.
+||||||| parent of 50c8645 (fix(multiplexer): complete herdr production runtime wiring (#659))
+- `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
+- `commercial`: a commercial license covers the integration shape;
+- `review-only`: no distributable/generated/write integration may be shipped.
+
+CLI or socket use alone does not resolve licensing obligations. A future issue
+must record the exact integration shape before changing dependency, vendoring,
+generated code, or distribution behavior.
+=======
+- `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
+- `commercial`: a commercial license covers the integration shape;
+- `review-only`: no distributable/generated/write integration may be shipped.
+
+CLI or socket use alone does not resolve licensing obligations. Any future
+change that adds dependency, vendoring, generated code, or broader distribution
+behavior must record the exact integration shape before implementation.
+>>>>>>> 50c8645 (fix(multiplexer): complete herdr production runtime wiring (#659))
 
 ## 10. Out Of Scope
 

--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -186,21 +186,11 @@ The current accepted-path test records the official Herdr LICENSE permalink
 inputs only. This records source provenance without asserting legal
 compatibility.
 
-<<<<<<< HEAD
 The normative freshness boundary is 24 hours after `RevalidatedAt`, inclusive:
 the write gate accepts a record when `now - RevalidatedAt <= 24h` and rejects
 records older than 24 hours or whose revalidation timestamp is in the future.
 The runtime supplies the current time through an injectable policy time source;
 production uses the system clock and tests use a fixed clock.
-||||||| parent of 50c8645 (fix(multiplexer): complete herdr production runtime wiring (#659))
-- `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
-- `commercial`: a commercial license covers the integration shape;
-- `review-only`: no distributable/generated/write integration may be shipped.
-
-CLI or socket use alone does not resolve licensing obligations. A future issue
-must record the exact integration shape before changing dependency, vendoring,
-generated code, or distribution behavior.
-=======
 - `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
 - `commercial`: a commercial license covers the integration shape;
 - `review-only`: no distributable/generated/write integration may be shipped.
@@ -208,7 +198,6 @@ generated code, or distribution behavior.
 CLI or socket use alone does not resolve licensing obligations. Any future
 change that adds dependency, vendoring, generated code, or broader distribution
 behavior must record the exact integration shape before implementation.
->>>>>>> 50c8645 (fix(multiplexer): complete herdr production runtime wiring (#659))
 
 ## 10. Out Of Scope
 

--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -192,9 +192,13 @@ records older than 24 hours or whose revalidation timestamp is in the future.
 The runtime supplies the current time through an injectable policy time source;
 production uses the system clock and tests use a fixed clock.
 
-- `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
-- `commercial`: a commercial license covers the integration shape;
-- `review-only`: no distributable/generated/write integration may be shipped.
+Historical decision labels are audit provenance only and are not accepted by
+the current write gate:
+
+- `agpl-3.0-or-later`: historical AGPL-compatible interpretation;
+- `commercial`: historical commercial-license interpretation;
+- `review-only`: pending-review marker; no distributable/generated/write
+  integration may be shipped.
 
 CLI or socket use alone does not resolve licensing obligations. Any future
 change that adds dependency, vendoring, generated code, or broader distribution
@@ -202,6 +206,7 @@ behavior must record the exact integration shape before implementation.
 
 ## 10. Out Of Scope
 
-Issue #660 does not implement Herdr discovery, capture, status, interactive
-delivery, ownership mutation, socket clients, generated protocol clients, or
-packaging changes.
+This document does not authorize generated protocol clients, vendoring,
+packaging changes, or broader distribution behavior. Discovery, capture,
+status, interactive delivery, ownership mutation, and socket-client paths must
+remain behind the gates above.

--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -140,8 +140,10 @@ Herdr interactive delivery must preserve the security intent of the tmux
 - keep key-combo APIs and text-input APIs separate;
 - never pass untrusted body text as key-combo syntax.
 
-Until this path exists and has focused tests, `ValidateHerdrWriteGate` must
-return `sanitizer_missing`.
+Issue #659 implements this path behind explicit registration. Herdr write
+configuration still must set `InputSanitizerReady`; otherwise
+`ValidateHerdrWriteGate` returns `sanitizer_missing` before write or mutation
+RPCs are issued.
 
 ## 9. Licensing And Compliance
 

--- a/docs/design/herdr-security-licensing-gates.md
+++ b/docs/design/herdr-security-licensing-gates.md
@@ -191,6 +191,7 @@ the write gate accepts a record when `now - RevalidatedAt <= 24h` and rejects
 records older than 24 hours or whose revalidation timestamp is in the future.
 The runtime supplies the current time through an injectable policy time source;
 production uses the system clock and tests use a fixed clock.
+
 - `agpl-3.0-or-later`: the integration shape is AGPL-compatible;
 - `commercial`: a commercial license covers the integration shape;
 - `review-only`: no distributable/generated/write integration may be shipped.

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -24,6 +24,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/daemon"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/lock"
@@ -34,6 +35,10 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/session"
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
 )
+
+var newHerdrRuntimeClient herdrruntime.ClientFactory = func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+	return nil, fmt.Errorf("%w: herdr socket client is not configured", multiplexer.ErrHerdrBackendUnavailable)
+}
 
 // safeGo starts a goroutine with panic recovery (Issue #57).
 func safeGo(name string, events chan<- tui.DaemonEvent, fn func()) {
@@ -87,6 +92,22 @@ func activePingNodeNames(nodes map[string]discovery.NodeInfo) []string {
 	}
 	sort.Strings(activeNodes)
 	return activeNodes
+}
+
+func mergeDiscoveredNodes(dst, src map[string]discovery.NodeInfo) {
+	if dst == nil || len(src) == 0 {
+		return
+	}
+	for nodeKey, nodeInfo := range src {
+		dst[nodeKey] = nodeInfo
+	}
+}
+
+func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
+	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
+		return herdrRuntime.SetSessionEnabledMarker(ctx, contextID, sessionName, enabled)
+	}
+	return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
 }
 
 func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle.IdleTracker, nodes map[string]discovery.NodeInfo, targets []idle.CompactionPingTarget) {
@@ -282,12 +303,29 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		defer func() { _ = lockObj.Release() }()
 	}
 
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	herdrRuntime, err := herdrruntime.New(cfg, newHerdrRuntimeClient)
+	if err != nil {
+		return fmt.Errorf("configuring herdr runtime: %w", err)
+	}
+	defer herdrRuntime.Close()
+	var herdrStartupNodes map[string]discovery.NodeInfo
+	var herdrStartupCollisions []discovery.CollisionReport
+	if herdrRuntime != nil {
+		herdrStartupNodes, herdrStartupCollisions, err = herdrRuntime.Discover(ctx, baseDir, contextID)
+		if err != nil {
+			return fmt.Errorf("discovering herdr runtime: %w", err)
+		}
+	}
+
 	pidPath := filepath.Join(sessionDir, "postman.pid")
 	if err := config.WriteSessionPIDFile(pidPath, os.Getpid()); err != nil {
 		return fmt.Errorf("writing PID file: %w", err)
 	}
 	defer func() { _ = os.Remove(pidPath) }()
-	if err := config.SetSessionEnabledMarker(contextID, sessionName, true); err != nil {
+	if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
 		return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
 	}
 	startupActivatedSessions := activateStartupSessions(baseDir, contextDir, contextID, sessionName, cfg)
@@ -304,9 +342,6 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	} else if removed > 0 {
 		log.Printf("postman: pruned %d expired runtime path(s) at startup\n", removed)
 	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
 
 	// Issue #57: Signal handling logging
 	sigCh := make(chan os.Signal, 1)
@@ -358,6 +393,8 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		nodes = make(map[string]discovery.NodeInfo)
 		startupCollisions = nil
 	}
+	mergeDiscoveredNodes(nodes, herdrStartupNodes)
+	startupCollisions = append(startupCollisions, herdrStartupCollisions...)
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	// Claim discovered panes with this daemon's context ID.
@@ -395,6 +432,14 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		if err != nil {
 			log.Printf("⚠️  postman: startup re-discovery failed: %v\n", err)
 			return
+		}
+		if herdrRuntime != nil {
+			herdrNodes, _, herdrErr := herdrRuntime.Discover(context.Background(), baseDir, contextID)
+			if herdrErr != nil {
+				log.Printf("⚠️  postman: startup herdr re-discovery failed: %v\n", herdrErr)
+			} else {
+				mergeDiscoveredNodes(fresh, herdrNodes)
+			}
 		}
 		activationNodesLocal := activationNodeNames(cfg)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
@@ -506,6 +551,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 
 	// Issue #71: Create state management instances
 	daemonState := daemon.NewDaemonState(cfg.StartupDrainWindowSeconds, contextID)
+	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
+		daemonState.SetOwnershipBackend(herdrRuntime.OwnershipBackend())
+	}
 	daemonState.AutoEnableSessionIfNew(sessionName)
 	for _, activatedSession := range startupActivatedSessions {
 		daemonState.AutoEnableSessionIfNew(activatedSession)
@@ -527,7 +575,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		relayDaemonEventsToTUI(ctx, daemonEvents, tuiEvents, baseDir, contextID, cfg)
 	})
 	safeGo("daemon-loop", daemonEvents, func() {
-		daemon.RunDaemonLoop(ctx, baseDir, sessionDir, contextID, cfg, watcher, adjacency, nodes, knownNodes, daemonEvents, resolvedConfigPath, nil, nil, daemonState, idleTracker, &sharedNodes, sessionName)
+		daemon.RunDaemonLoop(ctx, baseDir, sessionDir, contextID, cfg, watcher, adjacency, nodes, knownNodes, daemonEvents, resolvedConfigPath, nil, nil, daemonState, idleTracker, &sharedNodes, sessionName, herdrRuntime)
 	})
 
 	// Issue #117: Discover all tmux sessions
@@ -604,6 +652,14 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						// that set titles after startup or after the last scan).
 						freshDiscovered, _, discErr := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
 						if discErr == nil && len(freshDiscovered) > 0 {
+							if herdrRuntime != nil {
+								herdrNodes, _, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
+								if herdrErr != nil {
+									log.Printf("⚠️  postman: manual PING herdr discovery failed: %v\n", herdrErr)
+								} else {
+									mergeDiscoveredNodes(freshDiscovered, herdrNodes)
+								}
+							}
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
 							sharedNodes.Store(&freshNodes)
 							targetNodes = pingTargetsForSession(freshNodes, cmd.Target)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -120,6 +120,29 @@ func logDiscoveredCollisions(collisions []discovery.CollisionReport, activationN
 	}
 }
 
+func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessionName string, herdrRuntime *herdrruntime.Runtime) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+	fresh, collisions, err := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
+	if err != nil {
+		if herdrRuntime == nil {
+			return nil, nil, err
+		}
+		log.Printf("⚠️  postman: tmux discovery failed before Herdr refresh: %v\n", err)
+		fresh = make(map[string]discovery.NodeInfo)
+		collisions = nil
+	}
+	if herdrRuntime == nil {
+		return fresh, collisions, nil
+	}
+	herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
+	if herdrErr != nil {
+		log.Printf("⚠️  postman: herdr discovery failed: %v\n", herdrErr)
+		return fresh, collisions, nil
+	}
+	collisions = append(collisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
+	collisions = append(collisions, herdrCollisions...)
+	return fresh, collisions, nil
+}
+
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
 	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
 		return herdrRuntime.SetSessionEnabledMarker(ctx, contextID, sessionName, enabled)
@@ -445,20 +468,10 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 				log.Printf("🚨 startup-rediscovery panic: %v\n", r)
 			}
 		}()
-		fresh, _, err := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
+		fresh, freshCollisions, err := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
 		if err != nil {
 			log.Printf("⚠️  postman: startup re-discovery failed: %v\n", err)
 			return
-		}
-		var freshCollisions []discovery.CollisionReport
-		if herdrRuntime != nil {
-			herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
-			if herdrErr != nil {
-				log.Printf("⚠️  postman: startup herdr re-discovery failed: %v\n", herdrErr)
-			} else {
-				freshCollisions = append(freshCollisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
-				freshCollisions = append(freshCollisions, herdrCollisions...)
-			}
 		}
 		activationNodesLocal := activationNodeNames(cfg)
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
@@ -668,18 +681,8 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						activationBlocked := false
 						// Attempt a fresh discovery before giving up (catches panes
 						// that set titles after startup or after the last scan).
-						freshDiscovered, _, discErr := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
-						if discErr == nil && len(freshDiscovered) > 0 {
-							var freshCollisions []discovery.CollisionReport
-							if herdrRuntime != nil {
-								herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
-								if herdrErr != nil {
-									log.Printf("⚠️  postman: manual PING herdr discovery failed: %v\n", herdrErr)
-								} else {
-									freshCollisions = append(freshCollisions, mergeDiscoveredNodes(freshDiscovered, herdrNodes)...)
-									freshCollisions = append(freshCollisions, herdrCollisions...)
-								}
-							}
+						freshDiscovered, freshCollisions, discErr := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
+						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
 							sharedNodes.Store(&freshNodes)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -36,9 +36,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
 )
 
-var newHerdrRuntimeClient herdrruntime.ClientFactory = func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
-	return nil, fmt.Errorf("%w: herdr socket client is not configured", multiplexer.ErrHerdrBackendUnavailable)
-}
+var newHerdrRuntimeClient herdrruntime.ClientFactory = herdrruntime.NewSocketClient
 
 // safeGo starts a goroutine with panic recovery (Issue #57).
 func safeGo(name string, events chan<- tui.DaemonEvent, fn func()) {
@@ -94,13 +92,23 @@ func activePingNodeNames(nodes map[string]discovery.NodeInfo) []string {
 	return activeNodes
 }
 
-func mergeDiscoveredNodes(dst, src map[string]discovery.NodeInfo) {
+func mergeDiscoveredNodes(dst, src map[string]discovery.NodeInfo) []discovery.CollisionReport {
 	if dst == nil || len(src) == 0 {
-		return
+		return nil
 	}
+	var collisions []discovery.CollisionReport
 	for nodeKey, nodeInfo := range src {
+		if existing, exists := dst[nodeKey]; exists && multiplexer.BackendKindFromString(existing.Backend) != multiplexer.BackendKindFromString(nodeInfo.Backend) {
+			collisions = append(collisions, discovery.CollisionReport{
+				NodeKey:      nodeKey,
+				WinnerPaneID: existing.PaneID,
+				LoserPaneID:  nodeInfo.PaneID,
+			})
+			continue
+		}
 		dst[nodeKey] = nodeInfo
 	}
+	return collisions
 }
 
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
@@ -393,7 +401,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		nodes = make(map[string]discovery.NodeInfo)
 		startupCollisions = nil
 	}
-	mergeDiscoveredNodes(nodes, herdrStartupNodes)
+	startupCollisions = append(startupCollisions, mergeDiscoveredNodes(nodes, herdrStartupNodes)...)
 	startupCollisions = append(startupCollisions, herdrStartupCollisions...)
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
@@ -438,7 +446,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 			if herdrErr != nil {
 				log.Printf("⚠️  postman: startup herdr re-discovery failed: %v\n", herdrErr)
 			} else {
-				mergeDiscoveredNodes(fresh, herdrNodes)
+				_ = mergeDiscoveredNodes(fresh, herdrNodes)
 			}
 		}
 		activationNodesLocal := activationNodeNames(cfg)
@@ -551,9 +559,12 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 
 	// Issue #71: Create state management instances
 	daemonState := daemon.NewDaemonState(cfg.StartupDrainWindowSeconds, contextID)
-	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
-		daemonState.SetOwnershipBackend(herdrRuntime.OwnershipBackend())
-	}
+	daemonState.SetOwnershipBackendSelector(func(session string) multiplexer.OwnershipBackend {
+		if herdrRuntime != nil && herdrRuntime.OwnsSession(session) {
+			return herdrRuntime.OwnershipBackend()
+		}
+		return multiplexer.TmuxBackend{}
+	})
 	daemonState.AutoEnableSessionIfNew(sessionName)
 	for _, activatedSession := range startupActivatedSessions {
 		daemonState.AutoEnableSessionIfNew(activatedSession)
@@ -657,7 +668,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 								if herdrErr != nil {
 									log.Printf("⚠️  postman: manual PING herdr discovery failed: %v\n", herdrErr)
 								} else {
-									mergeDiscoveredNodes(freshDiscovered, herdrNodes)
+									_ = mergeDiscoveredNodes(freshDiscovered, herdrNodes)
 								}
 							}
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -136,6 +136,9 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
 	if herdrErr != nil {
 		log.Printf("⚠️  postman: herdr discovery failed: %v\n", herdrErr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tmux discovery failed: %w; herdr discovery failed: %v", err, herdrErr)
+		}
 		return fresh, collisions, nil
 	}
 	collisions = append(collisions, mergeDiscoveredNodes(fresh, herdrNodes)...)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -111,6 +111,15 @@ func mergeDiscoveredNodes(dst, src map[string]discovery.NodeInfo) []discovery.Co
 	return collisions
 }
 
+func logDiscoveredCollisions(collisions []discovery.CollisionReport, activationNodes map[string]bool) {
+	for _, collision := range collisions {
+		if !config.EdgeNodeAllowed(activationNodes, collision.NodeKey) {
+			continue
+		}
+		log.Printf("⚠️  postman: pane collision: %s: %s displaced by %s\n", collision.NodeKey, collision.LoserPaneID, collision.WinnerPaneID)
+	}
+}
+
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
 	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
 		return herdrRuntime.SetSessionEnabledMarker(ctx, contextID, sessionName, enabled)
@@ -441,27 +450,25 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 			log.Printf("⚠️  postman: startup re-discovery failed: %v\n", err)
 			return
 		}
+		var freshCollisions []discovery.CollisionReport
 		if herdrRuntime != nil {
-			herdrNodes, _, herdrErr := herdrRuntime.Discover(context.Background(), baseDir, contextID)
+			herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
 			if herdrErr != nil {
 				log.Printf("⚠️  postman: startup herdr re-discovery failed: %v\n", herdrErr)
 			} else {
-				_ = mergeDiscoveredNodes(fresh, herdrNodes)
+				freshCollisions = append(freshCollisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
+				freshCollisions = append(freshCollisions, herdrCollisions...)
 			}
 		}
 		activationNodesLocal := activationNodeNames(cfg)
+		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
 		sharedNodes.Store(&fresh)
 		log.Printf("postman: startup re-discovery complete (%d nodes)\n", len(fresh))
 	})
 
 	// Log collisions for edge nodes after edge filter
-	for _, collision := range startupCollisions {
-		if !config.EdgeNodeAllowed(activationNodes, collision.NodeKey) {
-			continue
-		}
-		log.Printf("⚠️  postman: pane collision: %s: %s displaced by %s\n", collision.NodeKey, collision.LoserPaneID, collision.WinnerPaneID)
-	}
+	logDiscoveredCollisions(startupCollisions, activationNodes)
 
 	// Watch all discovered session directories
 	watchedDirs := make(map[string]bool)
@@ -663,14 +670,17 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						// that set titles after startup or after the last scan).
 						freshDiscovered, _, discErr := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
 						if discErr == nil && len(freshDiscovered) > 0 {
+							var freshCollisions []discovery.CollisionReport
 							if herdrRuntime != nil {
-								herdrNodes, _, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
+								herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
 								if herdrErr != nil {
 									log.Printf("⚠️  postman: manual PING herdr discovery failed: %v\n", herdrErr)
 								} else {
-									_ = mergeDiscoveredNodes(freshDiscovered, herdrNodes)
+									freshCollisions = append(freshCollisions, mergeDiscoveredNodes(freshDiscovered, herdrNodes)...)
+									freshCollisions = append(freshCollisions, herdrCollisions...)
 								}
 							}
+							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
 							sharedNodes.Store(&freshNodes)
 							targetNodes = pingTargetsForSession(freshNodes, cmd.Target)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -362,7 +362,17 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	// Claim discovered panes with this daemon's context ID.
 	for _, nodeInfo := range nodes {
-		if err := tmuxBackend.SetPaneOwnerMarker(ctx, multiplexer.TmuxPaneID(nodeInfo.PaneID), contextID); err != nil {
+		backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+		backend, backendErr := multiplexer.OwnershipBackendForKind(backendKind)
+		if backendErr != nil {
+			log.Printf(
+				"postman: WARNING: failed to select ownership backend for pane %s: %v\n",
+				nodeInfo.PaneID, backendErr,
+			)
+			continue
+		}
+		pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+		if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
 			log.Printf(
 				"postman: WARNING: failed to claim pane %s: %v\n",
 				nodeInfo.PaneID, err,

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -147,17 +147,57 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	return fresh, collisions, herdrToken, nil
 }
 
-func publishFreshHerdrNodes(herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
+func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
+	prepare := func(publication *herdrruntime.FinalPublication) error {
+		for _, nodeInfo := range fresh {
+			if nodeInfo.PaneID == "" {
+				continue
+			}
+			backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+			var backend multiplexer.OwnershipBackend
+			var err error
+			if backendKind == multiplexer.BackendKindHerdr && publication != nil {
+				backend = publication
+			} else {
+				backend, err = multiplexer.OwnershipBackendForKind(backendKind)
+				if err != nil {
+					return fmt.Errorf("selecting ownership backend for pane %s: %w", nodeInfo.PaneID, err)
+				}
+			}
+			if err := backend.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
+				return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
+			}
+		}
+		return nil
+	}
 	commit := func() {
 		if sharedNodes != nil {
 			sharedNodes.Store(&fresh)
 		}
 	}
 	if herdrRuntime != nil {
-		return herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, nil, commit) == nil
+		return herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, prepare, commit) == nil
+	}
+	if err := prepare(nil); err != nil {
+		return false
 	}
 	commit()
 	return true
+}
+
+func paneResourceForNodeInfo(nodeInfo discovery.NodeInfo) multiplexer.ResourceID {
+	backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+	pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+	if backendKind == multiplexer.BackendKindHerdr {
+		return multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  nodeInfo.HerdrSocketPath,
+			SessionName: nodeInfo.SessionName,
+			WorkspaceID: nodeInfo.HerdrWorkspaceID,
+			TabID:       nodeInfo.HerdrTabID,
+			PaneID:      nodeInfo.PaneID,
+		}, nodeInfo.PaneID)
+	}
+	return pane
 }
 
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
@@ -478,17 +518,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 				)
 				continue
 			}
-			pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
-			if backendKind == multiplexer.BackendKindHerdr && nodeInfo.HerdrSocketPath != "" && nodeInfo.HerdrWorkspaceID != "" {
-				pane = multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
-					SocketPath:  nodeInfo.HerdrSocketPath,
-					SessionName: nodeInfo.SessionName,
-					WorkspaceID: nodeInfo.HerdrWorkspaceID,
-					TabID:       nodeInfo.HerdrTabID,
-					PaneID:      nodeInfo.PaneID,
-				}, nodeInfo.PaneID)
-			}
-			if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
+			if err := backend.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
 				log.Printf(
 					"postman: WARNING: failed to claim pane %s: %v\n",
 					nodeInfo.PaneID, err,
@@ -527,7 +557,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		activationNodesLocal := activationNodeNames(cfg)
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
-		if !publishFreshHerdrNodes(herdrRuntime, herdrToken, fresh, &sharedNodes) {
+		if !publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, fresh, &sharedNodes) {
 			log.Printf("postman: startup re-discovery skipped stale Herdr snapshot (%d nodes)\n", len(fresh))
 			return
 		}
@@ -741,7 +771,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
-							if publishFreshHerdrNodes(herdrRuntime, herdrToken, freshNodes, &sharedNodes) {
+							if publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, freshNodes, &sharedNodes) {
 								targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
 							} else {
 								log.Printf("postman: PING refresh skipped stale Herdr snapshot (%d nodes)\n", len(freshNodes))

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -369,9 +369,6 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		return fmt.Errorf("writing PID file: %w", err)
 	}
 	defer func() { _ = os.Remove(pidPath) }()
-	if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
-		return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
-	}
 	startupActivatedSessions := activateStartupSessions(baseDir, contextDir, contextID, sessionName, cfg)
 
 	inboxDir := filepath.Join(sessionDir, "inbox")
@@ -443,6 +440,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	if herdrRuntime != nil {
 		herdrRuntime.ReconcileFinalNodes(nodes)
+	}
+	if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
+		return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
 	}
 	// Claim discovered panes with this daemon's context ID.
 	for _, nodeInfo := range nodes {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -209,13 +209,6 @@ func paneResourceForNodeInfo(nodeInfo discovery.NodeInfo) multiplexer.ResourceID
 	return pane
 }
 
-func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
-	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
-		return herdrRuntime.SetSessionEnabledMarker(ctx, contextID, sessionName, enabled)
-	}
-	return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
-}
-
 func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle.IdleTracker, nodes map[string]discovery.NodeInfo, targets []idle.CompactionPingTarget) {
 	if len(targets) == 0 {
 		return

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -148,16 +148,15 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 }
 
 func publishFreshHerdrNodes(herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
-	publish := func() error {
+	commit := func() {
 		if sharedNodes != nil {
 			sharedNodes.Store(&fresh)
 		}
-		return nil
 	}
 	if herdrRuntime != nil {
-		return herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrToken, fresh, publish) == nil
+		return herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, nil, commit) == nil
 	}
-	_ = publish()
+	commit()
 	return true
 }
 
@@ -454,14 +453,24 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
-	publishStartupNodes := func() error {
-		if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
+	prepareStartupNodes := func(publication *herdrruntime.FinalPublication) error {
+		if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
+			if err := publication.SetSessionEnabledMarker(ctx, contextID, sessionName, true); err != nil {
+				return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
+			}
+		} else if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
 			return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
 		}
 		// Claim discovered panes with this daemon's context ID.
 		for _, nodeInfo := range nodes {
 			backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
-			backend, backendErr := multiplexer.OwnershipBackendForKind(backendKind)
+			var backend multiplexer.OwnershipBackend
+			var backendErr error
+			if backendKind == multiplexer.BackendKindHerdr && publication != nil {
+				backend = publication
+			} else {
+				backend, backendErr = multiplexer.OwnershipBackendForKind(backendKind)
+			}
 			if backendErr != nil {
 				log.Printf(
 					"postman: WARNING: failed to select ownership backend for pane %s: %v\n",
@@ -486,15 +495,19 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 				)
 			}
 		}
-		sharedNodes.Store(&nodes)
 		return nil
 	}
+	commitStartupNodes := func() {
+		sharedNodes.Store(&nodes)
+	}
 	if herdrRuntime != nil {
-		if err := herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes, publishStartupNodes); err != nil {
+		if err := herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrStartupToken, nodes, prepareStartupNodes, commitStartupNodes); err != nil {
 			return fmt.Errorf("publishing Herdr startup snapshot: %w", err)
 		}
-	} else if err := publishStartupNodes(); err != nil {
+	} else if err := prepareStartupNodes(nil); err != nil {
 		return err
+	} else {
+		commitStartupNodes()
 	}
 	// Shared node snapshot for background periodic refresh (Issue #139)
 
@@ -706,6 +719,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 				// Issue #47: Handle TUI commands
 				switch cmd.Type {
 				case "send_ping":
+					multiplexer.LockHerdrPublicationRead()
 					cachedPtr := sharedNodes.Load()
 					var freshNodes map[string]discovery.NodeInfo
 					if cachedPtr != nil {
@@ -715,6 +729,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 							freshNodes[k] = v
 						}
 					}
+					multiplexer.UnlockHerdrPublicationRead()
 					// Edge-filter and session-filter nodes (replicate startup logic, main.go:268-274)
 					activationNodesFilter := activationNodeNames(cfg)
 					targetNodes := pingTargetsForSession(freshNodes, cmd.Target)
@@ -738,7 +753,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 							case activationErr == nil:
 								daemonState.SetSessionEnabled(cmd.Target, true)
 								freshNodes = activatedNodes
+								multiplexer.LockHerdrPublicationWrite()
 								sharedNodes.Store(&freshNodes)
+								multiplexer.UnlockHerdrPublicationWrite()
 								targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
 								daemonEvents <- tui.DaemonEvent{
 									Type:    "status_update",

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -144,7 +144,6 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	}
 	collisions = append(collisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
 	collisions = append(collisions, herdrCollisions...)
-	herdrRuntime.ReconcileFinalNodes(fresh)
 	return fresh, collisions, nil
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -148,12 +148,16 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 }
 
 func publishFreshHerdrNodes(herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
-	if herdrRuntime != nil && !herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh) {
-		return false
+	publish := func() error {
+		if sharedNodes != nil {
+			sharedNodes.Store(&fresh)
+		}
+		return nil
 	}
-	if sharedNodes != nil {
-		sharedNodes.Store(&fresh)
+	if herdrRuntime != nil {
+		return herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrToken, fresh, publish) == nil
 	}
+	_ = publish()
 	return true
 }
 
@@ -449,34 +453,50 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	startupCollisions = append(startupCollisions, herdrStartupCollisions...)
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
+	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
+	publishStartupNodes := func() error {
+		if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
+			return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
+		}
+		// Claim discovered panes with this daemon's context ID.
+		for _, nodeInfo := range nodes {
+			backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+			backend, backendErr := multiplexer.OwnershipBackendForKind(backendKind)
+			if backendErr != nil {
+				log.Printf(
+					"postman: WARNING: failed to select ownership backend for pane %s: %v\n",
+					nodeInfo.PaneID, backendErr,
+				)
+				continue
+			}
+			pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+			if backendKind == multiplexer.BackendKindHerdr && nodeInfo.HerdrSocketPath != "" && nodeInfo.HerdrWorkspaceID != "" {
+				pane = multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+					SocketPath:  nodeInfo.HerdrSocketPath,
+					SessionName: nodeInfo.SessionName,
+					WorkspaceID: nodeInfo.HerdrWorkspaceID,
+					TabID:       nodeInfo.HerdrTabID,
+					PaneID:      nodeInfo.PaneID,
+				}, nodeInfo.PaneID)
+			}
+			if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
+				log.Printf(
+					"postman: WARNING: failed to claim pane %s: %v\n",
+					nodeInfo.PaneID, err,
+				)
+			}
+		}
+		sharedNodes.Store(&nodes)
+		return nil
+	}
 	if herdrRuntime != nil {
-		herdrRuntime.ReconcileFinalNodesForToken(herdrStartupToken, nodes)
-	}
-	if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
-		return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
-	}
-	// Claim discovered panes with this daemon's context ID.
-	for _, nodeInfo := range nodes {
-		backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
-		backend, backendErr := multiplexer.OwnershipBackendForKind(backendKind)
-		if backendErr != nil {
-			log.Printf(
-				"postman: WARNING: failed to select ownership backend for pane %s: %v\n",
-				nodeInfo.PaneID, backendErr,
-			)
-			continue
+		if err := herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes, publishStartupNodes); err != nil {
+			return fmt.Errorf("publishing Herdr startup snapshot: %w", err)
 		}
-		pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
-		if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
-			log.Printf(
-				"postman: WARNING: failed to claim pane %s: %v\n",
-				nodeInfo.PaneID, err,
-			)
-		}
+	} else if err := publishStartupNodes(); err != nil {
+		return err
 	}
 	// Shared node snapshot for background periodic refresh (Issue #139)
-	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
-	sharedNodes.Store(&nodes)
 
 	// Post-startup background re-discovery: catches panes that set their titles
 	// slightly after daemon start (agent launch scripts run after daemon starts).

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -147,6 +147,16 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	return fresh, collisions, herdrToken, nil
 }
 
+func publishFreshHerdrNodes(herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
+	if herdrRuntime != nil && !herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh) {
+		return false
+	}
+	if sharedNodes != nil {
+		sharedNodes.Store(&fresh)
+	}
+	return true
+}
+
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
 	if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
 		return herdrRuntime.SetSessionEnabledMarker(ctx, contextID, sessionName, enabled)
@@ -484,10 +494,10 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		activationNodesLocal := activationNodeNames(cfg)
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
-		if herdrRuntime != nil {
-			herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh)
+		if !publishFreshHerdrNodes(herdrRuntime, herdrToken, fresh, &sharedNodes) {
+			log.Printf("postman: startup re-discovery skipped stale Herdr snapshot (%d nodes)\n", len(fresh))
+			return
 		}
-		sharedNodes.Store(&fresh)
 		log.Printf("postman: startup re-discovery complete (%d nodes)\n", len(fresh))
 	})
 
@@ -696,11 +706,11 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
-							if herdrRuntime != nil {
-								herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)
+							if publishFreshHerdrNodes(herdrRuntime, herdrToken, freshNodes, &sharedNodes) {
+								targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
+							} else {
+								log.Printf("postman: PING refresh skipped stale Herdr snapshot (%d nodes)\n", len(freshNodes))
 							}
-							sharedNodes.Store(&freshNodes)
-							targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
 						}
 						if len(targetNodes) == 0 {
 							activatedNodes, activationErr := activateSessionForPing(baseDir, contextDir, contextID, sessionName, cmd.Target, cfg, watcher, watchedDirs)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -484,6 +484,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		activationNodesLocal := activationNodeNames(cfg)
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
+		if herdrRuntime != nil {
+			herdrRuntime.ReconcileFinalNodes(fresh)
+		}
 		sharedNodes.Store(&fresh)
 		log.Printf("postman: startup re-discovery complete (%d nodes)\n", len(fresh))
 	})
@@ -693,6 +696,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
+							if herdrRuntime != nil {
+								herdrRuntime.ReconcileFinalNodes(freshNodes)
+							}
 							sharedNodes.Store(&freshNodes)
 							targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
 						}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -136,6 +136,7 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
 	if herdrErr != nil {
 		log.Printf("⚠️  postman: herdr discovery failed: %v\n", herdrErr)
+		herdrRuntime.ClearPaneRoutes()
 		if err != nil {
 			return nil, nil, fmt.Errorf("tmux discovery failed: %w; herdr discovery failed: %v", err, herdrErr)
 		}
@@ -143,6 +144,7 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	}
 	collisions = append(collisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
 	collisions = append(collisions, herdrCollisions...)
+	herdrRuntime.ReconcileFinalNodes(fresh)
 	return fresh, collisions, nil
 }
 
@@ -440,6 +442,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	startupCollisions = append(startupCollisions, herdrStartupCollisions...)
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
+	if herdrRuntime != nil {
+		herdrRuntime.ReconcileFinalNodes(nodes)
+	}
 	// Claim discovered panes with this daemon's context ID.
 	for _, nodeInfo := range nodes {
 		backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -147,7 +147,15 @@ func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessio
 	return fresh, collisions, herdrToken, nil
 }
 
-func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) bool {
+type freshHerdrPublicationOutcome int
+
+const (
+	freshHerdrPublicationPublished freshHerdrPublicationOutcome = iota
+	freshHerdrPublicationStale
+	freshHerdrPublicationFailed
+)
+
+func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime *herdrruntime.Runtime, herdrToken uint64, fresh map[string]discovery.NodeInfo, sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]) (freshHerdrPublicationOutcome, error) {
 	prepare := func(publication *herdrruntime.FinalPublication) error {
 		for _, nodeInfo := range fresh {
 			if nodeInfo.PaneID == "" {
@@ -165,17 +173,25 @@ func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime 
 		}
 	}
 	if herdrRuntime != nil {
-		return herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, prepare, commit) == nil
+		err := herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, prepare, commit)
+		switch {
+		case err == nil:
+			return freshHerdrPublicationPublished, nil
+		case errors.Is(err, herdrruntime.ErrStaleFinalReconcileToken):
+			return freshHerdrPublicationStale, nil
+		default:
+			return freshHerdrPublicationFailed, err
+		}
 	}
 	publication := herdrruntime.NewFinalPublication()
 	if err := prepare(publication); err != nil {
 		if rollbackErr := publication.Rollback(); rollbackErr != nil {
-			log.Printf("postman: WARNING: failed to roll back fresh node ownership publication: %v\n", rollbackErr)
+			return freshHerdrPublicationFailed, errors.Join(err, fmt.Errorf("rollback failed: %w", rollbackErr))
 		}
-		return false
+		return freshHerdrPublicationFailed, err
 	}
 	commit()
-	return true
+	return freshHerdrPublicationPublished, nil
 }
 
 func paneResourceForNodeInfo(nodeInfo discovery.NodeInfo) multiplexer.ResourceID {
@@ -536,7 +552,12 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		activationNodesLocal := activationNodeNames(cfg)
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
-		if !publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, fresh, &sharedNodes) {
+		outcome, publishErr := publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, fresh, &sharedNodes)
+		switch {
+		case publishErr != nil:
+			log.Printf("postman: startup re-discovery failed to publish fresh nodes: %v\n", publishErr)
+			return
+		case outcome == freshHerdrPublicationStale:
 			log.Printf("postman: startup re-discovery skipped stale Herdr snapshot (%d nodes)\n", len(fresh))
 			return
 		}
@@ -750,9 +771,13 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
-							if publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, freshNodes, &sharedNodes) {
+							outcome, publishErr := publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, freshNodes, &sharedNodes)
+							switch {
+							case publishErr != nil:
+								log.Printf("postman: PING refresh failed to publish fresh nodes: %v\n", publishErr)
+							case outcome == freshHerdrPublicationPublished:
 								targetNodes = pingTargetsForSession(freshNodes, cmd.Target)
-							} else {
+							case outcome == freshHerdrPublicationStale:
 								log.Printf("postman: PING refresh skipped stale Herdr snapshot (%d nodes)\n", len(freshNodes))
 							}
 						}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -153,18 +153,7 @@ func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime 
 			if nodeInfo.PaneID == "" {
 				continue
 			}
-			backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
-			var backend multiplexer.OwnershipBackend
-			var err error
-			if backendKind == multiplexer.BackendKindHerdr && publication != nil {
-				backend = publication
-			} else {
-				backend, err = multiplexer.OwnershipBackendForKind(backendKind)
-				if err != nil {
-					return fmt.Errorf("selecting ownership backend for pane %s: %w", nodeInfo.PaneID, err)
-				}
-			}
-			if err := backend.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
+			if err := publication.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
 				return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
 			}
 		}
@@ -178,7 +167,11 @@ func publishFreshHerdrNodes(ctx context.Context, contextID string, herdrRuntime 
 	if herdrRuntime != nil {
 		return herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, fresh, prepare, commit) == nil
 	}
-	if err := prepare(nil); err != nil {
+	publication := herdrruntime.NewFinalPublication()
+	if err := prepare(publication); err != nil {
+		if rollbackErr := publication.Rollback(); rollbackErr != nil {
+			log.Printf("postman: WARNING: failed to roll back fresh node ownership publication: %v\n", rollbackErr)
+		}
 		return false
 	}
 	commit()
@@ -494,35 +487,16 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
 	prepareStartupNodes := func(publication *herdrruntime.FinalPublication) error {
-		if herdrRuntime != nil && herdrRuntime.OwnsSession(sessionName) {
-			if err := publication.SetSessionEnabledMarker(ctx, contextID, sessionName, true); err != nil {
-				return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
-			}
-		} else if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
+		if err := publication.SetSessionEnabledMarker(ctx, contextID, sessionName, true); err != nil {
 			return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
 		}
 		// Claim discovered panes with this daemon's context ID.
 		for _, nodeInfo := range nodes {
-			backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
-			var backend multiplexer.OwnershipBackend
-			var backendErr error
-			if backendKind == multiplexer.BackendKindHerdr && publication != nil {
-				backend = publication
-			} else {
-				backend, backendErr = multiplexer.OwnershipBackendForKind(backendKind)
-			}
-			if backendErr != nil {
-				log.Printf(
-					"postman: WARNING: failed to select ownership backend for pane %s: %v\n",
-					nodeInfo.PaneID, backendErr,
-				)
+			if nodeInfo.PaneID == "" {
 				continue
 			}
-			if err := backend.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
-				log.Printf(
-					"postman: WARNING: failed to claim pane %s: %v\n",
-					nodeInfo.PaneID, err,
-				)
+			if err := publication.SetPaneOwnerMarker(ctx, paneResourceForNodeInfo(nodeInfo), contextID); err != nil {
+				return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
 			}
 		}
 		return nil
@@ -534,9 +508,14 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		if err := herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrStartupToken, nodes, prepareStartupNodes, commitStartupNodes); err != nil {
 			return fmt.Errorf("publishing Herdr startup snapshot: %w", err)
 		}
-	} else if err := prepareStartupNodes(nil); err != nil {
-		return err
 	} else {
+		publication := herdrruntime.NewFinalPublication()
+		if err := prepareStartupNodes(publication); err != nil {
+			if rollbackErr := publication.Rollback(); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback failed: %w", err, rollbackErr)
+			}
+			return err
+		}
 		commitStartupNodes()
 	}
 	// Shared node snapshot for background periodic refresh (Issue #139)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -120,31 +120,31 @@ func logDiscoveredCollisions(collisions []discovery.CollisionReport, activationN
 	}
 }
 
-func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessionName string, herdrRuntime *herdrruntime.Runtime) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+func discoverFreshNodesWithHerdr(ctx context.Context, baseDir, contextID, sessionName string, herdrRuntime *herdrruntime.Runtime) (map[string]discovery.NodeInfo, []discovery.CollisionReport, uint64, error) {
 	fresh, collisions, err := discovery.DiscoverNodesWithCollisions(baseDir, contextID, sessionName)
 	if err != nil {
 		if herdrRuntime == nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		log.Printf("⚠️  postman: tmux discovery failed before Herdr refresh: %v\n", err)
 		fresh = make(map[string]discovery.NodeInfo)
 		collisions = nil
 	}
 	if herdrRuntime == nil {
-		return fresh, collisions, nil
+		return fresh, collisions, 0, nil
 	}
-	herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)
+	herdrNodes, herdrCollisions, herdrToken, herdrErr := herdrRuntime.DiscoverForReconcile(ctx, baseDir, contextID)
 	if herdrErr != nil {
 		log.Printf("⚠️  postman: herdr discovery failed: %v\n", herdrErr)
-		herdrRuntime.ClearPaneRoutes()
+		herdrRuntime.ClearPaneRoutesForToken(herdrToken)
 		if err != nil {
-			return nil, nil, fmt.Errorf("tmux discovery failed: %w; herdr discovery failed: %v", err, herdrErr)
+			return nil, nil, herdrToken, fmt.Errorf("tmux discovery failed: %w; herdr discovery failed: %v", err, herdrErr)
 		}
-		return fresh, collisions, nil
+		return fresh, collisions, herdrToken, nil
 	}
 	collisions = append(collisions, mergeDiscoveredNodes(fresh, herdrNodes)...)
 	collisions = append(collisions, herdrCollisions...)
-	return fresh, collisions, nil
+	return fresh, collisions, herdrToken, nil
 }
 
 func setSessionEnabledMarkerWithRuntime(ctx context.Context, herdrRuntime *herdrruntime.Runtime, contextID, sessionName string, enabled bool) error {
@@ -357,8 +357,9 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	defer herdrRuntime.Close()
 	var herdrStartupNodes map[string]discovery.NodeInfo
 	var herdrStartupCollisions []discovery.CollisionReport
+	var herdrStartupToken uint64
 	if herdrRuntime != nil {
-		herdrStartupNodes, herdrStartupCollisions, err = herdrRuntime.Discover(ctx, baseDir, contextID)
+		herdrStartupNodes, herdrStartupCollisions, herdrStartupToken, err = herdrRuntime.DiscoverForReconcile(ctx, baseDir, contextID)
 		if err != nil {
 			return fmt.Errorf("discovering herdr runtime: %w", err)
 		}
@@ -439,7 +440,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 	activationNodes := activationNodeNames(cfg)
 	nodes = filterDiscoveredActivationNodes(nodes, activationNodes)
 	if herdrRuntime != nil {
-		herdrRuntime.ReconcileFinalNodes(nodes)
+		herdrRuntime.ReconcileFinalNodesForToken(herdrStartupToken, nodes)
 	}
 	if err := setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true); err != nil {
 		return fmt.Errorf("publishing enabled-session marker for %s: %w", sessionName, err)
@@ -475,7 +476,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 				log.Printf("🚨 startup-rediscovery panic: %v\n", r)
 			}
 		}()
-		fresh, freshCollisions, err := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
+		fresh, freshCollisions, herdrToken, err := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
 		if err != nil {
 			log.Printf("⚠️  postman: startup re-discovery failed: %v\n", err)
 			return
@@ -484,7 +485,7 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 		logDiscoveredCollisions(freshCollisions, activationNodesLocal)
 		fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)
 		if herdrRuntime != nil {
-			herdrRuntime.ReconcileFinalNodes(fresh)
+			herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh)
 		}
 		sharedNodes.Store(&fresh)
 		log.Printf("postman: startup re-discovery complete (%d nodes)\n", len(fresh))
@@ -691,12 +692,12 @@ func RunStartWithFlags(contextID, configPath, logFilePath string) error {
 						activationBlocked := false
 						// Attempt a fresh discovery before giving up (catches panes
 						// that set titles after startup or after the last scan).
-						freshDiscovered, freshCollisions, discErr := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
+						freshDiscovered, freshCollisions, herdrToken, discErr := discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)
 						if discErr == nil {
 							logDiscoveredCollisions(freshCollisions, activationNodesFilter)
 							freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)
 							if herdrRuntime != nil {
-								herdrRuntime.ReconcileFinalNodes(freshNodes)
+								herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)
 							}
 							sharedNodes.Store(&freshNodes)
 							targetNodes = pingTargetsForSession(freshNodes, cmd.Target)

--- a/internal/cli/start_ping_activation_test.go
+++ b/internal/cli/start_ping_activation_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 )
 
 func TestActivateSessionForPing_ActivatesUnownedForeignSession(t *testing.T) {
@@ -341,6 +343,86 @@ func TestActivateSessionForPing_RejectsSameUserOwnedSession(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(contextDir, targetSession)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("self dotfiles dir exists unexpectedly: %v", err)
 	}
+}
+
+func TestActivateSessionForPing_RejectsHerdrOwnedSession(t *testing.T) {
+	root := t.TempDir()
+	baseDir := filepath.Join(root, "state")
+	contextID := "ctx-self"
+	selfSession := "tmux-a2a-postman"
+	targetSession := "dotfiles"
+	contextDir := filepath.Join(baseDir, contextID)
+	if err := config.CreateMultiSessionDirs(contextDir, selfSession); err != nil {
+		t.Fatalf("CreateMultiSessionDirs(self): %v", err)
+	}
+
+	ownerContext := "ctx-owner"
+	ownerDir := filepath.Join(baseDir, ownerContext, targetSession)
+	if err := os.MkdirAll(ownerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(ownerDir): %v", err)
+	}
+	if err := config.WriteSessionPIDFile(filepath.Join(ownerDir, "postman.pid"), os.Getpid()); err != nil {
+		t.Fatalf("WriteFile(postman.pid): %v", err)
+	}
+	backend := &fakeActivationHerdrOwnerBackend{owners: map[string]string{
+		targetSession: ownerContext + ":43210",
+	}}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig()
+	cfg.Edges = []string{"orchestrator --- messenger"}
+
+	_, err := activateSessionForPing(baseDir, contextDir, contextID, selfSession, targetSession, cfg, nil, nil)
+	if err == nil {
+		t.Fatal("activateSessionForPing() error = nil, want Herdr ownership rejection")
+	}
+	if !errors.Is(err, errPingSessionOwned) {
+		t.Fatalf("activateSessionForPing() error = %v, want errPingSessionOwned", err)
+	}
+	if _, err := os.Stat(filepath.Join(contextDir, targetSession)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("self dotfiles dir exists unexpectedly: %v", err)
+	}
+}
+
+type fakeActivationHerdrOwnerBackend struct {
+	owners map[string]string
+}
+
+func (f *fakeActivationHerdrOwnerBackend) Kind() multiplexer.BackendKind {
+	return multiplexer.BackendKindHerdr
+}
+
+func (f *fakeActivationHerdrOwnerBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {
+	return f.owners[sessionName], nil
+}
+
+func (f *fakeActivationHerdrOwnerBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+	return nil
+}
+
+func (f *fakeActivationHerdrOwnerBackend) ClearSessionOwnerMarker(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeActivationHerdrOwnerBackend) PaneOwnerMarker(context.Context, multiplexer.ResourceID) (string, error) {
+	return "", nil
+}
+
+func (f *fakeActivationHerdrOwnerBackend) SetPaneOwnerMarker(context.Context, multiplexer.ResourceID, string) error {
+	return nil
+}
+
+func (f *fakeActivationHerdrOwnerBackend) ClearPaneOwnerMarker(context.Context, multiplexer.ResourceID) error {
+	return nil
 }
 
 func TestActivateSessionForPing_PreservesBareEdgeKeys(t *testing.T) {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/lock"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 )
 
@@ -41,6 +42,44 @@ func isolateConfigLookup(t *testing.T, root string) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "xdg"))
 	t.Setenv("HOME", filepath.Join(root, "home"))
 	t.Chdir(root)
+}
+
+func TestMergeDiscoveredNodesReportsCrossBackendCollisionWithoutOverwrite(t *testing.T) {
+	nodes := map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:      "%1",
+			SessionName: "work",
+			Backend:     string(multiplexer.BackendKindTmux),
+		},
+	}
+	collisions := mergeDiscoveredNodes(nodes, map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:      "workspace-1:pane-1",
+			SessionName: "work",
+			Backend:     string(multiplexer.BackendKindHerdr),
+		},
+	})
+
+	if got := nodes["work:worker"].PaneID; got != "%1" {
+		t.Fatalf("node pane = %q, want original tmux pane", got)
+	}
+	if len(collisions) != 1 {
+		t.Fatalf("collisions = %#v, want one cross-backend collision", collisions)
+	}
+	if collisions[0].NodeKey != "work:worker" || collisions[0].WinnerPaneID != "%1" || collisions[0].LoserPaneID != "workspace-1:pane-1" {
+		t.Fatalf("collision = %#v, want tmux winner and Herdr loser", collisions[0])
+	}
+}
+
+func TestRunStartWithFlags_SourceContractUsesProductionHerdrSocketClient(t *testing.T) {
+	source := readRepoFile(t, "internal/cli/start.go")
+
+	if !strings.Contains(source, "newHerdrRuntimeClient herdrruntime.ClientFactory = herdrruntime.NewSocketClient") {
+		t.Fatal("start.go no longer wires the production Herdr socket client factory")
+	}
+	if strings.Contains(source, "herdr socket client is not configured") {
+		t.Fatal("start.go still contains the disabled Herdr client stub")
+	}
 }
 
 func TestRunStartWithFlags_RejectsDuplicateDaemonForSameSession(t *testing.T) {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,6 +70,42 @@ func TestMergeDiscoveredNodesReportsCrossBackendCollisionWithoutOverwrite(t *tes
 	}
 	if collisions[0].NodeKey != "work:worker" || collisions[0].WinnerPaneID != "%1" || collisions[0].LoserPaneID != "workspace-1:pane-1" {
 		t.Fatalf("collision = %#v, want tmux winner and Herdr loser", collisions[0])
+	}
+}
+
+func TestLogDiscoveredCollisionsReportsHerdrRediscoveryAndManualPingCollisions(t *testing.T) {
+	var buf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(originalOutput) })
+
+	collisions := []discovery.CollisionReport{{
+		NodeKey:      "work:worker",
+		WinnerPaneID: "%1",
+		LoserPaneID:  "workspace-1:pane-1",
+	}}
+	activationNodes := map[string]bool{"worker": true}
+
+	logDiscoveredCollisions(collisions, activationNodes)
+	logDiscoveredCollisions(collisions, activationNodes)
+
+	got := buf.String()
+	if strings.Count(got, "pane collision: work:worker: workspace-1:pane-1 displaced by %1") != 2 {
+		t.Fatalf("collision log output = %q, want startup rediscovery and manual PING reports", got)
+	}
+}
+
+func TestRunStartWithFlags_SourceContractReportsHerdrCollisionsAfterStartupRediscoveryAndManualPing(t *testing.T) {
+	source := readRepoFile(t, "internal/cli/start.go")
+
+	if !strings.Contains(source, "herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)") {
+		t.Fatal("startup re-discovery no longer collects Herdr collision reports with bounded context")
+	}
+	if !strings.Contains(source, "freshCollisions = append(freshCollisions, herdrCollisions...)") {
+		t.Fatal("Herdr collision reports are no longer appended before rediscovery/manual PING logging")
+	}
+	if strings.Contains(source, "herdrRuntime.Discover(context.Background(), baseDir, contextID)") {
+		t.Fatal("start.go still uses an unbounded background context for Herdr discovery")
 	}
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -98,6 +99,7 @@ func TestLogDiscoveredCollisionsReportsHerdrRediscoveryAndManualPingCollisions(t
 }
 
 func TestDiscoverFreshNodesWithHerdrReportsDuplicateCollisionsWhenTmuxDiscoveryEmpty(t *testing.T) {
+	t.Setenv("PATH", "")
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
 	sessionName := "work"
@@ -124,6 +126,38 @@ func TestDiscoverFreshNodesWithHerdrReportsDuplicateCollisionsWhenTmuxDiscoveryE
 	}
 	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
 		t.Fatalf("collisions = %#v, want Herdr-only duplicate collision despite empty tmux discovery", collisions)
+	}
+}
+
+func TestDiscoverFreshNodesWithHerdrReturnsErrorWhenTmuxAndHerdrDiscoveryFail(t *testing.T) {
+	t.Setenv("PATH", "")
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	herdrErr := errors.New("herdr unavailable")
+	client := &fakeCLIHerdrClient{
+		snapshot:    validCLIDuplicateHerdrSnapshot(),
+		snapshotErr: herdrErr,
+	}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validCLIHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, collisions, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
+	if err == nil {
+		t.Fatal("discoverFreshNodesWithHerdr() error = nil, want combined tmux+Herdr discovery error")
+	}
+	if !strings.Contains(err.Error(), "tmux discovery failed") || !strings.Contains(err.Error(), "herdr discovery failed") {
+		t.Fatalf("error = %v, want both discovery failures preserved", err)
+	}
+	if nodes != nil || collisions != nil {
+		t.Fatalf("nodes=%#v collisions=%#v, want nil results on dual discovery failure", nodes, collisions)
 	}
 }
 
@@ -912,7 +946,8 @@ func assertPathMissing(t *testing.T, path string) {
 }
 
 type fakeCLIHerdrClient struct {
-	snapshot multiplexer.HerdrSessionSnapshot
+	snapshot    multiplexer.HerdrSessionSnapshot
+	snapshotErr error
 }
 
 func (f *fakeCLIHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
@@ -920,6 +955,9 @@ func (f *fakeCLIHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnv
 }
 
 func (f *fakeCLIHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	if f.snapshotErr != nil {
+		return multiplexer.HerdrSessionSnapshot{}, f.snapshotErr
+	}
 	return f.snapshot, nil
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -626,7 +626,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	if strings.Contains(source, "config.IsSessionPIDAlive(baseDir, claimedContext, paneSessionName)") {
 		t.Fatal("start.go still clears foreign pane claims from a raw PID check")
 	}
-	markerIndex := strings.Index(source, `config.SetSessionEnabledMarker(contextID, sessionName, true)`)
+	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
 	if markerIndex == -1 {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/autoping"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/lock"
@@ -95,17 +97,50 @@ func TestLogDiscoveredCollisionsReportsHerdrRediscoveryAndManualPingCollisions(t
 	}
 }
 
+func TestDiscoverFreshNodesWithHerdrReportsDuplicateCollisionsWhenTmuxDiscoveryEmpty(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+	client := &fakeCLIHerdrClient{snapshot: validCLIDuplicateHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validCLIHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, collisions, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
+	if err != nil {
+		t.Fatalf("discoverFreshNodesWithHerdr() error = %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("nodes = %#v, want duplicate Herdr claims to remain unroutable", nodes)
+	}
+	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
+		t.Fatalf("collisions = %#v, want Herdr-only duplicate collision despite empty tmux discovery", collisions)
+	}
+}
+
 func TestRunStartWithFlags_SourceContractReportsHerdrCollisionsAfterStartupRediscoveryAndManualPing(t *testing.T) {
 	source := readRepoFile(t, "internal/cli/start.go")
 
-	if !strings.Contains(source, "herdrNodes, herdrCollisions, herdrErr := herdrRuntime.Discover(ctx, baseDir, contextID)") {
-		t.Fatal("startup re-discovery no longer collects Herdr collision reports with bounded context")
+	if !strings.Contains(source, "discoverFreshNodesWithHerdr(ctx, baseDir, contextID, sessionName, herdrRuntime)") {
+		t.Fatal("startup/manual rediscovery no longer uses the shared Herdr collision helper")
 	}
-	if !strings.Contains(source, "freshCollisions = append(freshCollisions, herdrCollisions...)") {
+	if !strings.Contains(source, "collisions = append(collisions, herdrCollisions...)") {
 		t.Fatal("Herdr collision reports are no longer appended before rediscovery/manual PING logging")
 	}
 	if strings.Contains(source, "herdrRuntime.Discover(context.Background(), baseDir, contextID)") {
 		t.Fatal("start.go still uses an unbounded background context for Herdr discovery")
+	}
+	if strings.Contains(source, "discErr == nil && len(freshDiscovered) > 0") {
+		t.Fatal("manual PING still skips Herdr discovery when tmux discovery returns zero nodes")
 	}
 }
 
@@ -873,5 +908,74 @@ func assertPathMissing(t *testing.T, path string) {
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("Stat(%q) error = %v, want not exists", path, err)
+	}
+}
+
+type fakeCLIHerdrClient struct {
+	snapshot multiplexer.HerdrSessionSnapshot
+}
+
+func (f *fakeCLIHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}, nil
+}
+
+func (f *fakeCLIHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeCLIHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func validCLIHerdrConfig() config.HerdrConfig {
+	return config.HerdrConfig{
+		Enabled:                 true,
+		SocketPath:              "/tmp/herdr.sock",
+		SessionName:             "work",
+		WorkspaceID:             "workspace-1",
+		AllowedSocketPaths:      []string{"/tmp/herdr.sock"},
+		AllowedSessions:         []string{"work"},
+		AllowedWorkspaceIDs:     []string{"workspace-1"},
+		AllowedProtocolVersions: []string{"1"},
+		AllowedSchemaVersions:   []int{1},
+		ReadEnabled:             true,
+		WriteEnabled:            true,
+		InputSanitizerReady:     true,
+		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionAGPL),
+	}
+}
+
+func validCLIDuplicateHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
+	return multiplexer.HerdrSessionSnapshot{
+		Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
+		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
+			ID:       "workspace-1",
+			Metadata: map[string]string{},
+		}},
+		Tabs: []multiplexer.HerdrTabSnapshot{{
+			ID:          "workspace-1:tab-1",
+			WorkspaceID: "workspace-1",
+			Metadata:    map[string]string{},
+		}},
+		Panes: []multiplexer.HerdrPaneSnapshot{
+			{
+				ID:          "workspace-1:pane-1",
+				WorkspaceID: "workspace-1",
+				TabID:       "workspace-1:tab-1",
+				PostmanNode: "worker",
+				ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+			},
+			{
+				ID:          "workspace-1:pane-2",
+				WorkspaceID: "workspace-1",
+				TabID:       "workspace-1:tab-1",
+				PostmanNode: "worker",
+				ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+			},
+		},
 	}
 }

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -860,7 +860,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	if strings.Contains(source, "config.IsSessionPIDAlive(baseDir, claimedContext, paneSessionName)") {
 		t.Fatal("start.go still clears foreign pane claims from a raw PID check")
 	}
-	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
+	markerIndex := strings.Index(source, `publication.SetSessionEnabledMarker(ctx, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
 	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrStartupToken, nodes")
@@ -882,6 +882,9 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	}
 	if markerIndex > claimIndex {
 		t.Fatal("start.go publishes the enabled-session marker after pane ownership claims")
+	}
+	if strings.Contains(source[claimIndex:reconcileIndex], "failed to claim pane") {
+		t.Fatal("startup pane ownership claims still log and continue instead of rejecting prepare")
 	}
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -198,16 +199,70 @@ func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering
 	if firstFilter == -1 {
 		t.Fatal("startup rediscovery activation filter not found")
 	}
-	if !strings.Contains(source[firstFilter:], "herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh)") {
-		t.Fatal("startup rediscovery no longer reconciles Herdr routes after activation filtering")
+	if !strings.Contains(source[firstFilter:], "publishFreshHerdrNodes(herdrRuntime, herdrToken, fresh, &sharedNodes)") {
+		t.Fatal("startup rediscovery no longer publishes Herdr routes after activation filtering")
 	}
 
 	secondFilter := strings.Index(source, "freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)")
 	if secondFilter == -1 {
 		t.Fatal("on-demand refresh activation filter not found")
 	}
-	if !strings.Contains(source[secondFilter:], "herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)") {
-		t.Fatal("on-demand refresh no longer reconciles Herdr routes after activation filtering")
+	if !strings.Contains(source[secondFilter:], "publishFreshHerdrNodes(herdrRuntime, herdrToken, freshNodes, &sharedNodes)") {
+		t.Fatal("on-demand refresh no longer publishes Herdr routes after activation filtering")
+	}
+}
+
+func TestPublishFreshHerdrNodesRejectsStaleCLIRefreshSnapshot(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeCLIHerdrClient{snapshot: cliHerdrSnapshotFor("workspace-1:pane-old")}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validCLIHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldNodes, _, oldToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("old DiscoverForReconcile() error = %v", err)
+	}
+	client.snapshot = cliHerdrSnapshotFor("workspace-1:pane-new")
+	newNodes, _, newToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("new DiscoverForReconcile() error = %v", err)
+	}
+
+	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
+	if !publishFreshHerdrNodes(rt, newToken, newNodes, &sharedNodes) {
+		t.Fatal("publishFreshHerdrNodes(new) = false, want true")
+	}
+	if publishFreshHerdrNodes(rt, oldToken, oldNodes, &sharedNodes) {
+		t.Fatal("publishFreshHerdrNodes(old) = true, want stale rejection")
+	}
+
+	loaded := sharedNodes.Load()
+	if loaded == nil {
+		t.Fatal("sharedNodes.Load() = nil")
+	}
+	if got := (*loaded)["work:worker"].PaneID; got != "workspace-1:pane-new" {
+		t.Fatalf("sharedNodes work:worker pane = %q, want newest pane", got)
+	}
+	oldTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-old"}}
+	if _, err := controlplane.DefaultHandAdapter(oldTarget); err == nil {
+		t.Fatal("stale CLI refresh registered old Herdr route")
+	}
+	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("new CLI refresh route missing after stale publish attempt: %v", err)
 	}
 }
 
@@ -1038,6 +1093,24 @@ func validCLIHerdrConfig() config.HerdrConfig {
 }
 
 func validCLIDuplicateHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
+	return cliHerdrSnapshotWithPanes("workspace-1:pane-1", "workspace-1:pane-2")
+}
+
+func cliHerdrSnapshotFor(paneID string) multiplexer.HerdrSessionSnapshot {
+	return cliHerdrSnapshotWithPanes(paneID)
+}
+
+func cliHerdrSnapshotWithPanes(paneIDs ...string) multiplexer.HerdrSessionSnapshot {
+	panes := make([]multiplexer.HerdrPaneSnapshot, 0, len(paneIDs))
+	for _, paneID := range paneIDs {
+		panes = append(panes, multiplexer.HerdrPaneSnapshot{
+			ID:          paneID,
+			WorkspaceID: "workspace-1",
+			TabID:       "workspace-1:tab-1",
+			PostmanNode: "worker",
+			ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+		})
+	}
 	return multiplexer.HerdrSessionSnapshot{
 		Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
 		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
@@ -1049,21 +1122,6 @@ func validCLIDuplicateHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
 			WorkspaceID: "workspace-1",
 			Metadata:    map[string]string{},
 		}},
-		Panes: []multiplexer.HerdrPaneSnapshot{
-			{
-				ID:          "workspace-1:pane-1",
-				WorkspaceID: "workspace-1",
-				TabID:       "workspace-1:tab-1",
-				PostmanNode: "worker",
-				ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
-			},
-			{
-				ID:          "workspace-1:pane-2",
-				WorkspaceID: "workspace-1",
-				TabID:       "workspace-1:tab-1",
-				PostmanNode: "worker",
-				ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
-			},
-		},
+		Panes: panes,
 	}
 }

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -178,6 +178,25 @@ func TestRunStartWithFlags_SourceContractReportsHerdrCollisionsAfterStartupRedis
 	}
 }
 
+func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering(t *testing.T) {
+	source := readRepoFile(t, "internal/cli/start.go")
+	firstFilter := strings.Index(source, "fresh = filterDiscoveredActivationNodes(fresh, activationNodesLocal)")
+	if firstFilter == -1 {
+		t.Fatal("startup rediscovery activation filter not found")
+	}
+	if !strings.Contains(source[firstFilter:], "herdrRuntime.ReconcileFinalNodes(fresh)") {
+		t.Fatal("startup rediscovery no longer reconciles Herdr routes after activation filtering")
+	}
+
+	secondFilter := strings.Index(source, "freshNodes = filterDiscoveredActivationNodes(freshDiscovered, activationNodesFilter)")
+	if secondFilter == -1 {
+		t.Fatal("on-demand refresh activation filter not found")
+	}
+	if !strings.Contains(source[secondFilter:], "herdrRuntime.ReconcileFinalNodes(freshNodes)") {
+		t.Fatal("on-demand refresh no longer reconciles Herdr routes after activation filtering")
+	}
+}
+
 func TestRunStartWithFlags_SourceContractUsesProductionHerdrSocketClient(t *testing.T) {
 	source := readRepoFile(t, "internal/cli/start.go")
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -863,7 +863,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
-	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForToken(herdrStartupToken, nodes)")
+	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes")
 	claimIndex := strings.Index(source, "// Claim discovered panes with this daemon's context ID.")
 	if markerIndex == -1 {
 		t.Fatal("start.go no longer publishes the enabled-session marker during cold start")
@@ -877,7 +877,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	if markerIndex < discoveryIndex {
 		t.Fatal("start.go publishes the enabled-session marker before startup discovery")
 	}
-	if markerIndex < reconcileIndex {
+	if !strings.Contains(source, "herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes, publishStartupNodes)") {
 		t.Fatal("start.go publishes the enabled-session marker before Herdr final reconciliation")
 	}
 	if markerIndex > claimIndex {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -118,7 +118,7 @@ func TestDiscoverFreshNodesWithHerdrReportsDuplicateCollisionsWhenTmuxDiscoveryE
 	}
 	t.Cleanup(rt.Close)
 
-	nodes, collisions, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
+	nodes, collisions, _, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
 	if err != nil {
 		t.Fatalf("discoverFreshNodesWithHerdr() error = %v", err)
 	}
@@ -163,7 +163,7 @@ func TestDiscoverFreshNodesWithHerdrReturnsErrorWhenTmuxAndHerdrDiscoveryFail(t 
 	}
 	t.Cleanup(rt.Close)
 
-	nodes, collisions, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
+	nodes, collisions, _, err := discoverFreshNodesWithHerdr(context.Background(), baseDir, contextID, sessionName, rt)
 	if err == nil {
 		t.Fatal("discoverFreshNodesWithHerdr() error = nil, want combined tmux+Herdr discovery error")
 	}
@@ -198,7 +198,7 @@ func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering
 	if firstFilter == -1 {
 		t.Fatal("startup rediscovery activation filter not found")
 	}
-	if !strings.Contains(source[firstFilter:], "herdrRuntime.ReconcileFinalNodes(fresh)") {
+	if !strings.Contains(source[firstFilter:], "herdrRuntime.ReconcileFinalNodesForToken(herdrToken, fresh)") {
 		t.Fatal("startup rediscovery no longer reconciles Herdr routes after activation filtering")
 	}
 
@@ -206,7 +206,7 @@ func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering
 	if secondFilter == -1 {
 		t.Fatal("on-demand refresh activation filter not found")
 	}
-	if !strings.Contains(source[secondFilter:], "herdrRuntime.ReconcileFinalNodes(freshNodes)") {
+	if !strings.Contains(source[secondFilter:], "herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)") {
 		t.Fatal("on-demand refresh no longer reconciles Herdr routes after activation filtering")
 	}
 }
@@ -808,7 +808,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
-	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodes(nodes)")
+	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForToken(herdrStartupToken, nodes)")
 	claimIndex := strings.Index(source, "// Claim discovered panes with this daemon's context ID.")
 	if markerIndex == -1 {
 		t.Fatal("start.go no longer publishes the enabled-session marker during cold start")

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -989,6 +989,8 @@ func (f *fakeCLIHerdrClient) PaneProcessInfo(context.Context, string) (multiplex
 }
 
 func validCLIHerdrConfig() config.HerdrConfig {
+	revalidatedAt := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	decidedAt := revalidatedAt.Add(-time.Hour)
 	return config.HerdrConfig{
 		Enabled:                 true,
 		SocketPath:              "/tmp/herdr.sock",
@@ -1005,8 +1007,8 @@ func validCLIHerdrConfig() config.HerdrConfig {
 		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionRecorded),
 		ComplianceAuthorizedBy:  "test-authority",
 		ComplianceDecisionID:    "decision-001",
-		ComplianceDecidedAt:     "2026-08-12T00:00:00Z",
-		ComplianceRevalidatedAt: "2026-08-12T00:00:00Z",
+		ComplianceDecidedAt:     decidedAt.Format(time.RFC3339),
+		ComplianceRevalidatedAt: revalidatedAt.Format(time.RFC3339),
 		ComplianceCurrentReferences: []string{
 			"https://github.com/ogulcancelik/herdr/blob/master/LICENSE",
 		},

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -808,17 +808,25 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
+	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodes(nodes)")
+	claimIndex := strings.Index(source, "// Claim discovered panes with this daemon's context ID.")
 	if markerIndex == -1 {
 		t.Fatal("start.go no longer publishes the enabled-session marker during cold start")
 	}
-	if reclaimIndex == -1 || discoveryIndex == -1 {
+	if reclaimIndex == -1 || discoveryIndex == -1 || reconcileIndex == -1 || claimIndex == -1 {
 		t.Fatal("start.go startup ordering markers changed; update the source contract test")
 	}
-	if markerIndex > reclaimIndex {
-		t.Fatal("start.go still publishes the enabled-session marker after pane-claim reclaim begins")
+	if markerIndex < reclaimIndex {
+		t.Fatal("start.go publishes the enabled-session marker before pane-claim reclaim")
 	}
-	if markerIndex > discoveryIndex {
-		t.Fatal("start.go still publishes the enabled-session marker after startup discovery begins")
+	if markerIndex < discoveryIndex {
+		t.Fatal("start.go publishes the enabled-session marker before startup discovery")
+	}
+	if markerIndex < reconcileIndex {
+		t.Fatal("start.go publishes the enabled-session marker before Herdr final reconciliation")
+	}
+	if markerIndex > claimIndex {
+		t.Fatal("start.go publishes the enabled-session marker after pane ownership claims")
 	}
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -242,11 +242,13 @@ func TestPublishFreshHerdrNodesRejectsStaleCLIRefreshSnapshot(t *testing.T) {
 	}
 
 	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
-	if !publishFreshHerdrNodes(context.Background(), contextID, rt, newToken, newNodes, &sharedNodes) {
-		t.Fatal("publishFreshHerdrNodes(new) = false, want true")
+	outcome, err := publishFreshHerdrNodes(context.Background(), contextID, rt, newToken, newNodes, &sharedNodes)
+	if err != nil || outcome != freshHerdrPublicationPublished {
+		t.Fatalf("publishFreshHerdrNodes(new) = %v, %v; want published", outcome, err)
 	}
-	if publishFreshHerdrNodes(context.Background(), contextID, rt, oldToken, oldNodes, &sharedNodes) {
-		t.Fatal("publishFreshHerdrNodes(old) = true, want stale rejection")
+	outcome, err = publishFreshHerdrNodes(context.Background(), contextID, rt, oldToken, oldNodes, &sharedNodes)
+	if err != nil || outcome != freshHerdrPublicationStale {
+		t.Fatalf("publishFreshHerdrNodes(old) = %v, %v; want stale rejection", outcome, err)
 	}
 
 	loaded := sharedNodes.Load()
@@ -263,6 +265,84 @@ func TestPublishFreshHerdrNodesRejectsStaleCLIRefreshSnapshot(t *testing.T) {
 	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
 	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
 		t.Fatalf("new CLI refresh route missing after stale publish attempt: %v", err)
+	}
+}
+
+func TestPublishFreshHerdrNodesNoRuntimeReturnsPrepareFailureAndKeepsSharedNodes(t *testing.T) {
+	claimErr := errors.New("claim failed")
+	backend := &fakeCLIOwnershipBackend{
+		kind:        multiplexer.BackendKindHerdr,
+		paneMarkers: map[string]string{"workspace-1:pane-1": "ctx-old"},
+		failSetFor:  "ctx-new",
+		failSetErr:  claimErr,
+	}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	oldNodes := map[string]discovery.NodeInfo{"work:worker": {PaneID: "workspace-old:pane-1"}}
+	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
+	sharedNodes.Store(&oldNodes)
+	fresh := map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:           "workspace-1:pane-1",
+			SessionName:      "work",
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  "/tmp/herdr.sock",
+			HerdrWorkspaceID: "workspace-1",
+			HerdrTabID:       "workspace-1:tab-1",
+		},
+	}
+
+	outcome, err := publishFreshHerdrNodes(context.Background(), "ctx-new", nil, 0, fresh, &sharedNodes)
+
+	if outcome != freshHerdrPublicationFailed {
+		t.Fatalf("publishFreshHerdrNodes() outcome = %v, want failed", outcome)
+	}
+	if !errors.Is(err, claimErr) {
+		t.Fatalf("publishFreshHerdrNodes() error = %v, want claim failure", err)
+	}
+	if got := backend.paneMarkers["workspace-1:pane-1"]; got != "ctx-old" {
+		t.Fatalf("pane marker after failed no-runtime publish = %q, want restored ctx-old", got)
+	}
+	if loaded := sharedNodes.Load(); loaded == nil || (*loaded)["work:worker"].PaneID != "workspace-old:pane-1" {
+		t.Fatalf("sharedNodes after failed no-runtime publish = %#v, want prior snapshot", loaded)
+	}
+}
+
+func TestPublishFreshHerdrNodesNoRuntimeReturnsRollbackFailure(t *testing.T) {
+	claimErr := errors.New("claim failed")
+	rollbackErr := errors.New("rollback failed")
+	backend := &fakeCLIOwnershipBackend{
+		kind:        multiplexer.BackendKindHerdr,
+		paneMarkers: map[string]string{},
+		failSetFor:  "ctx-new",
+		failSetErr:  claimErr,
+		clearErr:    rollbackErr,
+	}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	fresh := map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:           "workspace-1:pane-1",
+			SessionName:      "work",
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  "/tmp/herdr.sock",
+			HerdrWorkspaceID: "workspace-1",
+			HerdrTabID:       "workspace-1:tab-1",
+		},
+	}
+
+	outcome, err := publishFreshHerdrNodes(context.Background(), "ctx-new", nil, 0, fresh, nil)
+
+	if outcome != freshHerdrPublicationFailed {
+		t.Fatalf("publishFreshHerdrNodes() outcome = %v, want failed", outcome)
+	}
+	if !errors.Is(err, claimErr) {
+		t.Fatalf("publishFreshHerdrNodes() error = %v, want claim failure", err)
+	}
+	if !errors.Is(err, rollbackErr) {
+		t.Fatalf("publishFreshHerdrNodes() error = %v, want rollback failure", err)
 	}
 }
 
@@ -1090,6 +1170,53 @@ func (f *fakeCLIHerdrClient) SetPaneMetadata(context.Context, string, string, st
 
 func (f *fakeCLIHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+type fakeCLIOwnershipBackend struct {
+	kind        multiplexer.BackendKind
+	paneMarkers map[string]string
+	failSetFor  string
+	failSetErr  error
+	clearErr    error
+}
+
+func (f *fakeCLIOwnershipBackend) Kind() multiplexer.BackendKind {
+	return f.kind
+}
+
+func (f *fakeCLIOwnershipBackend) SessionOwnerMarker(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCLIOwnershipBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+	return nil
+}
+
+func (f *fakeCLIOwnershipBackend) ClearSessionOwnerMarker(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeCLIOwnershipBackend) PaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) (string, error) {
+	return f.paneMarkers[pane.Native], nil
+}
+
+func (f *fakeCLIOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID, contextID string) error {
+	if f.paneMarkers == nil {
+		f.paneMarkers = make(map[string]string)
+	}
+	f.paneMarkers[pane.Native] = contextID
+	if contextID == f.failSetFor {
+		return f.failSetErr
+	}
+	return nil
+}
+
+func (f *fakeCLIOwnershipBackend) ClearPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) error {
+	if f.clearErr != nil {
+		return f.clearErr
+	}
+	delete(f.paneMarkers, pane.Native)
+	return nil
 }
 
 func validCLIHerdrConfig() config.HerdrConfig {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/autoping"
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
@@ -126,6 +127,19 @@ func TestDiscoverFreshNodesWithHerdrReportsDuplicateCollisionsWhenTmuxDiscoveryE
 	}
 	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
 		t.Fatalf("collisions = %#v, want Herdr-only duplicate collision despite empty tmux discovery", collisions)
+	}
+	for _, paneID := range []string{"workspace-1:pane-1", "workspace-1:pane-2"} {
+		target := controlplane.TargetForNode(sessionName+":worker", discovery.NodeInfo{
+			PaneID:           paneID,
+			SessionName:      sessionName,
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  cfg.Herdr.SocketPath,
+			HerdrWorkspaceID: cfg.Herdr.WorkspaceID,
+			HerdrTabID:       "workspace-1:tab-1",
+		})
+		if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+			t.Fatalf("startup Herdr duplicate candidate %q was addressable before final acceptance", paneID)
+		}
 	}
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -863,7 +863,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	markerIndex := strings.Index(source, `setSessionEnabledMarkerWithRuntime(ctx, herdrRuntime, contextID, sessionName, true)`)
 	reclaimIndex := strings.Index(source, "// Reclaim panes from dead daemon contexts (#272)")
 	discoveryIndex := strings.Index(source, "// Discover nodes at startup (before watching, edge-filtered)")
-	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes")
+	reconcileIndex := strings.Index(source, "herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrStartupToken, nodes")
 	claimIndex := strings.Index(source, "// Claim discovered panes with this daemon's context ID.")
 	if markerIndex == -1 {
 		t.Fatal("start.go no longer publishes the enabled-session marker during cold start")
@@ -877,7 +877,7 @@ func TestRunStartWithFlags_SourceContractKeepsUnreadInboxAndOwnershipGuard(t *te
 	if markerIndex < discoveryIndex {
 		t.Fatal("start.go publishes the enabled-session marker before startup discovery")
 	}
-	if !strings.Contains(source, "herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrStartupToken, nodes, publishStartupNodes)") {
+	if !strings.Contains(source, "herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrStartupToken, nodes, prepareStartupNodes, commitStartupNodes)") {
 		t.Fatal("start.go publishes the enabled-session marker before Herdr final reconciliation")
 	}
 	if markerIndex > claimIndex {

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -983,7 +983,14 @@ func validCLIHerdrConfig() config.HerdrConfig {
 		ReadEnabled:             true,
 		WriteEnabled:            true,
 		InputSanitizerReady:     true,
-		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionAGPL),
+		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionRecorded),
+		ComplianceAuthorizedBy:  "test-authority",
+		ComplianceDecisionID:    "decision-001",
+		ComplianceDecidedAt:     "2026-08-12T00:00:00Z",
+		ComplianceRevalidatedAt: "2026-08-12T00:00:00Z",
+		ComplianceCurrentReferences: []string{
+			"https://github.com/ogulcancelik/herdr/blob/master/LICENSE",
+		},
 	}
 }
 

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -199,7 +199,7 @@ func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering
 	if firstFilter == -1 {
 		t.Fatal("startup rediscovery activation filter not found")
 	}
-	if !strings.Contains(source[firstFilter:], "publishFreshHerdrNodes(herdrRuntime, herdrToken, fresh, &sharedNodes)") {
+	if !strings.Contains(source[firstFilter:], "publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, fresh, &sharedNodes)") {
 		t.Fatal("startup rediscovery no longer publishes Herdr routes after activation filtering")
 	}
 
@@ -207,7 +207,7 @@ func TestRunStartWithFlags_SourceContractReconcilesHerdrAfterActivationFiltering
 	if secondFilter == -1 {
 		t.Fatal("on-demand refresh activation filter not found")
 	}
-	if !strings.Contains(source[secondFilter:], "publishFreshHerdrNodes(herdrRuntime, herdrToken, freshNodes, &sharedNodes)") {
+	if !strings.Contains(source[secondFilter:], "publishFreshHerdrNodes(ctx, contextID, herdrRuntime, herdrToken, freshNodes, &sharedNodes)") {
 		t.Fatal("on-demand refresh no longer publishes Herdr routes after activation filtering")
 	}
 }
@@ -242,10 +242,10 @@ func TestPublishFreshHerdrNodesRejectsStaleCLIRefreshSnapshot(t *testing.T) {
 	}
 
 	var sharedNodes atomic.Pointer[map[string]discovery.NodeInfo]
-	if !publishFreshHerdrNodes(rt, newToken, newNodes, &sharedNodes) {
+	if !publishFreshHerdrNodes(context.Background(), contextID, rt, newToken, newNodes, &sharedNodes) {
 		t.Fatal("publishFreshHerdrNodes(new) = false, want true")
 	}
-	if publishFreshHerdrNodes(rt, oldToken, oldNodes, &sharedNodes) {
+	if publishFreshHerdrNodes(context.Background(), contextID, rt, oldToken, oldNodes, &sharedNodes) {
 		t.Fatal("publishFreshHerdrNodes(old) = true, want stale rejection")
 	}
 
@@ -1063,6 +1063,30 @@ func (f *fakeCLIHerdrClient) ReadPane(context.Context, string, multiplexer.Herdr
 
 func (f *fakeCLIHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
 	return multiplexer.HerdrPaneProcessInfoResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) WritePaneText(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) SendPaneKey(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeCLIHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 
 func validCLIHerdrConfig() config.HerdrConfig {

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -74,9 +74,7 @@ func TestRunStop_StopsDaemonOwningManagedSession(t *testing.T) {
 		waitCh <- child.Wait()
 	}()
 	t.Cleanup(func() {
-		if child.ProcessState == nil || !child.ProcessState.Exited() {
-			_ = child.Process.Kill()
-		}
+		_ = child.Process.Kill()
 		select {
 		case <-waitCh:
 		case <-time.After(2 * time.Second):
@@ -135,9 +133,7 @@ func TestRunStop_StopsDaemonOwnerSession(t *testing.T) {
 		waitCh <- child.Wait()
 	}()
 	t.Cleanup(func() {
-		if child.ProcessState == nil || !child.ProcessState.Exited() {
-			_ = child.Process.Kill()
-		}
+		_ = child.Process.Kill()
 		select {
 		case <-waitCh:
 		case <-time.After(2 * time.Second):

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	CommandApproval                []CommandApprovalPolicy         `toml:"command_approval"`
 	CommandApproverNode            string                          `toml:"-"` // Mermaid-sourced reviewer node for command approval; unset/unresolvable = fail-open
 	DeprecatedCommandApproverNodes []DeprecatedCommandApproverNode `toml:"-"` // Ignored legacy TOML approver keys surfaced in get-status
+	Herdr                          HerdrConfig                     `toml:"herdr"`
 
 	// Node-specific configurations (loaded from [nodename] sections)
 	Nodes map[string]NodeConfig
@@ -107,6 +108,44 @@ type CommandApprovalPolicy struct {
 type DeprecatedCommandApproverNode struct {
 	Field string
 	Value string
+}
+
+type HerdrConfig struct {
+	Enabled                 bool     `toml:"enabled"`
+	SocketPath              string   `toml:"socket_path"`
+	SessionName             string   `toml:"session_name"`
+	WorkspaceID             string   `toml:"workspace_id"`
+	AllowedSocketPaths      []string `toml:"allowed_socket_paths"`
+	AllowedSessions         []string `toml:"allowed_sessions"`
+	AllowedWorkspaceIDs     []string `toml:"allowed_workspace_ids"`
+	AllowedProtocolVersions []string `toml:"allowed_protocol_versions"`
+	AllowedSchemaVersions   []int    `toml:"allowed_schema_versions"`
+	ReadEnabled             bool     `toml:"read_enabled"`
+	WriteEnabled            bool     `toml:"write_enabled"`
+	InputSanitizerReady     bool     `toml:"input_sanitizer_ready"`
+	ComplianceDecision      string   `toml:"compliance_decision"`
+}
+
+func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
+	return multiplexer.HerdrReadConfig{
+		Enabled: h.Enabled,
+		Runtime: multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  h.SocketPath,
+			SessionName: h.SessionName,
+			WorkspaceID: h.WorkspaceID,
+		},
+		Policy: multiplexer.HerdrGatePolicy{
+			ReadEnabled:             h.ReadEnabled,
+			WriteEnabled:            h.WriteEnabled,
+			AllowedSocketPaths:      h.AllowedSocketPaths,
+			AllowedSessions:         h.AllowedSessions,
+			AllowedWorkspaceIDs:     h.AllowedWorkspaceIDs,
+			AllowedProtocolVersions: h.AllowedProtocolVersions,
+			AllowedSchemaVersions:   h.AllowedSchemaVersions,
+			InputSanitizerReady:     h.InputSanitizerReady,
+			ComplianceDecision:      multiplexer.HerdrComplianceDecision(h.ComplianceDecision),
+		},
+	}
 }
 
 // NodeConfig holds per-node configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1314,13 +1314,20 @@ func FindContextSessionName(baseDir, contextID string) string {
 }
 
 func SetSessionEnabledMarker(contextID, sessionName string, enabled bool) error {
+	return SetSessionEnabledMarkerWithBackend(multiplexer.TmuxBackend{}, contextID, sessionName, enabled)
+}
+
+func SetSessionEnabledMarkerWithBackend(backend multiplexer.OwnershipBackend, contextID, sessionName string, enabled bool) error {
 	if sessionName == "" {
 		return fmt.Errorf("session name is empty")
 	}
-	if enabled {
-		return (multiplexer.TmuxBackend{}).SetSessionOwnerMarker(context.Background(), contextID, sessionName, os.Getpid())
+	if backend == nil {
+		backend = multiplexer.TmuxBackend{}
 	}
-	return (multiplexer.TmuxBackend{}).ClearSessionOwnerMarker(context.Background(), sessionName)
+	if enabled {
+		return backend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, os.Getpid())
+	}
+	return backend.ClearSessionOwnerMarker(context.Background(), sessionName)
 }
 
 func CurrentTmuxIdentity() (multiplexer.CurrentIdentity, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,7 +145,7 @@ func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   h.AllowedSchemaVersions,
 			InputSanitizerReady:     h.InputSanitizerReady,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecision(h.ComplianceDecision),
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecision(h.ComplianceDecision), AuthorizedBy: "config", DecisionID: "config", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "config", DecisionID: "config", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"config"}},
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/i9wa4/tmux-a2a-postman/internal/binding"
@@ -144,6 +145,7 @@ func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   h.AllowedSchemaVersions,
 			InputSanitizerReady:     h.InputSanitizerReady,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecision(h.ComplianceDecision),
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecision(h.ComplianceDecision), AuthorizedBy: "config", DecisionID: "config", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -132,9 +133,32 @@ type HerdrConfig struct {
 	ComplianceCurrentReferences []string `toml:"compliance_current_references"`
 }
 
+var (
+	herdrComplianceNowMu sync.Mutex
+	herdrComplianceNow   = time.Now
+)
+
+func SetHerdrComplianceNowForTest(now func() time.Time) func() {
+	herdrComplianceNowMu.Lock()
+	previous := herdrComplianceNow
+	if now == nil {
+		now = time.Now
+	}
+	herdrComplianceNow = now
+	herdrComplianceNowMu.Unlock()
+	return func() {
+		herdrComplianceNowMu.Lock()
+		herdrComplianceNow = previous
+		herdrComplianceNowMu.Unlock()
+	}
+}
+
 func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 	decidedAt, _ := time.Parse(time.RFC3339, h.ComplianceDecidedAt)
 	revalidatedAt, _ := time.Parse(time.RFC3339, h.ComplianceRevalidatedAt)
+	herdrComplianceNowMu.Lock()
+	complianceNow := herdrComplianceNow
+	herdrComplianceNowMu.Unlock()
 	return multiplexer.HerdrReadConfig{
 		Enabled: h.Enabled,
 		Runtime: multiplexer.HerdrRuntimeIdentity{
@@ -153,6 +177,7 @@ func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 			InputSanitizerReady:     h.InputSanitizerReady,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecision(h.ComplianceDecision),
 			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecision(h.ComplianceDecision), AuthorizedBy: h.ComplianceAuthorizedBy, DecisionID: h.ComplianceDecisionID, DecidedAt: decidedAt, RevalidatedAt: revalidatedAt, CurrentReferences: append([]string(nil), h.ComplianceCurrentReferences...)},
+			ComplianceNow:           complianceNow,
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,22 +112,29 @@ type DeprecatedCommandApproverNode struct {
 }
 
 type HerdrConfig struct {
-	Enabled                 bool     `toml:"enabled"`
-	SocketPath              string   `toml:"socket_path"`
-	SessionName             string   `toml:"session_name"`
-	WorkspaceID             string   `toml:"workspace_id"`
-	AllowedSocketPaths      []string `toml:"allowed_socket_paths"`
-	AllowedSessions         []string `toml:"allowed_sessions"`
-	AllowedWorkspaceIDs     []string `toml:"allowed_workspace_ids"`
-	AllowedProtocolVersions []string `toml:"allowed_protocol_versions"`
-	AllowedSchemaVersions   []int    `toml:"allowed_schema_versions"`
-	ReadEnabled             bool     `toml:"read_enabled"`
-	WriteEnabled            bool     `toml:"write_enabled"`
-	InputSanitizerReady     bool     `toml:"input_sanitizer_ready"`
-	ComplianceDecision      string   `toml:"compliance_decision"`
+	Enabled                     bool     `toml:"enabled"`
+	SocketPath                  string   `toml:"socket_path"`
+	SessionName                 string   `toml:"session_name"`
+	WorkspaceID                 string   `toml:"workspace_id"`
+	AllowedSocketPaths          []string `toml:"allowed_socket_paths"`
+	AllowedSessions             []string `toml:"allowed_sessions"`
+	AllowedWorkspaceIDs         []string `toml:"allowed_workspace_ids"`
+	AllowedProtocolVersions     []string `toml:"allowed_protocol_versions"`
+	AllowedSchemaVersions       []int    `toml:"allowed_schema_versions"`
+	ReadEnabled                 bool     `toml:"read_enabled"`
+	WriteEnabled                bool     `toml:"write_enabled"`
+	InputSanitizerReady         bool     `toml:"input_sanitizer_ready"`
+	ComplianceDecision          string   `toml:"compliance_decision"`
+	ComplianceAuthorizedBy      string   `toml:"compliance_authorized_by"`
+	ComplianceDecisionID        string   `toml:"compliance_decision_id"`
+	ComplianceDecidedAt         string   `toml:"compliance_decided_at"`
+	ComplianceRevalidatedAt     string   `toml:"compliance_revalidated_at"`
+	ComplianceCurrentReferences []string `toml:"compliance_current_references"`
 }
 
 func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
+	decidedAt, _ := time.Parse(time.RFC3339, h.ComplianceDecidedAt)
+	revalidatedAt, _ := time.Parse(time.RFC3339, h.ComplianceRevalidatedAt)
 	return multiplexer.HerdrReadConfig{
 		Enabled: h.Enabled,
 		Runtime: multiplexer.HerdrRuntimeIdentity{
@@ -145,7 +152,7 @@ func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   h.AllowedSchemaVersions,
 			InputSanitizerReady:     h.InputSanitizerReady,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecision(h.ComplianceDecision),
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "config", DecisionID: "config", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"config"}},
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecision(h.ComplianceDecision), AuthorizedBy: h.ComplianceAuthorizedBy, DecisionID: h.ComplianceDecisionID, DecidedAt: decidedAt, RevalidatedAt: revalidatedAt, CurrentReferences: append([]string(nil), h.ComplianceCurrentReferences...)},
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -131,34 +130,22 @@ type HerdrConfig struct {
 	ComplianceDecidedAt         string   `toml:"compliance_decided_at"`
 	ComplianceRevalidatedAt     string   `toml:"compliance_revalidated_at"`
 	ComplianceCurrentReferences []string `toml:"compliance_current_references"`
+
+	complianceNow func() time.Time `toml:"-"`
 }
 
-var (
-	herdrComplianceNowMu sync.Mutex
-	herdrComplianceNow   = time.Now
-)
-
-func SetHerdrComplianceNowForTest(now func() time.Time) func() {
-	herdrComplianceNowMu.Lock()
-	previous := herdrComplianceNow
-	if now == nil {
-		now = time.Now
-	}
-	herdrComplianceNow = now
-	herdrComplianceNowMu.Unlock()
-	return func() {
-		herdrComplianceNowMu.Lock()
-		herdrComplianceNow = previous
-		herdrComplianceNowMu.Unlock()
-	}
+func (h HerdrConfig) withComplianceNow(now func() time.Time) HerdrConfig {
+	h.complianceNow = now
+	return h
 }
 
 func (h HerdrConfig) ReadConfig() multiplexer.HerdrReadConfig {
 	decidedAt, _ := time.Parse(time.RFC3339, h.ComplianceDecidedAt)
 	revalidatedAt, _ := time.Parse(time.RFC3339, h.ComplianceRevalidatedAt)
-	herdrComplianceNowMu.Lock()
-	complianceNow := herdrComplianceNow
-	herdrComplianceNowMu.Unlock()
+	complianceNow := h.complianceNow
+	if complianceNow == nil {
+		complianceNow = time.Now
+	}
 	return multiplexer.HerdrReadConfig{
 		Enabled: h.Enabled,
 		Runtime: multiplexer.HerdrRuntimeIdentity{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1242,7 +1242,24 @@ func enabledSessionOwner(baseDir, sessionName string) string {
 	if sessionName == "" {
 		return ""
 	}
-	value, err := (multiplexer.TmuxBackend{}).SessionOwnerMarker(context.Background(), sessionName)
+	for _, backend := range sessionOwnershipBackends() {
+		if owner := enabledSessionOwnerFromBackend(baseDir, sessionName, backend); owner != "" {
+			return owner
+		}
+	}
+	return ""
+}
+
+func sessionOwnershipBackends() []multiplexer.OwnershipBackend {
+	backends := []multiplexer.OwnershipBackend{multiplexer.TmuxBackend{}}
+	if backend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr); err == nil && backend != nil {
+		backends = append(backends, backend)
+	}
+	return backends
+}
+
+func enabledSessionOwnerFromBackend(baseDir, sessionName string, backend multiplexer.OwnershipBackend) string {
+	value, err := backend.SessionOwnerMarker(context.Background(), sessionName)
 	if err != nil {
 		return ""
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -1476,6 +1477,67 @@ func TestMergeConfig_NodeMerge(t *testing.T) {
 	if base.Nodes["new"].Template != "new template" {
 		t.Errorf("new.Template: got %q, want %q", base.Nodes["new"].Template, "new template")
 	}
+}
+
+func TestSetSessionEnabledMarkerWithBackendUsesInjectedBackend(t *testing.T) {
+	backend := &fakeConfigOwnershipBackend{kind: multiplexer.BackendKindHerdr}
+
+	if err := SetSessionEnabledMarkerWithBackend(backend, "ctx-main", "work", true); err != nil {
+		t.Fatalf("SetSessionEnabledMarkerWithBackend(enable) error = %v", err)
+	}
+	if backend.setSessionCalls != 1 || backend.contextID != "ctx-main" || backend.sessionName != "work" {
+		t.Fatalf("set session marker = calls:%d context:%q session:%q, want injected backend", backend.setSessionCalls, backend.contextID, backend.sessionName)
+	}
+
+	if err := SetSessionEnabledMarkerWithBackend(backend, "ctx-main", "work", false); err != nil {
+		t.Fatalf("SetSessionEnabledMarkerWithBackend(disable) error = %v", err)
+	}
+	if backend.clearSessionCalls != 1 || backend.clearSessionName != "work" {
+		t.Fatalf("clear session marker = calls:%d session:%q, want injected backend", backend.clearSessionCalls, backend.clearSessionName)
+	}
+}
+
+type fakeConfigOwnershipBackend struct {
+	kind multiplexer.BackendKind
+
+	setSessionCalls   int
+	contextID         string
+	sessionName       string
+	clearSessionCalls int
+	clearSessionName  string
+}
+
+func (f *fakeConfigOwnershipBackend) Kind() multiplexer.BackendKind {
+	return f.kind
+}
+
+func (f *fakeConfigOwnershipBackend) SessionOwnerMarker(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeConfigOwnershipBackend) SetSessionOwnerMarker(_ context.Context, contextID, sessionName string, _ int) error {
+	f.setSessionCalls++
+	f.contextID = contextID
+	f.sessionName = sessionName
+	return nil
+}
+
+func (f *fakeConfigOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, sessionName string) error {
+	f.clearSessionCalls++
+	f.clearSessionName = sessionName
+	return nil
+}
+
+func (f *fakeConfigOwnershipBackend) PaneOwnerMarker(context.Context, multiplexer.ResourceID) (string, error) {
+	return "", nil
+}
+
+func (f *fakeConfigOwnershipBackend) SetPaneOwnerMarker(context.Context, multiplexer.ResourceID, string) error {
+	return nil
+}
+
+func (f *fakeConfigOwnershipBackend) ClearPaneOwnerMarker(context.Context, multiplexer.ResourceID) error {
+	return nil
 }
 
 func TestLoadConfig_IgnoresProjectLocalWhenXDGExists(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -241,9 +241,8 @@ edges = [
 
 func TestHerdrConfigReadConfigUsesInjectedCurrentTimeWithoutSelfValidatingStaleRecords(t *testing.T) {
 	now := time.Date(2031, 4, 5, 6, 7, 8, 0, time.UTC)
-	t.Cleanup(SetHerdrComplianceNowForTest(func() time.Time { return now }))
 
-	fresh := validHerdrGateConfigFor(now)
+	fresh := validHerdrGateConfigFor(now).withComplianceNow(func() time.Time { return now })
 	freshConfig := fresh.ReadConfig()
 	freshConfig.Runtime.TabID = "workspace-1:tab-1"
 	freshConfig.Runtime.PaneID = "workspace-1:pane-1"
@@ -251,12 +250,52 @@ func TestHerdrConfigReadConfigUsesInjectedCurrentTimeWithoutSelfValidatingStaleR
 		t.Fatalf("ValidateHerdrWriteGate(fresh) error = %v", err)
 	}
 
-	stale := validHerdrGateConfigFor(now.Add(-25 * time.Hour))
+	stale := validHerdrGateConfigFor(now.Add(-25 * time.Hour)).withComplianceNow(func() time.Time { return now })
 	staleConfig := stale.ReadConfig()
 	staleConfig.Runtime.TabID = "workspace-1:tab-1"
 	staleConfig.Runtime.PaneID = "workspace-1:pane-1"
 	if err := multiplexer.ValidateHerdrWriteGate(staleConfig.Policy, staleConfig.Runtime, multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}); err == nil {
 		t.Fatal("ValidateHerdrWriteGate(stale) error = nil, want stale config record to fail closed")
+	}
+}
+
+func TestHerdrConfigReadConfigClockInjectionIsPerConfigAndConcurrent(t *testing.T) {
+	now := time.Date(2031, 4, 5, 6, 7, 8, 0, time.UTC)
+	fresh := validHerdrGateConfigFor(now).withComplianceNow(func() time.Time { return now })
+	stale := validHerdrGateConfigFor(now).withComplianceNow(func() time.Time { return now.Add(25 * time.Hour) })
+
+	validate := func(cfg HerdrConfig) error {
+		readConfig := cfg.ReadConfig()
+		readConfig.Runtime.TabID = "workspace-1:tab-1"
+		readConfig.Runtime.PaneID = "workspace-1:pane-1"
+		return multiplexer.ValidateHerdrWriteGate(readConfig.Policy, readConfig.Runtime, multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1})
+	}
+
+	type result struct {
+		fresh bool
+		err   error
+	}
+	results := make(chan result, 200)
+	for range 100 {
+		go func() { results <- result{fresh: true, err: validate(fresh)} }()
+		go func() { results <- result{err: validate(stale)} }()
+	}
+	var freshPass, staleFail int
+	for range 200 {
+		got := <-results
+		switch {
+		case got.fresh && got.err == nil:
+			freshPass++
+		case !got.fresh && got.err != nil:
+			staleFail++
+		case got.fresh:
+			t.Fatalf("fresh config validation error = %v", got.err)
+		default:
+			t.Fatal("stale config validation passed, want fail-closed")
+		}
+	}
+	if freshPass != 100 || staleFail != 100 {
+		t.Fatalf("concurrent validation freshPass=%d staleFail=%d, want 100/100", freshPass, staleFail)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -239,6 +239,51 @@ edges = [
 	}
 }
 
+func TestHerdrConfigReadConfigUsesInjectedCurrentTimeWithoutSelfValidatingStaleRecords(t *testing.T) {
+	now := time.Date(2031, 4, 5, 6, 7, 8, 0, time.UTC)
+	t.Cleanup(SetHerdrComplianceNowForTest(func() time.Time { return now }))
+
+	fresh := validHerdrGateConfigFor(now)
+	freshConfig := fresh.ReadConfig()
+	freshConfig.Runtime.TabID = "workspace-1:tab-1"
+	freshConfig.Runtime.PaneID = "workspace-1:pane-1"
+	if err := multiplexer.ValidateHerdrWriteGate(freshConfig.Policy, freshConfig.Runtime, multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}); err != nil {
+		t.Fatalf("ValidateHerdrWriteGate(fresh) error = %v", err)
+	}
+
+	stale := validHerdrGateConfigFor(now.Add(-25 * time.Hour))
+	staleConfig := stale.ReadConfig()
+	staleConfig.Runtime.TabID = "workspace-1:tab-1"
+	staleConfig.Runtime.PaneID = "workspace-1:pane-1"
+	if err := multiplexer.ValidateHerdrWriteGate(staleConfig.Policy, staleConfig.Runtime, multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}); err == nil {
+		t.Fatal("ValidateHerdrWriteGate(stale) error = nil, want stale config record to fail closed")
+	}
+}
+
+func validHerdrGateConfigFor(revalidatedAt time.Time) HerdrConfig {
+	decidedAt := revalidatedAt.Add(-time.Hour)
+	return HerdrConfig{
+		Enabled:                     true,
+		SocketPath:                  "/tmp/herdr.sock",
+		SessionName:                 "work",
+		WorkspaceID:                 "workspace-1",
+		AllowedSocketPaths:          []string{"/tmp/herdr.sock"},
+		AllowedSessions:             []string{"work"},
+		AllowedWorkspaceIDs:         []string{"workspace-1"},
+		AllowedProtocolVersions:     []string{"1"},
+		AllowedSchemaVersions:       []int{1},
+		ReadEnabled:                 true,
+		WriteEnabled:                true,
+		InputSanitizerReady:         true,
+		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionRecorded),
+		ComplianceAuthorizedBy:      "test-authority",
+		ComplianceDecisionID:        "test-decision",
+		ComplianceDecidedAt:         decidedAt.Format(time.RFC3339),
+		ComplianceRevalidatedAt:     revalidatedAt.Format(time.RFC3339),
+		ComplianceCurrentReferences: []string{"https://github.com/ogulcancelik/herdr/blob/master/LICENSE"},
+	}
+}
+
 func TestLoadConfig_WorkspaceTree(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/internal/config/session_owner_test.go
+++ b/internal/config/session_owner_test.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 )
 
 func installSessionOwnerTmux(t *testing.T, owners map[string]string) {
@@ -115,6 +118,77 @@ func TestFindSessionOwner_IgnoresLiveForeignContextWithoutEnabledMarker(t *testi
 	if got := FindSessionOwner(baseDir, "managed-session", "ctx-self"); got != "" {
 		t.Fatalf("FindSessionOwner() = %q, want empty without enabled-session marker", got)
 	}
+}
+
+func TestFindSessionOwner_UsesRegisteredHerdrEnabledMarker(t *testing.T) {
+	baseDir := t.TempDir()
+	writeLivePID(t, baseDir, "ctx-owner", "daemon-session")
+	if err := os.MkdirAll(filepath.Join(baseDir, "ctx-owner", "managed-session"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(managed-session): %v", err)
+	}
+	installSessionOwnerTmux(t, map[string]string{})
+	backend := &fakeHerdrSessionOwnerBackend{owners: map[string]string{
+		"managed-session": "ctx-owner:43210",
+	}}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	if got := FindSessionOwner(baseDir, "managed-session", "ctx-self"); got != "ctx-owner" {
+		t.Fatalf("FindSessionOwner() = %q, want ctx-owner from Herdr ownership marker", got)
+	}
+}
+
+func TestContextOwnsSession_UsesRegisteredHerdrEnabledMarker(t *testing.T) {
+	baseDir := t.TempDir()
+	writeLivePID(t, baseDir, "ctx-owner", "daemon-session")
+	if err := os.MkdirAll(filepath.Join(baseDir, "ctx-owner", "managed-session"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(managed-session): %v", err)
+	}
+	installSessionOwnerTmux(t, map[string]string{})
+	backend := &fakeHerdrSessionOwnerBackend{owners: map[string]string{
+		"managed-session": "ctx-owner:43210",
+	}}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	if !ContextOwnsSession(baseDir, "ctx-owner", "managed-session") {
+		t.Fatal("ContextOwnsSession() = false, want true from Herdr ownership marker")
+	}
+	if ContextOwnsSession(baseDir, "ctx-other", "managed-session") {
+		t.Fatal("ContextOwnsSession() = true for non-owner context, want false")
+	}
+}
+
+type fakeHerdrSessionOwnerBackend struct {
+	owners map[string]string
+}
+
+func (f *fakeHerdrSessionOwnerBackend) Kind() multiplexer.BackendKind {
+	return multiplexer.BackendKindHerdr
+}
+
+func (f *fakeHerdrSessionOwnerBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {
+	return f.owners[sessionName], nil
+}
+
+func (f *fakeHerdrSessionOwnerBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+	return nil
+}
+
+func (f *fakeHerdrSessionOwnerBackend) ClearSessionOwnerMarker(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeHerdrSessionOwnerBackend) PaneOwnerMarker(context.Context, multiplexer.ResourceID) (string, error) {
+	return "", nil
+}
+
+func (f *fakeHerdrSessionOwnerBackend) SetPaneOwnerMarker(context.Context, multiplexer.ResourceID, string) error {
+	return nil
+}
+
+func (f *fakeHerdrSessionOwnerBackend) ClearPaneOwnerMarker(context.Context, multiplexer.ResourceID) error {
+	return nil
 }
 
 func TestContextOwnsSession_LiveDaemonSessionRemainsOwnedWithoutMarker(t *testing.T) {

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -40,6 +40,7 @@ type HandAttachment struct {
 }
 
 type registeredHerdrHandAdapter struct {
+	owner   string
 	token   uint64
 	adapter HerdrHandAdapter
 }
@@ -52,9 +53,10 @@ type herdrHandAdapterKey struct {
 }
 
 var (
-	registeredHerdrHandAdapters sync.Map
-	herdrHandAdapterToken       atomic.Uint64
-	herdrHandAdapterCleanupHook func(herdrHandAdapterKey, *registeredHerdrHandAdapter)
+	registeredHerdrHandAdapters   = make(map[herdrHandAdapterKey]*registeredHerdrHandAdapter)
+	registeredHerdrHandAdaptersMu sync.RWMutex
+	herdrHandAdapterToken         atomic.Uint64
+	herdrHandAdapterCleanupHook   func(herdrHandAdapterKey, *registeredHerdrHandAdapter)
 )
 
 type Target struct {
@@ -196,19 +198,72 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 	}
 	keys := herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID)
 	token := herdrHandAdapterToken.Add(1)
+	registeredHerdrHandAdaptersMu.Lock()
 	for _, key := range keys {
-		registeredHerdrHandAdapters.Store(key, &registeredHerdrHandAdapter{token: token, adapter: adapter})
+		registeredHerdrHandAdapters[key] = &registeredHerdrHandAdapter{token: token, adapter: adapter}
 	}
+	registeredHerdrHandAdaptersMu.Unlock()
 	return func() {
+		var observed []struct {
+			key     herdrHandAdapterKey
+			current *registeredHerdrHandAdapter
+		}
+		registeredHerdrHandAdaptersMu.Lock()
 		for _, key := range keys {
-			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
-				current, ok := registered.(*registeredHerdrHandAdapter)
-				if ok && current.token == token {
-					if herdrHandAdapterCleanupHook != nil {
-						herdrHandAdapterCleanupHook(key, current)
-					}
-					registeredHerdrHandAdapters.CompareAndDelete(key, current)
-				}
+			if current, ok := registeredHerdrHandAdapters[key]; ok && current.token == token {
+				observed = append(observed, struct {
+					key     herdrHandAdapterKey
+					current *registeredHerdrHandAdapter
+				}{key: key, current: current})
+				delete(registeredHerdrHandAdapters, key)
+			}
+		}
+		registeredHerdrHandAdaptersMu.Unlock()
+		for _, item := range observed {
+			if herdrHandAdapterCleanupHook != nil {
+				herdrHandAdapterCleanupHook(item.key, item.current)
+			}
+		}
+	}
+}
+
+func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHandAdapter) func() {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return func() {}
+	}
+	token := herdrHandAdapterToken.Add(1)
+	registeredHerdrHandAdaptersMu.Lock()
+	for key, current := range registeredHerdrHandAdapters {
+		if current.owner == owner {
+			delete(registeredHerdrHandAdapters, key)
+		}
+	}
+	for paneID, adapter := range adapters {
+		for _, key := range herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID) {
+			registeredHerdrHandAdapters[key] = &registeredHerdrHandAdapter{owner: owner, token: token, adapter: adapter}
+		}
+	}
+	registeredHerdrHandAdaptersMu.Unlock()
+	return func() {
+		var observed []struct {
+			key     herdrHandAdapterKey
+			current *registeredHerdrHandAdapter
+		}
+		registeredHerdrHandAdaptersMu.Lock()
+		for key, current := range registeredHerdrHandAdapters {
+			if current.owner == owner && current.token == token {
+				observed = append(observed, struct {
+					key     herdrHandAdapterKey
+					current *registeredHerdrHandAdapter
+				}{key: key, current: current})
+				delete(registeredHerdrHandAdapters, key)
+			}
+		}
+		registeredHerdrHandAdaptersMu.Unlock()
+		for _, item := range observed {
+			if herdrHandAdapterCleanupHook != nil {
+				herdrHandAdapterCleanupHook(item.key, item.current)
 			}
 		}
 	}
@@ -397,11 +452,11 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 	case HandKindTmux:
 		return TmuxHandAdapter{}, nil
 	case HandKindHerdr:
+		registeredHerdrHandAdaptersMu.RLock()
+		defer registeredHerdrHandAdaptersMu.RUnlock()
 		for _, key := range herdrHandAdapterKeysForTarget(target) {
-			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
-				if registration, ok := registered.(*registeredHerdrHandAdapter); ok {
-					return registration.adapter, nil
-				}
+			if registration, ok := registeredHerdrHandAdapters[key]; ok {
+				return registration.adapter, nil
 			}
 		}
 		return nil, fmt.Errorf("herdr hand adapter not registered for %q", target.Hand.Address)

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -54,6 +54,7 @@ type herdrHandAdapterKey struct {
 var (
 	registeredHerdrHandAdapters sync.Map
 	herdrHandAdapterToken       atomic.Uint64
+	herdrHandAdapterCleanupHook func(herdrHandAdapterKey, *registeredHerdrHandAdapter)
 )
 
 type Target struct {
@@ -196,14 +197,17 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 	keys := herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID)
 	token := herdrHandAdapterToken.Add(1)
 	for _, key := range keys {
-		registeredHerdrHandAdapters.Store(key, registeredHerdrHandAdapter{token: token, adapter: adapter})
+		registeredHerdrHandAdapters.Store(key, &registeredHerdrHandAdapter{token: token, adapter: adapter})
 	}
 	return func() {
 		for _, key := range keys {
 			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
-				current, ok := registered.(registeredHerdrHandAdapter)
+				current, ok := registered.(*registeredHerdrHandAdapter)
 				if ok && current.token == token {
-					registeredHerdrHandAdapters.Delete(key)
+					if herdrHandAdapterCleanupHook != nil {
+						herdrHandAdapterCleanupHook(key, current)
+					}
+					registeredHerdrHandAdapters.CompareAndDelete(key, current)
 				}
 			}
 		}
@@ -395,7 +399,7 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 	case HandKindHerdr:
 		for _, key := range herdrHandAdapterKeysForTarget(target) {
 			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
-				if registration, ok := registered.(registeredHerdrHandAdapter); ok {
+				if registration, ok := registered.(*registeredHerdrHandAdapter); ok {
 					return registration.adapter, nil
 				}
 			}

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -59,7 +59,7 @@ type herdrHandAdapterKey struct {
 }
 
 var (
-	registeredHerdrHandAdapters   = make(map[herdrHandAdapterKey]*registeredHerdrHandAdapter)
+	registeredHerdrHandAdapters   = make(map[herdrHandAdapterKey][]*registeredHerdrHandAdapter)
 	registeredHerdrHandAdaptersMu sync.RWMutex
 	herdrHandAdapterToken         atomic.Uint64
 	herdrHandAdapterCleanupHook   func(herdrHandAdapterKey, *registeredHerdrHandAdapter)
@@ -206,7 +206,7 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 	token := herdrHandAdapterToken.Add(1)
 	registeredHerdrHandAdaptersMu.Lock()
 	for _, key := range keys {
-		registeredHerdrHandAdapters[key] = &registeredHerdrHandAdapter{token: token, adapter: adapter}
+		registeredHerdrHandAdapters[key] = append(registeredHerdrHandAdapters[key], &registeredHerdrHandAdapter{token: token, adapter: adapter})
 	}
 	registeredHerdrHandAdaptersMu.Unlock()
 	return func() {
@@ -216,12 +216,22 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 		}
 		registeredHerdrHandAdaptersMu.Lock()
 		for _, key := range keys {
-			if current, ok := registeredHerdrHandAdapters[key]; ok && current.token == token {
+			current := registeredHerdrHandAdapters[key]
+			kept := current[:0]
+			for _, candidate := range current {
+				if candidate.token != token {
+					kept = append(kept, candidate)
+					continue
+				}
 				observed = append(observed, struct {
 					key     herdrHandAdapterKey
 					current *registeredHerdrHandAdapter
-				}{key: key, current: current})
+				}{key: key, current: candidate})
+			}
+			if len(kept) == 0 {
 				delete(registeredHerdrHandAdapters, key)
+			} else {
+				registeredHerdrHandAdapters[key] = kept
 			}
 		}
 		registeredHerdrHandAdaptersMu.Unlock()
@@ -265,12 +275,21 @@ func ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner string, adapters map[m
 	}
 	registeredHerdrHandAdaptersMu.Lock()
 	for key, current := range registeredHerdrHandAdapters {
-		if current.owner == owner {
+		kept := current[:0]
+		for _, candidate := range current {
+			if candidate.owner != owner {
+				kept = append(kept, candidate)
+				continue
+			}
 			displaced = append(displaced, struct {
 				key     herdrHandAdapterKey
 				current *registeredHerdrHandAdapter
-			}{key: key, current: current})
+			}{key: key, current: candidate})
+		}
+		if len(kept) == 0 {
 			delete(registeredHerdrHandAdapters, key)
+		} else {
+			registeredHerdrHandAdapters[key] = kept
 		}
 	}
 	for runtime, adapter := range adapters {
@@ -279,7 +298,7 @@ func ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner string, adapters map[m
 			paneID = adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime.PaneID
 		}
 		for _, key := range herdrHandAdapterKeysForRegistration(runtime, paneID) {
-			registeredHerdrHandAdapters[key] = &registeredHerdrHandAdapter{owner: owner, token: token, adapter: adapter}
+			registeredHerdrHandAdapters[key] = append(registeredHerdrHandAdapters[key], &registeredHerdrHandAdapter{owner: owner, token: token, adapter: adapter})
 		}
 	}
 	registeredHerdrHandAdaptersMu.Unlock()
@@ -297,12 +316,21 @@ func ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner string, adapters map[m
 		}
 		registeredHerdrHandAdaptersMu.Lock()
 		for key, current := range registeredHerdrHandAdapters {
-			if current.owner == owner && current.token == token {
+			kept := current[:0]
+			for _, candidate := range current {
+				if candidate.owner != owner || candidate.token != token {
+					kept = append(kept, candidate)
+					continue
+				}
 				observed = append(observed, struct {
 					key     herdrHandAdapterKey
 					current *registeredHerdrHandAdapter
-				}{key: key, current: current})
+				}{key: key, current: candidate})
+			}
+			if len(kept) == 0 {
 				delete(registeredHerdrHandAdapters, key)
+			} else {
+				registeredHerdrHandAdapters[key] = kept
 			}
 		}
 		registeredHerdrHandAdaptersMu.Unlock()
@@ -360,6 +388,18 @@ func herdrHandAdapterKeysForTarget(target Target) []herdrHandAdapterKey {
 		keys = append(keys, herdrHandAdapterKeyForRuntime(runtime, target.Hand.Address))
 	}
 	return keys
+}
+
+func registeredHerdrHandAdapterForKeyLocked(key herdrHandAdapterKey) (*registeredHerdrHandAdapter, bool, error) {
+	candidates := registeredHerdrHandAdapters[key]
+	switch len(candidates) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		return candidates[0], true, nil
+	default:
+		return nil, true, fmt.Errorf("ambiguous herdr hand adapter registration for pane %q", key.PaneID)
+	}
 }
 
 func (HerdrInteractiveDeliveryAdapter) Kind() HandKind {
@@ -531,7 +571,11 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 		registeredHerdrHandAdaptersMu.RLock()
 		defer registeredHerdrHandAdaptersMu.RUnlock()
 		for _, key := range herdrHandAdapterKeysForTarget(target) {
-			if registration, ok := registeredHerdrHandAdapters[key]; ok {
+			registration, ok, err := registeredHerdrHandAdapterForKeyLocked(key)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
 				return generationBoundHerdrHandAdapter{
 					generation: multiplexer.HerdrPublicationGenerationLocked(),
 					adapter:    registration.adapter,

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/agentruntime"
@@ -36,6 +37,8 @@ type HandAttachment struct {
 	Address string
 }
 
+var registeredHerdrHandAdapters sync.Map
+
 type Target struct {
 	ActorID     string
 	RunID       string
@@ -57,14 +60,23 @@ func TargetForNode(nodeName string, nodeInfo discovery.NodeInfo) Target {
 		}
 	}
 
+	handKind := HandKindTmux
+	if multiplexer.BackendKindFromString(nodeInfo.Backend) == multiplexer.BackendKindHerdr {
+		handKind = HandKindHerdr
+	}
+	brainRuntime := BrainRuntimeUnknown
+	if nodeInfo.Runtime != "" {
+		brainRuntime = nodeInfo.Runtime
+	}
+
 	return Target{
 		ActorID: actorID,
 		RunID:   runID,
 		Brain: Brain{
-			Runtime: BrainRuntimeUnknown,
+			Runtime: brainRuntime,
 		},
 		Hand: HandAttachment{
-			Kind:    HandKindTmux,
+			Kind:    handKind,
 			Address: nodeInfo.PaneID,
 		},
 		SessionName: nodeInfo.SessionName,
@@ -148,6 +160,21 @@ type HerdrInteractiveDeliveryAdapter struct {
 	InputSanitizer multiplexer.HerdrInputSanitizer
 }
 
+type HerdrHandAdapter struct {
+	HerdrInteractiveDeliveryAdapter
+	SystemMessageDeliveryAdapter SystemMessageDeliveryAdapter
+}
+
+func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
+	if strings.TrimSpace(paneID) == "" {
+		return func() {}
+	}
+	registeredHerdrHandAdapters.Store(paneID, adapter)
+	return func() {
+		registeredHerdrHandAdapters.Delete(paneID)
+	}
+}
+
 func (HerdrInteractiveDeliveryAdapter) Kind() HandKind {
 	return HandKindHerdr
 }
@@ -163,10 +190,32 @@ func (a HerdrInteractiveDeliveryAdapter) Deliver(target Target, delivery PaneDel
 	if backend.InputSanitizer == nil {
 		backend.InputSanitizer = notification.PrepareInteractivePaneMessage
 	}
+	enterCount := notification.ResolveEnterCount(delivery.EnterCount, func() (string, error) {
+		if target.Brain.Runtime != "" && target.Brain.Runtime != BrainRuntimeUnknown {
+			return target.Brain.Runtime, nil
+		}
+		return backend.PaneCurrentCommand(context.Background(), multiplexer.HerdrPaneID(target.Hand.Address))
+	})
 	return backend.SendPaneInput(context.Background(), multiplexer.HerdrPaneID(target.Hand.Address), multiplexer.HerdrPaneInput{
 		Text:       delivery.Content,
-		EnterCount: delivery.EnterCount,
+		EnterCount: enterCount,
 	})
+}
+
+func (a HerdrHandAdapter) Kind() HandKind {
+	return HandKindHerdr
+}
+
+func (a HerdrHandAdapter) Deliver(target Target, delivery PaneDelivery) error {
+	return a.HerdrInteractiveDeliveryAdapter.Deliver(target, delivery)
+}
+
+func (a HerdrHandAdapter) DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error) {
+	adapter := a.SystemMessageDeliveryAdapter
+	if adapter == nil {
+		adapter = FilesystemSystemMessageAdapter{}
+	}
+	return adapter.DeliverSystemMessage(target, delivery)
 }
 
 func (TmuxInteractiveDeliveryAdapter) Kind() HandKind {
@@ -262,6 +311,13 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 	switch target.Hand.Kind {
 	case HandKindTmux:
 		return TmuxHandAdapter{}, nil
+	case HandKindHerdr:
+		if registered, ok := registeredHerdrHandAdapters.Load(target.Hand.Address); ok {
+			if adapter, ok := registered.(HerdrHandAdapter); ok {
+				return adapter, nil
+			}
+		}
+		return nil, fmt.Errorf("herdr hand adapter not registered for %q", target.Hand.Address)
 	default:
 		return nil, fmt.Errorf("unsupported hand kind %q", target.Hand.Kind)
 	}

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/agentruntime"
@@ -33,11 +34,27 @@ type Brain struct {
 }
 
 type HandAttachment struct {
-	Kind    HandKind
-	Address string
+	Kind           HandKind
+	Address        string
+	HerdrRuntimeID multiplexer.HerdrRuntimeIdentity
 }
 
-var registeredHerdrHandAdapters sync.Map
+type registeredHerdrHandAdapter struct {
+	token   uint64
+	adapter HerdrHandAdapter
+}
+
+type herdrHandAdapterKey struct {
+	SocketPath  string
+	SessionName string
+	WorkspaceID string
+	PaneID      string
+}
+
+var (
+	registeredHerdrHandAdapters sync.Map
+	herdrHandAdapterToken       atomic.Uint64
+)
 
 type Target struct {
 	ActorID     string
@@ -78,6 +95,13 @@ func TargetForNode(nodeName string, nodeInfo discovery.NodeInfo) Target {
 		Hand: HandAttachment{
 			Kind:    handKind,
 			Address: nodeInfo.PaneID,
+			HerdrRuntimeID: multiplexer.HerdrRuntimeIdentity{
+				SocketPath:  nodeInfo.HerdrSocketPath,
+				SessionName: nodeInfo.SessionName,
+				WorkspaceID: nodeInfo.HerdrWorkspaceID,
+				TabID:       nodeInfo.HerdrTabID,
+				PaneID:      nodeInfo.PaneID,
+			},
 		},
 		SessionName: nodeInfo.SessionName,
 		SessionDir:  nodeInfo.SessionDir,
@@ -169,10 +193,67 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 	if strings.TrimSpace(paneID) == "" {
 		return func() {}
 	}
-	registeredHerdrHandAdapters.Store(paneID, adapter)
-	return func() {
-		registeredHerdrHandAdapters.Delete(paneID)
+	keys := herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID)
+	token := herdrHandAdapterToken.Add(1)
+	for _, key := range keys {
+		registeredHerdrHandAdapters.Store(key, registeredHerdrHandAdapter{token: token, adapter: adapter})
 	}
+	return func() {
+		for _, key := range keys {
+			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
+				current, ok := registered.(registeredHerdrHandAdapter)
+				if ok && current.token == token {
+					registeredHerdrHandAdapters.Delete(key)
+				}
+			}
+		}
+	}
+}
+
+func herdrHandAdapterKeysForRegistration(runtime multiplexer.HerdrRuntimeIdentity, paneID string) []herdrHandAdapterKey {
+	key := herdrHandAdapterKeyForRuntime(runtime, paneID)
+	keys := []herdrHandAdapterKey{key}
+	if key.SocketPath != "" || key.WorkspaceID != "" {
+		keys = append(keys, herdrHandAdapterKey{
+			SessionName: key.SessionName,
+			PaneID:      key.PaneID,
+		})
+	}
+	if key.SessionName != "" {
+		keys = append(keys, herdrHandAdapterKey{PaneID: key.PaneID})
+	}
+	return keys
+}
+
+func herdrHandAdapterKeyForRuntime(runtime multiplexer.HerdrRuntimeIdentity, paneID string) herdrHandAdapterKey {
+	if runtime.PaneID == "" {
+		runtime.PaneID = paneID
+	}
+	return herdrHandAdapterKey{
+		SocketPath:  strings.TrimSpace(runtime.SocketPath),
+		SessionName: strings.TrimSpace(runtime.SessionName),
+		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		PaneID:      strings.TrimSpace(runtime.PaneID),
+	}
+}
+
+func herdrHandAdapterKeysForTarget(target Target) []herdrHandAdapterKey {
+	runtime := target.Hand.HerdrRuntimeID
+	if runtime.SessionName == "" {
+		runtime.SessionName = target.SessionName
+	}
+	if runtime.PaneID == "" {
+		runtime.PaneID = target.Hand.Address
+	}
+	keys := []herdrHandAdapterKey{herdrHandAdapterKeyForRuntime(runtime, target.Hand.Address)}
+	if runtime.SocketPath != "" && runtime.WorkspaceID != "" {
+		return keys
+	}
+	if runtime.SessionName != "" {
+		runtime.SessionName = ""
+		keys = append(keys, herdrHandAdapterKeyForRuntime(runtime, target.Hand.Address))
+	}
+	return keys
 }
 
 func (HerdrInteractiveDeliveryAdapter) Kind() HandKind {
@@ -312,9 +393,11 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 	case HandKindTmux:
 		return TmuxHandAdapter{}, nil
 	case HandKindHerdr:
-		if registered, ok := registeredHerdrHandAdapters.Load(target.Hand.Address); ok {
-			if adapter, ok := registered.(HerdrHandAdapter); ok {
-				return adapter, nil
+		for _, key := range herdrHandAdapterKeysForTarget(target) {
+			if registered, ok := registeredHerdrHandAdapters.Load(key); ok {
+				if registration, ok := registered.(registeredHerdrHandAdapter); ok {
+					return registration.adapter, nil
+				}
 			}
 		}
 		return nil, fmt.Errorf("herdr hand adapter not registered for %q", target.Hand.Address)

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -233,9 +233,17 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 		return func() {}
 	}
 	token := herdrHandAdapterToken.Add(1)
+	var displaced []struct {
+		key     herdrHandAdapterKey
+		current *registeredHerdrHandAdapter
+	}
 	registeredHerdrHandAdaptersMu.Lock()
 	for key, current := range registeredHerdrHandAdapters {
 		if current.owner == owner {
+			displaced = append(displaced, struct {
+				key     herdrHandAdapterKey
+				current *registeredHerdrHandAdapter
+			}{key: key, current: current})
 			delete(registeredHerdrHandAdapters, key)
 		}
 	}
@@ -245,6 +253,11 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 		}
 	}
 	registeredHerdrHandAdaptersMu.Unlock()
+	for _, item := range displaced {
+		if herdrHandAdapterCleanupHook != nil {
+			herdrHandAdapterCleanupHook(item.key, item.current)
+		}
+	}
 	return func() {
 		var observed []struct {
 			key     herdrHandAdapterKey
@@ -452,6 +465,8 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 	case HandKindTmux:
 		return TmuxHandAdapter{}, nil
 	case HandKindHerdr:
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
 		registeredHerdrHandAdaptersMu.RLock()
 		defer registeredHerdrHandAdaptersMu.RUnlock()
 		for _, key := range herdrHandAdapterKeysForTarget(target) {

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -21,7 +21,8 @@ import (
 type HandKind string
 
 const (
-	HandKindTmux HandKind = "tmux"
+	HandKindTmux  HandKind = "tmux"
+	HandKindHerdr HandKind = "herdr"
 
 	BrainRuntimeUnknown = agentruntime.Unknown
 )
@@ -140,6 +141,32 @@ type TmuxInteractiveDeliveryAdapter struct {
 	SendToPane   func(paneID string, message string, enterDelay time.Duration, tmuxTimeout time.Duration, enterCount int, bypassCooldown bool, verifyDelay time.Duration, maxRetries int) error
 	PaneSender   notification.PaneSender
 	Backend      multiplexer.PaneBackend
+}
+
+type HerdrInteractiveDeliveryAdapter struct {
+	Backend        multiplexer.HerdrBackend
+	InputSanitizer multiplexer.HerdrInputSanitizer
+}
+
+func (HerdrInteractiveDeliveryAdapter) Kind() HandKind {
+	return HandKindHerdr
+}
+
+func (a HerdrInteractiveDeliveryAdapter) Deliver(target Target, delivery PaneDelivery) error {
+	if target.Hand.Kind != HandKindHerdr {
+		return fmt.Errorf("herdr hand adapter cannot deliver to %q", target.Hand.Kind)
+	}
+	backend := a.Backend
+	if backend.InputSanitizer == nil {
+		backend.InputSanitizer = a.InputSanitizer
+	}
+	if backend.InputSanitizer == nil {
+		backend.InputSanitizer = notification.PrepareInteractivePaneMessage
+	}
+	return backend.SendPaneInput(context.Background(), multiplexer.HerdrPaneID(target.Hand.Address), multiplexer.HerdrPaneInput{
+		Text:       delivery.Content,
+		EnterCount: delivery.EnterCount,
+	})
 }
 
 func (TmuxInteractiveDeliveryAdapter) Kind() HandKind {

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -45,6 +45,11 @@ type registeredHerdrHandAdapter struct {
 	adapter HerdrHandAdapter
 }
 
+type HerdrHandAdapterReplacement struct {
+	Cleanup          func()
+	DisplacedCleanup func()
+}
+
 type herdrHandAdapterKey struct {
 	SocketPath  string
 	SessionName string
@@ -228,9 +233,17 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 }
 
 func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHandAdapter) func() {
+	replacement := ReplaceHerdrHandAdaptersForOwnerCollect(owner, adapters)
+	if replacement.DisplacedCleanup != nil {
+		replacement.DisplacedCleanup()
+	}
+	return replacement.Cleanup
+}
+
+func ReplaceHerdrHandAdaptersForOwnerCollect(owner string, adapters map[string]HerdrHandAdapter) HerdrHandAdapterReplacement {
 	owner = strings.TrimSpace(owner)
 	if owner == "" {
-		return func() {}
+		return HerdrHandAdapterReplacement{Cleanup: func() {}, DisplacedCleanup: func() {}}
 	}
 	token := herdrHandAdapterToken.Add(1)
 	var displaced []struct {
@@ -253,12 +266,14 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 		}
 	}
 	registeredHerdrHandAdaptersMu.Unlock()
-	for _, item := range displaced {
-		if herdrHandAdapterCleanupHook != nil {
-			herdrHandAdapterCleanupHook(item.key, item.current)
+	displacedCleanup := func() {
+		for _, item := range displaced {
+			if herdrHandAdapterCleanupHook != nil {
+				herdrHandAdapterCleanupHook(item.key, item.current)
+			}
 		}
 	}
-	return func() {
+	cleanup := func() {
 		var observed []struct {
 			key     herdrHandAdapterKey
 			current *registeredHerdrHandAdapter
@@ -280,6 +295,7 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 			}
 		}
 	}
+	return HerdrHandAdapterReplacement{Cleanup: cleanup, DisplacedCleanup: displacedCleanup}
 }
 
 func herdrHandAdapterKeysForRegistration(runtime multiplexer.HerdrRuntimeIdentity, paneID string) []herdrHandAdapterKey {
@@ -369,6 +385,33 @@ func (a HerdrHandAdapter) DeliverSystemMessage(target Target, delivery SystemMes
 		adapter = FilesystemSystemMessageAdapter{}
 	}
 	return adapter.DeliverSystemMessage(target, delivery)
+}
+
+type generationBoundHerdrHandAdapter struct {
+	generation uint64
+	adapter    HerdrHandAdapter
+}
+
+func (a generationBoundHerdrHandAdapter) Kind() HandKind {
+	return HandKindHerdr
+}
+
+func (a generationBoundHerdrHandAdapter) Deliver(target Target, delivery PaneDelivery) error {
+	multiplexer.LockHerdrPublicationRead()
+	defer multiplexer.UnlockHerdrPublicationRead()
+	if multiplexer.HerdrPublicationGenerationLocked() != a.generation {
+		return fmt.Errorf("stale herdr hand adapter generation")
+	}
+	return a.adapter.Deliver(target, delivery)
+}
+
+func (a generationBoundHerdrHandAdapter) DeliverSystemMessage(target Target, delivery SystemMessageDelivery) (SystemMessageResult, error) {
+	multiplexer.LockHerdrPublicationRead()
+	defer multiplexer.UnlockHerdrPublicationRead()
+	if multiplexer.HerdrPublicationGenerationLocked() != a.generation {
+		return SystemMessageResult{}, fmt.Errorf("stale herdr hand adapter generation")
+	}
+	return a.adapter.DeliverSystemMessage(target, delivery)
 }
 
 func (TmuxInteractiveDeliveryAdapter) Kind() HandKind {
@@ -471,7 +514,10 @@ func DefaultHandAdapter(target Target) (HandAdapter, error) {
 		defer registeredHerdrHandAdaptersMu.RUnlock()
 		for _, key := range herdrHandAdapterKeysForTarget(target) {
 			if registration, ok := registeredHerdrHandAdapters[key]; ok {
-				return registration.adapter, nil
+				return generationBoundHerdrHandAdapter{
+					generation: multiplexer.HerdrPublicationGenerationLocked(),
+					adapter:    registration.adapter,
+				}, nil
 			}
 		}
 		return nil, fmt.Errorf("herdr hand adapter not registered for %q", target.Hand.Address)

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -54,6 +54,7 @@ type herdrHandAdapterKey struct {
 	SocketPath  string
 	SessionName string
 	WorkspaceID string
+	TabID       string
 	PaneID      string
 }
 
@@ -241,6 +242,18 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 }
 
 func ReplaceHerdrHandAdaptersForOwnerCollect(owner string, adapters map[string]HerdrHandAdapter) HerdrHandAdapterReplacement {
+	runtimeAdapters := make(map[multiplexer.HerdrRuntimeIdentity]HerdrHandAdapter, len(adapters))
+	for paneID, adapter := range adapters {
+		runtime := adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime
+		if runtime.PaneID == "" {
+			runtime.PaneID = paneID
+		}
+		runtimeAdapters[runtime] = adapter
+	}
+	return ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner, runtimeAdapters)
+}
+
+func ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner string, adapters map[multiplexer.HerdrRuntimeIdentity]HerdrHandAdapter) HerdrHandAdapterReplacement {
 	owner = strings.TrimSpace(owner)
 	if owner == "" {
 		return HerdrHandAdapterReplacement{Cleanup: func() {}, DisplacedCleanup: func() {}}
@@ -260,8 +273,12 @@ func ReplaceHerdrHandAdaptersForOwnerCollect(owner string, adapters map[string]H
 			delete(registeredHerdrHandAdapters, key)
 		}
 	}
-	for paneID, adapter := range adapters {
-		for _, key := range herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID) {
+	for runtime, adapter := range adapters {
+		paneID := runtime.PaneID
+		if paneID == "" {
+			paneID = adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime.PaneID
+		}
+		for _, key := range herdrHandAdapterKeysForRegistration(runtime, paneID) {
 			registeredHerdrHandAdapters[key] = &registeredHerdrHandAdapter{owner: owner, token: token, adapter: adapter}
 		}
 	}
@@ -321,6 +338,7 @@ func herdrHandAdapterKeyForRuntime(runtime multiplexer.HerdrRuntimeIdentity, pan
 		SocketPath:  strings.TrimSpace(runtime.SocketPath),
 		SessionName: strings.TrimSpace(runtime.SessionName),
 		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		TabID:       strings.TrimSpace(runtime.TabID),
 		PaneID:      strings.TrimSpace(runtime.PaneID),
 	}
 }

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -202,7 +202,7 @@ func RegisterHerdrHandAdapter(paneID string, adapter HerdrHandAdapter) func() {
 	if strings.TrimSpace(paneID) == "" {
 		return func() {}
 	}
-	keys := herdrHandAdapterKeysForRegistration(adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime, paneID)
+	keys := herdrHandAdapterKeysForRegistration(adapter.Backend.Config.Runtime, paneID)
 	token := herdrHandAdapterToken.Add(1)
 	registeredHerdrHandAdaptersMu.Lock()
 	for _, key := range keys {
@@ -254,7 +254,7 @@ func ReplaceHerdrHandAdaptersForOwner(owner string, adapters map[string]HerdrHan
 func ReplaceHerdrHandAdaptersForOwnerCollect(owner string, adapters map[string]HerdrHandAdapter) HerdrHandAdapterReplacement {
 	runtimeAdapters := make(map[multiplexer.HerdrRuntimeIdentity]HerdrHandAdapter, len(adapters))
 	for paneID, adapter := range adapters {
-		runtime := adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime
+		runtime := adapter.Backend.Config.Runtime
 		if runtime.PaneID == "" {
 			runtime.PaneID = paneID
 		}
@@ -295,7 +295,7 @@ func ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner string, adapters map[m
 	for runtime, adapter := range adapters {
 		paneID := runtime.PaneID
 		if paneID == "" {
-			paneID = adapter.HerdrInteractiveDeliveryAdapter.Backend.Config.Runtime.PaneID
+			paneID = adapter.Backend.Config.Runtime.PaneID
 		}
 		for _, key := range herdrHandAdapterKeysForRegistration(runtime, paneID) {
 			registeredHerdrHandAdapters[key] = append(registeredHerdrHandAdapters[key], &registeredHerdrHandAdapter{owner: owner, token: token, adapter: adapter})

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -1,14 +1,17 @@
 package controlplane
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/notification"
 )
 
@@ -194,6 +197,66 @@ func TestTmuxInteractiveDeliveryAdapterUsesPaneSender(t *testing.T) {
 	}
 }
 
+func TestHerdrInteractiveDeliveryAdapterUsesBackendAndSanitizes(t *testing.T) {
+	client := &fakeHerdrControlplaneWriteClient{
+		snapshot: validHerdrControlplaneSnapshot(),
+	}
+	adapter := HerdrInteractiveDeliveryAdapter{
+		Backend: multiplexer.HerdrBackend{
+			Config: validHerdrControlplaneConfig(),
+			Client: client,
+		},
+	}
+
+	err := adapter.Deliver(Target{
+		ActorID:     "worker",
+		RunID:       "work:worker",
+		SessionName: "work",
+		SessionDir:  t.TempDir(),
+		Hand:        HandAttachment{Kind: HandKindHerdr, Address: "workspace-1:pane-1"},
+	}, PaneDelivery{
+		Content: "\x1b[31mnotice worker\x1b[0m",
+	})
+	if err != nil {
+		t.Fatalf("Deliver() error = %v", err)
+	}
+
+	if client.writeTextCalls != 1 || client.writeTextPane != "workspace-1:pane-1" {
+		t.Fatalf("write text call = calls:%d pane:%q, want Herdr pane write", client.writeTextCalls, client.writeTextPane)
+	}
+	if !strings.Contains(client.writeTextText, "<!-- message start -->") ||
+		!strings.Contains(client.writeTextText, "notice worker") ||
+		strings.Contains(client.writeTextText, "\x1b") {
+		t.Fatalf("write text = %q, want wrapped sanitized content", client.writeTextText)
+	}
+	if client.sendKeyCalls != 1 || client.sendKeyKey != multiplexer.HerdrKeyEnter {
+		t.Fatalf("send key call = calls:%d key:%q, want one Herdr Enter key", client.sendKeyCalls, client.sendKeyKey)
+	}
+}
+
+func TestHerdrInteractiveDeliveryAdapterRejectsWrongHandKind(t *testing.T) {
+	client := &fakeHerdrControlplaneWriteClient{
+		snapshot: validHerdrControlplaneSnapshot(),
+	}
+	adapter := HerdrInteractiveDeliveryAdapter{
+		Backend: multiplexer.HerdrBackend{
+			Config:         validHerdrControlplaneConfig(),
+			Client:         client,
+			InputSanitizer: func(text string) (string, error) { return text, nil },
+		},
+	}
+
+	err := adapter.Deliver(Target{
+		Hand: HandAttachment{Kind: HandKindTmux, Address: "%1"},
+	}, PaneDelivery{Content: "notice"})
+	if err == nil {
+		t.Fatal("Deliver() error = nil, want wrong hand kind error")
+	}
+	if client.writeTextCalls != 0 || client.sendKeyCalls != 0 {
+		t.Fatalf("mutation calls = write:%d key:%d, want none", client.writeTextCalls, client.sendKeyCalls)
+	}
+}
+
 func TestTmuxHandAdapterDeliverSystemMessageWritesInbox(t *testing.T) {
 	sessionDir := filepath.Join(t.TempDir(), "review-session")
 	if err := config.CreateSessionDirs(sessionDir); err != nil {
@@ -229,6 +292,109 @@ func TestTmuxHandAdapterDeliverSystemMessageWritesInbox(t *testing.T) {
 	if string(body) != "system delivery" {
 		t.Fatalf("inbox body = %q, want %q", string(body), "system delivery")
 	}
+}
+
+type fakeHerdrControlplaneWriteClient struct {
+	snapshot multiplexer.HerdrSessionSnapshot
+
+	writeTextCalls int
+	writeTextPane  string
+	writeTextText  string
+	sendKeyCalls   int
+	sendKeyPane    string
+	sendKeyKey     string
+}
+
+func (f *fakeHerdrControlplaneWriteClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return validHerdrControlplaneEnvelope(), nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) WritePaneText(_ context.Context, paneID string, text string) (multiplexer.HerdrWriteResult, error) {
+	f.writeTextCalls++
+	f.writeTextPane = paneID
+	f.writeTextText = text
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) SendPaneKey(_ context.Context, paneID string, key string) (multiplexer.HerdrWriteResult, error) {
+	f.sendKeyCalls++
+	f.sendKeyPane = paneID
+	f.sendKeyKey = key
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func (f *fakeHerdrControlplaneWriteClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrControlplaneEnvelope()}, nil
+}
+
+func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
+	return multiplexer.HerdrReadConfig{
+		Enabled: true,
+		Runtime: multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-1",
+			TabID:       "workspace-1:tab-1",
+			PaneID:      "workspace-1:pane-1",
+		},
+		Policy: multiplexer.HerdrGatePolicy{
+			ReadEnabled:             true,
+			WriteEnabled:            true,
+			AllowedSocketPaths:      []string{"/tmp/herdr.sock"},
+			AllowedSessions:         []string{"work"},
+			AllowedWorkspaceIDs:     []string{"workspace-1"},
+			AllowedProtocolVersions: []string{"1"},
+			AllowedSchemaVersions:   []int{1},
+			InputSanitizerReady:     true,
+			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
+		},
+	}
+}
+
+func validHerdrControlplaneSnapshot() multiplexer.HerdrSessionSnapshot {
+	return multiplexer.HerdrSessionSnapshot{
+		Envelope: validHerdrControlplaneEnvelope(),
+		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
+			ID: "workspace-1",
+		}},
+		Tabs: []multiplexer.HerdrTabSnapshot{{
+			ID:          "workspace-1:tab-1",
+			WorkspaceID: "workspace-1",
+		}},
+		Panes: []multiplexer.HerdrPaneSnapshot{{
+			ID:          "workspace-1:pane-1",
+			WorkspaceID: "workspace-1",
+			TabID:       "workspace-1:tab-1",
+		}},
+	}
+}
+
+func validHerdrControlplaneEnvelope() multiplexer.HerdrResponseEnvelope {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}
 }
 
 func TestFilesystemSystemMessageAdapterWritesInbox(t *testing.T) {

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -45,6 +45,26 @@ func TestTargetForNodeSeparatesActorRunBrainAndHand(t *testing.T) {
 	}
 }
 
+func TestTargetForNodeUsesExplicitHerdrBackendMetadata(t *testing.T) {
+	target := TargetForNode("work:worker", discovery.NodeInfo{
+		PaneID:      "workspace-1:pane-1",
+		SessionName: "work",
+		SessionDir:  "/tmp/work",
+		Backend:     string(multiplexer.BackendKindHerdr),
+		Runtime:     "codex",
+	})
+
+	if target.Hand.Kind != HandKindHerdr {
+		t.Fatalf("Hand.Kind = %q, want herdr", target.Hand.Kind)
+	}
+	if target.Hand.Address != "workspace-1:pane-1" {
+		t.Fatalf("Hand.Address = %q, want Herdr pane", target.Hand.Address)
+	}
+	if target.Brain.Runtime != "codex" {
+		t.Fatalf("Brain.Runtime = %q, want codex", target.Brain.Runtime)
+	}
+}
+
 func TestTmuxHandAdapterDeliverUsesHandAttachment(t *testing.T) {
 	var (
 		gotPaneID         string
@@ -229,8 +249,66 @@ func TestHerdrInteractiveDeliveryAdapterUsesBackendAndSanitizes(t *testing.T) {
 		strings.Contains(client.writeTextText, "\x1b") {
 		t.Fatalf("write text = %q, want wrapped sanitized content", client.writeTextText)
 	}
-	if client.sendKeyCalls != 1 || client.sendKeyKey != multiplexer.HerdrKeyEnter {
+	if client.sendKeyCalls != 1 || client.sendKeyKey != multiplexer.HerdrKeySubmit {
 		t.Fatalf("send key call = calls:%d key:%q, want one Herdr Enter key", client.sendKeyCalls, client.sendKeyKey)
+	}
+}
+
+func TestHerdrInteractiveDeliveryAdapterUsesCodexDefaultEnterCount(t *testing.T) {
+	client := &fakeHerdrControlplaneWriteClient{
+		snapshot: validHerdrControlplaneSnapshot(),
+	}
+	adapter := HerdrInteractiveDeliveryAdapter{
+		Backend: multiplexer.HerdrBackend{
+			Config: validHerdrControlplaneConfig(),
+			Client: client,
+		},
+	}
+
+	err := adapter.Deliver(Target{
+		Brain: Brain{Runtime: "codex"},
+		Hand:  HandAttachment{Kind: HandKindHerdr, Address: "workspace-1:pane-1"},
+	}, PaneDelivery{Content: "notice", EnterCount: 0})
+	if err != nil {
+		t.Fatalf("Deliver() error = %v", err)
+	}
+	if client.sendKeyCalls != 2 || client.sendKeyKey != multiplexer.HerdrKeySubmit {
+		t.Fatalf("send key call = calls:%d key:%q, want two submit keys for Codex default", client.sendKeyCalls, client.sendKeyKey)
+	}
+}
+
+func TestDefaultHandAdapterSelectsRegisteredHerdrAdapter(t *testing.T) {
+	client := &fakeHerdrControlplaneWriteClient{
+		snapshot: validHerdrControlplaneSnapshot(),
+	}
+	unregister := RegisterHerdrHandAdapter("workspace-1:pane-1", HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{
+				Config: validHerdrControlplaneConfig(),
+				Client: client,
+			},
+		},
+	})
+	t.Cleanup(unregister)
+
+	target := TargetForNode("work:worker", discovery.NodeInfo{
+		PaneID:      "workspace-1:pane-1",
+		SessionName: "work",
+		Backend:     string(multiplexer.BackendKindHerdr),
+		Runtime:     "codex",
+	})
+	adapter, err := DefaultHandAdapter(target)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter() error = %v", err)
+	}
+	if adapter.Kind() != HandKindHerdr {
+		t.Fatalf("adapter.Kind() = %q, want herdr", adapter.Kind())
+	}
+	if err := adapter.Deliver(target, PaneDelivery{Content: "notice"}); err != nil {
+		t.Fatalf("Deliver() error = %v", err)
+	}
+	if client.writeTextCalls != 1 || client.sendKeyCalls != 2 {
+		t.Fatalf("Herdr delivery calls = write:%d key:%d, want reachable registered Herdr delivery", client.writeTextCalls, client.sendKeyCalls)
 	}
 }
 

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -448,8 +448,9 @@ func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
 			AllowedProtocolVersions: []string{"1"},
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
-			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"test"}},
+			ComplianceDecision:      multiplexer.HerdrComplianceDecisionRecorded,
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), RevalidatedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), CurrentReferences: []string{"test"}},
+			ComplianceNow:           func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
 		},
 	}
 }

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -312,6 +312,123 @@ func TestDefaultHandAdapterSelectsRegisteredHerdrAdapter(t *testing.T) {
 	}
 }
 
+func TestDefaultHandAdapterKeepsOverlappingHerdrPaneIDsIsolatedByRuntime(t *testing.T) {
+	paneID := "shared-native-pane"
+	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.SocketPath = "/tmp/herdr-first.sock"
+	firstConfig.Runtime.WorkspaceID = "workspace-first"
+	firstConfig.Runtime.PaneID = paneID
+	firstConfig.Policy.AllowedSocketPaths = []string{"/tmp/herdr-first.sock"}
+	firstConfig.Policy.AllowedWorkspaceIDs = []string{"workspace-first"}
+	firstClient.snapshot.Workspaces[0].ID = "workspace-first"
+	firstClient.snapshot.Tabs[0].WorkspaceID = "workspace-first"
+	firstClient.snapshot.Panes[0].WorkspaceID = "workspace-first"
+	firstClient.snapshot.Panes[0].ID = paneID
+	firstUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+		},
+	})
+	t.Cleanup(firstUnregister)
+
+	secondClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	secondConfig := validHerdrControlplaneConfig()
+	secondConfig.Runtime.SocketPath = "/tmp/herdr-second.sock"
+	secondConfig.Runtime.WorkspaceID = "workspace-second"
+	secondConfig.Runtime.PaneID = paneID
+	secondConfig.Policy.AllowedSocketPaths = []string{"/tmp/herdr-second.sock"}
+	secondConfig.Policy.AllowedWorkspaceIDs = []string{"workspace-second"}
+	secondClient.snapshot.Workspaces[0].ID = "workspace-second"
+	secondClient.snapshot.Tabs[0].WorkspaceID = "workspace-second"
+	secondClient.snapshot.Panes[0].WorkspaceID = "workspace-second"
+	secondClient.snapshot.Panes[0].ID = paneID
+	secondUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: secondConfig, Client: secondClient},
+		},
+	})
+	t.Cleanup(secondUnregister)
+
+	firstTarget := Target{
+		Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: firstConfig.Runtime},
+	}
+	secondTarget := Target{
+		Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: secondConfig.Runtime},
+	}
+	firstAdapter, err := DefaultHandAdapter(firstTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(first) error = %v", err)
+	}
+	if err := firstAdapter.Deliver(firstTarget, PaneDelivery{Content: "first"}); err != nil {
+		t.Fatalf("Deliver(first) error = %v", err)
+	}
+	secondAdapter, err := DefaultHandAdapter(secondTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(second) error = %v", err)
+	}
+	if err := secondAdapter.Deliver(secondTarget, PaneDelivery{Content: "second"}); err != nil {
+		t.Fatalf("Deliver(second) error = %v", err)
+	}
+	if firstClient.writeTextCalls != 1 || secondClient.writeTextCalls != 1 {
+		t.Fatalf("write calls first=%d second=%d, want isolated deliveries", firstClient.writeTextCalls, secondClient.writeTextCalls)
+	}
+
+	firstUnregister()
+	if _, err := DefaultHandAdapter(firstTarget); err == nil {
+		t.Fatal("first runtime adapter remained registered after cleanup")
+	}
+	if _, err := DefaultHandAdapter(secondTarget); err != nil {
+		t.Fatalf("second runtime adapter was removed by stale first cleanup: %v", err)
+	}
+
+	secondUnregister()
+	if _, err := DefaultHandAdapter(secondTarget); err == nil {
+		t.Fatal("second runtime adapter remained registered after cleanup")
+	}
+}
+
+func TestDefaultHandAdapterReverseCleanupKeepsOlderOverlappingHerdrRuntime(t *testing.T) {
+	paneID := "shared-native-pane-reverse"
+	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.SocketPath = "/tmp/herdr-reverse-first.sock"
+	firstConfig.Runtime.WorkspaceID = "workspace-reverse-first"
+	firstConfig.Runtime.PaneID = paneID
+	firstConfig.Policy.AllowedSocketPaths = []string{"/tmp/herdr-reverse-first.sock"}
+	firstConfig.Policy.AllowedWorkspaceIDs = []string{"workspace-reverse-first"}
+	firstClient.snapshot.Workspaces[0].ID = "workspace-reverse-first"
+	firstClient.snapshot.Tabs[0].WorkspaceID = "workspace-reverse-first"
+	firstClient.snapshot.Panes[0].WorkspaceID = "workspace-reverse-first"
+	firstClient.snapshot.Panes[0].ID = paneID
+	firstUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+		},
+	})
+	t.Cleanup(firstUnregister)
+
+	secondConfig := firstConfig
+	secondConfig.Runtime.SocketPath = "/tmp/herdr-reverse-second.sock"
+	secondConfig.Runtime.WorkspaceID = "workspace-reverse-second"
+	secondConfig.Policy.AllowedSocketPaths = []string{"/tmp/herdr-reverse-second.sock"}
+	secondConfig.Policy.AllowedWorkspaceIDs = []string{"workspace-reverse-second"}
+	secondUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: secondConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+		},
+	})
+	t.Cleanup(secondUnregister)
+
+	secondUnregister()
+	firstTarget := Target{
+		Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: firstConfig.Runtime},
+	}
+	if _, err := DefaultHandAdapter(firstTarget); err != nil {
+		t.Fatalf("first runtime adapter was removed by newer cleanup: %v", err)
+	}
+}
+
 func TestHerdrInteractiveDeliveryAdapterRejectsWrongHandKind(t *testing.T) {
 	client := &fakeHerdrControlplaneWriteClient{
 		snapshot: validHerdrControlplaneSnapshot(),

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -438,6 +438,96 @@ func TestDefaultHandAdapterKeepsOverlappingHerdrPaneIDsIsolatedByTab(t *testing.
 	}
 }
 
+func TestDefaultHandAdapterRejectsAmbiguousReducedHerdrTabFallback(t *testing.T) {
+	owner := "tab-ambiguous-owner"
+	paneID := "shared-native-pane-reduced"
+	tabOne := "workspace-1:tab-1"
+	tabTwo := "workspace-1:tab-2"
+
+	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.TabID = tabOne
+	firstConfig.Runtime.PaneID = paneID
+	firstClient.snapshot.Panes[0].ID = paneID
+	firstClient.snapshot.Panes[0].TabID = tabOne
+
+	secondClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	secondConfig := validHerdrControlplaneConfig()
+	secondConfig.Runtime.TabID = tabTwo
+	secondConfig.Runtime.PaneID = paneID
+	secondClient.snapshot.Tabs = append(secondClient.snapshot.Tabs, multiplexer.HerdrTabSnapshot{ID: tabTwo, WorkspaceID: "workspace-1"})
+	secondClient.snapshot.Panes[0].ID = paneID
+	secondClient.snapshot.Panes[0].TabID = tabTwo
+
+	replacement := ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner, map[multiplexer.HerdrRuntimeIdentity]HerdrHandAdapter{
+		firstConfig.Runtime: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+			},
+		},
+		secondConfig.Runtime: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: secondConfig, Client: secondClient},
+			},
+		},
+	})
+	replacement.DisplacedCleanup()
+	t.Cleanup(replacement.Cleanup)
+
+	firstTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: firstConfig.Runtime}}
+	firstAdapter, err := DefaultHandAdapter(firstTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(first exact) error = %v", err)
+	}
+	if err := firstAdapter.Deliver(firstTarget, PaneDelivery{Content: "first"}); err != nil {
+		t.Fatalf("Deliver(first exact) error = %v", err)
+	}
+
+	secondTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: secondConfig.Runtime}}
+	secondAdapter, err := DefaultHandAdapter(secondTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(second exact) error = %v", err)
+	}
+	if err := secondAdapter.Deliver(secondTarget, PaneDelivery{Content: "second"}); err != nil {
+		t.Fatalf("Deliver(second exact) error = %v", err)
+	}
+	if firstClient.writeTextCalls != 1 || secondClient.writeTextCalls != 1 {
+		t.Fatalf("exact write calls first=%d second=%d, want isolated deliveries", firstClient.writeTextCalls, secondClient.writeTextCalls)
+	}
+
+	reducedTarget := Target{
+		SessionName: firstConfig.Runtime.SessionName,
+		Hand:        HandAttachment{Kind: HandKindHerdr, Address: paneID},
+	}
+	if _, err := DefaultHandAdapter(reducedTarget); err == nil {
+		t.Fatal("DefaultHandAdapter(reduced ambiguous) succeeded, want fail-closed ambiguity")
+	}
+	if firstClient.writeTextCalls != 1 || secondClient.writeTextCalls != 1 {
+		t.Fatalf("ambiguous reduced lookup delivered unexpectedly: first=%d second=%d", firstClient.writeTextCalls, secondClient.writeTextCalls)
+	}
+
+	uniqueReplacement := ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner, map[multiplexer.HerdrRuntimeIdentity]HerdrHandAdapter{
+		firstConfig.Runtime: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+			},
+		},
+	})
+	uniqueReplacement.DisplacedCleanup()
+	t.Cleanup(uniqueReplacement.Cleanup)
+
+	uniqueAdapter, err := DefaultHandAdapter(reducedTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(reduced unique) error = %v", err)
+	}
+	if err := uniqueAdapter.Deliver(reducedTarget, PaneDelivery{Content: "unique"}); err != nil {
+		t.Fatalf("Deliver(reduced unique) error = %v", err)
+	}
+	if firstClient.writeTextCalls != 2 || secondClient.writeTextCalls != 1 {
+		t.Fatalf("unique fallback write calls first=%d second=%d, want first restored only", firstClient.writeTextCalls, secondClient.writeTextCalls)
+	}
+}
+
 func TestReplaceHerdrHandAdaptersForOwnerAtomicallySwapsVisibleSet(t *testing.T) {
 	owner := "runtime-owner"
 	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -388,6 +388,54 @@ func TestDefaultHandAdapterKeepsOverlappingHerdrPaneIDsIsolatedByRuntime(t *test
 	}
 }
 
+func TestReplaceHerdrHandAdaptersForOwnerAtomicallySwapsVisibleSet(t *testing.T) {
+	owner := "runtime-owner"
+	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.PaneID = "pane-old"
+	firstClient.snapshot.Panes[0].ID = "pane-old"
+	firstCleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		"pane-old": {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+			},
+		},
+	})
+	t.Cleanup(firstCleanup)
+	oldTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: "pane-old", HerdrRuntimeID: firstConfig.Runtime}}
+	if _, err := DefaultHandAdapter(oldTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(old) error = %v", err)
+	}
+
+	secondClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	secondConfig := validHerdrControlplaneConfig()
+	secondConfig.Runtime.PaneID = "pane-new"
+	secondClient.snapshot.Panes[0].ID = "pane-new"
+	secondCleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		"pane-new": {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: secondConfig, Client: secondClient},
+			},
+		},
+	})
+	t.Cleanup(secondCleanup)
+
+	if _, err := DefaultHandAdapter(oldTarget); err == nil {
+		t.Fatal("old owner adapter remained visible after owner-scoped replacement")
+	}
+	newTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: "pane-new", HerdrRuntimeID: secondConfig.Runtime}}
+	adapter, err := DefaultHandAdapter(newTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(new) error = %v", err)
+	}
+	if err := adapter.Deliver(newTarget, PaneDelivery{Content: "new"}); err != nil {
+		t.Fatalf("Deliver(new) error = %v", err)
+	}
+	if secondClient.writeTextCalls != 1 {
+		t.Fatalf("new adapter write calls = %d, want visible replacement", secondClient.writeTextCalls)
+	}
+}
+
 func TestDefaultHandAdapterReverseCleanupKeepsOlderOverlappingHerdrRuntime(t *testing.T) {
 	paneID := "shared-native-pane-reverse"
 	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -429,6 +429,128 @@ func TestDefaultHandAdapterReverseCleanupKeepsOlderOverlappingHerdrRuntime(t *te
 	}
 }
 
+func TestHerdrHandAdapterCleanupDoesNotDeleteExactReplacementAfterObservation(t *testing.T) {
+	paneID := "replacement-exact-pane"
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.SocketPath = "/tmp/herdr-exact-first.sock"
+	firstConfig.Runtime.WorkspaceID = "workspace-exact"
+	firstConfig.Runtime.PaneID = paneID
+	firstConfig.Policy.AllowedSocketPaths = []string{firstConfig.Runtime.SocketPath}
+	firstConfig.Policy.AllowedWorkspaceIDs = []string{firstConfig.Runtime.WorkspaceID}
+	firstCleanup := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+		},
+	})
+	t.Cleanup(firstCleanup)
+
+	replacementClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	replacementClient.snapshot.Workspaces[0].ID = firstConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Tabs[0].WorkspaceID = firstConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Panes[0].WorkspaceID = firstConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Panes[0].ID = paneID
+	replacementCleanup := func() {}
+	exactKey := herdrHandAdapterKeyForRuntime(firstConfig.Runtime, paneID)
+	installedReplacement := false
+	herdrHandAdapterCleanupHook = func(key herdrHandAdapterKey, _ *registeredHerdrHandAdapter) {
+		if installedReplacement || key != exactKey {
+			return
+		}
+		installedReplacement = true
+		replacementCleanup = RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: replacementClient},
+			},
+		})
+	}
+	t.Cleanup(func() {
+		herdrHandAdapterCleanupHook = nil
+		replacementCleanup()
+	})
+
+	firstCleanup()
+	if !installedReplacement {
+		t.Fatal("cleanup hook did not install replacement between observation and removal")
+	}
+
+	target := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: firstConfig.Runtime}}
+	adapter, err := DefaultHandAdapter(target)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(exact replacement) error = %v", err)
+	}
+	if err := adapter.Deliver(target, PaneDelivery{Content: "replacement"}); err != nil {
+		t.Fatalf("Deliver(exact replacement) error = %v", err)
+	}
+	if replacementClient.writeTextCalls != 1 {
+		t.Fatalf("replacement write calls = %d, want 1", replacementClient.writeTextCalls)
+	}
+}
+
+func TestHerdrHandAdapterCleanupDoesNotDeleteCompatibilityReplacementAfterObservation(t *testing.T) {
+	paneID := "replacement-compat-pane"
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.SocketPath = "/tmp/herdr-compat-first.sock"
+	firstConfig.Runtime.WorkspaceID = "workspace-compat-first"
+	firstConfig.Runtime.PaneID = paneID
+	firstConfig.Policy.AllowedSocketPaths = []string{firstConfig.Runtime.SocketPath}
+	firstConfig.Policy.AllowedWorkspaceIDs = []string{firstConfig.Runtime.WorkspaceID}
+	firstCleanup := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+		},
+	})
+	t.Cleanup(firstCleanup)
+
+	replacementConfig := firstConfig
+	replacementConfig.Runtime.SocketPath = "/tmp/herdr-compat-second.sock"
+	replacementConfig.Runtime.WorkspaceID = "workspace-compat-second"
+	replacementConfig.Policy.AllowedSocketPaths = []string{replacementConfig.Runtime.SocketPath}
+	replacementConfig.Policy.AllowedWorkspaceIDs = []string{replacementConfig.Runtime.WorkspaceID}
+	replacementClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	replacementClient.snapshot.Workspaces[0].ID = replacementConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Tabs[0].WorkspaceID = replacementConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Panes[0].WorkspaceID = replacementConfig.Runtime.WorkspaceID
+	replacementClient.snapshot.Panes[0].ID = paneID
+	replacementCleanup := func() {}
+	compatKey := herdrHandAdapterKey{SessionName: firstConfig.Runtime.SessionName, PaneID: paneID}
+	installedReplacement := false
+	herdrHandAdapterCleanupHook = func(key herdrHandAdapterKey, _ *registeredHerdrHandAdapter) {
+		if installedReplacement || key != compatKey {
+			return
+		}
+		installedReplacement = true
+		replacementCleanup = RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: replacementConfig, Client: replacementClient},
+			},
+		})
+	}
+	t.Cleanup(func() {
+		herdrHandAdapterCleanupHook = nil
+		replacementCleanup()
+	})
+
+	firstCleanup()
+	if !installedReplacement {
+		t.Fatal("cleanup hook did not install compatibility replacement between observation and removal")
+	}
+
+	target := Target{
+		SessionName: firstConfig.Runtime.SessionName,
+		Hand:        HandAttachment{Kind: HandKindHerdr, Address: paneID},
+	}
+	adapter, err := DefaultHandAdapter(target)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(compat replacement) error = %v", err)
+	}
+	if err := adapter.Deliver(target, PaneDelivery{Content: "replacement"}); err != nil {
+		t.Fatalf("Deliver(compat replacement) error = %v", err)
+	}
+	if replacementClient.writeTextCalls != 1 {
+		t.Fatalf("replacement write calls = %d, want 1", replacementClient.writeTextCalls)
+	}
+}
+
 func TestHerdrInteractiveDeliveryAdapterRejectsWrongHandKind(t *testing.T) {
 	client := &fakeHerdrControlplaneWriteClient{
 		snapshot: validHerdrControlplaneSnapshot(),

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -436,6 +436,57 @@ func TestReplaceHerdrHandAdaptersForOwnerAtomicallySwapsVisibleSet(t *testing.T)
 	}
 }
 
+func TestReplaceHerdrHandAdaptersForOwnerRunsDisplacedCleanupOutsideLockOnce(t *testing.T) {
+	owner := "runtime-owner-cleanup"
+	paneID := "pane-cleanup-old"
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.PaneID = paneID
+	firstCleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		paneID: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+			},
+		},
+	})
+	t.Cleanup(firstCleanup)
+
+	expected := make(map[herdrHandAdapterKey]bool)
+	for _, key := range herdrHandAdapterKeysForRegistration(firstConfig.Runtime, paneID) {
+		expected[key] = true
+	}
+	seen := make(map[herdrHandAdapterKey]int)
+	herdrHandAdapterCleanupHook = func(key herdrHandAdapterKey, _ *registeredHerdrHandAdapter) {
+		if !registeredHerdrHandAdaptersMu.TryLock() {
+			t.Fatalf("cleanup hook for %#v ran while registry lock was held", key)
+		}
+		registeredHerdrHandAdaptersMu.Unlock()
+		seen[key]++
+	}
+	t.Cleanup(func() {
+		herdrHandAdapterCleanupHook = nil
+	})
+
+	nextConfig := firstConfig
+	nextConfig.Runtime.PaneID = "pane-cleanup-new"
+	nextCleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		nextConfig.Runtime.PaneID: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: nextConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+			},
+		},
+	})
+	t.Cleanup(nextCleanup)
+
+	if len(seen) != len(expected) {
+		t.Fatalf("cleanup hook count = %d, want %d (%#v)", len(seen), len(expected), seen)
+	}
+	for key := range expected {
+		if seen[key] != 1 {
+			t.Fatalf("cleanup hook for %#v ran %d times, want exactly once", key, seen[key])
+		}
+	}
+}
+
 func TestDefaultHandAdapterReverseCleanupKeepsOlderOverlappingHerdrRuntime(t *testing.T) {
 	paneID := "shared-native-pane-reverse"
 	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -388,6 +388,56 @@ func TestDefaultHandAdapterKeepsOverlappingHerdrPaneIDsIsolatedByRuntime(t *test
 	}
 }
 
+func TestDefaultHandAdapterKeepsOverlappingHerdrPaneIDsIsolatedByTab(t *testing.T) {
+	paneID := "shared-native-pane"
+	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	firstConfig := validHerdrControlplaneConfig()
+	firstConfig.Runtime.TabID = "workspace-1:tab-1"
+	firstConfig.Runtime.PaneID = paneID
+	firstClient.snapshot.Panes[0].ID = paneID
+	firstClient.snapshot.Panes[0].TabID = "workspace-1:tab-1"
+	firstUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: firstConfig, Client: firstClient},
+		},
+	})
+	t.Cleanup(firstUnregister)
+
+	secondClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	secondConfig := validHerdrControlplaneConfig()
+	secondConfig.Runtime.TabID = "workspace-1:tab-2"
+	secondConfig.Runtime.PaneID = paneID
+	secondClient.snapshot.Tabs = append(secondClient.snapshot.Tabs, multiplexer.HerdrTabSnapshot{ID: "workspace-1:tab-2", WorkspaceID: "workspace-1"})
+	secondClient.snapshot.Panes[0].ID = paneID
+	secondClient.snapshot.Panes[0].TabID = "workspace-1:tab-2"
+	secondUnregister := RegisterHerdrHandAdapter(paneID, HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{Config: secondConfig, Client: secondClient},
+		},
+	})
+	t.Cleanup(secondUnregister)
+
+	firstTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: firstConfig.Runtime}}
+	firstAdapter, err := DefaultHandAdapter(firstTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(first tab) error = %v", err)
+	}
+	if err := firstAdapter.Deliver(firstTarget, PaneDelivery{Content: "first"}); err != nil {
+		t.Fatalf("Deliver(first tab) error = %v", err)
+	}
+	secondTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: secondConfig.Runtime}}
+	secondAdapter, err := DefaultHandAdapter(secondTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(second tab) error = %v", err)
+	}
+	if err := secondAdapter.Deliver(secondTarget, PaneDelivery{Content: "second"}); err != nil {
+		t.Fatalf("Deliver(second tab) error = %v", err)
+	}
+	if firstClient.writeTextCalls != 1 || secondClient.writeTextCalls != 1 {
+		t.Fatalf("write calls first=%d second=%d, want tab-isolated deliveries", firstClient.writeTextCalls, secondClient.writeTextCalls)
+	}
+}
+
 func TestReplaceHerdrHandAdaptersForOwnerAtomicallySwapsVisibleSet(t *testing.T) {
 	owner := "runtime-owner"
 	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -487,6 +487,92 @@ func TestReplaceHerdrHandAdaptersForOwnerRunsDisplacedCleanupOutsideLockOnce(t *
 	}
 }
 
+func TestDefaultHandAdapterRejectsGenerationStaleHandleBeforeWrite(t *testing.T) {
+	owner := "runtime-owner-stale-handle"
+	paneID := "pane-stale-handle"
+	client := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	cfg := validHerdrControlplaneConfig()
+	cfg.Runtime.PaneID = paneID
+	client.snapshot.Panes[0].ID = paneID
+	cleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		paneID: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: cfg, Client: client},
+			},
+		},
+	})
+	t.Cleanup(cleanup)
+	target := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: paneID, HerdrRuntimeID: cfg.Runtime}}
+	adapter, err := DefaultHandAdapter(target)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter() error = %v", err)
+	}
+
+	multiplexer.LockHerdrPublicationWrite()
+	multiplexer.AdvanceHerdrPublicationGenerationLocked()
+	multiplexer.UnlockHerdrPublicationWrite()
+
+	err = adapter.Deliver(target, PaneDelivery{Content: "stale"})
+	if err == nil || !strings.Contains(err.Error(), "stale herdr hand adapter generation") {
+		t.Fatalf("Deliver(stale handle) error = %v, want stale generation error", err)
+	}
+	if client.writeTextCalls != 0 || client.sendKeyCalls != 0 {
+		t.Fatalf("stale handle wrote to Herdr: write=%d key=%d", client.writeTextCalls, client.sendKeyCalls)
+	}
+}
+
+func TestOwnerReplacementCleanupHookCanReenterAdapterLookupAfterPublicationUnlock(t *testing.T) {
+	owner := "runtime-owner-reentrant-cleanup"
+	oldPaneID := "pane-reentrant-old"
+	oldConfig := validHerdrControlplaneConfig()
+	oldConfig.Runtime.PaneID = oldPaneID
+	firstCleanup := ReplaceHerdrHandAdaptersForOwner(owner, map[string]HerdrHandAdapter{
+		oldPaneID: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: oldConfig, Client: &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}},
+			},
+		},
+	})
+	t.Cleanup(firstCleanup)
+
+	newPaneID := "pane-reentrant-new"
+	newConfig := oldConfig
+	newConfig.Runtime.PaneID = newPaneID
+	newClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}
+	newClient.snapshot.Panes[0].ID = newPaneID
+	newTarget := Target{Hand: HandAttachment{Kind: HandKindHerdr, Address: newPaneID, HerdrRuntimeID: newConfig.Runtime}}
+	hookDone := make(chan error, 8)
+	herdrHandAdapterCleanupHook = func(herdrHandAdapterKey, *registeredHerdrHandAdapter) {
+		_, err := DefaultHandAdapter(newTarget)
+		hookDone <- err
+	}
+	t.Cleanup(func() {
+		herdrHandAdapterCleanupHook = nil
+	})
+
+	multiplexer.LockHerdrPublicationWrite()
+	replacement := ReplaceHerdrHandAdaptersForOwnerCollect(owner, map[string]HerdrHandAdapter{
+		newPaneID: {
+			HerdrInteractiveDeliveryAdapter: HerdrInteractiveDeliveryAdapter{
+				Backend: multiplexer.HerdrBackend{Config: newConfig, Client: newClient},
+			},
+		},
+	})
+	multiplexer.AdvanceHerdrPublicationGenerationLocked()
+	multiplexer.UnlockHerdrPublicationWrite()
+	t.Cleanup(replacement.Cleanup)
+	replacement.DisplacedCleanup()
+
+	select {
+	case err := <-hookDone:
+		if err != nil {
+			t.Fatalf("cleanup hook reentrant DefaultHandAdapter() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cleanup hook reentrant adapter lookup deadlocked")
+	}
+}
+
 func TestDefaultHandAdapterReverseCleanupKeepsOlderOverlappingHerdrRuntime(t *testing.T) {
 	paneID := "shared-native-pane-reverse"
 	firstClient := &fakeHerdrControlplaneWriteClient{snapshot: validHerdrControlplaneSnapshot()}

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -449,6 +449,7 @@ func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionCommercial, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
 		},
 	}
 }

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -449,7 +449,7 @@ func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionCommercial, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"test"}},
 		},
 	}
 }

--- a/internal/controlplane/controlplane_test.go
+++ b/internal/controlplane/controlplane_test.go
@@ -430,6 +430,7 @@ func (f *fakeHerdrControlplaneWriteClient) ClearPaneMetadata(context.Context, st
 }
 
 func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
+	now := time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC)
 	return multiplexer.HerdrReadConfig{
 		Enabled: true,
 		Runtime: multiplexer.HerdrRuntimeIdentity{
@@ -449,8 +450,8 @@ func validHerdrControlplaneConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionRecorded,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), RevalidatedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), CurrentReferences: []string{"test"}},
-			ComplianceNow:           func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: now.Add(-time.Hour), RevalidatedAt: now, CurrentReferences: []string{"test"}},
+			ComplianceNow:           func() time.Time { return now },
 		},
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -591,6 +591,7 @@ type DaemonState struct {
 	lastDeliveryMu                sync.RWMutex               // Issue #211: Mutex for lastDeliveryBySenderRecipient
 	nonDaemonDeliveryBudget       *nonDaemonDeliveryBudget   // Issue #572: bounded concurrency for post/auto-PING/manual-PING delivery
 	clock                         func() time.Time
+	ownershipBackend              multiplexer.OwnershipBackend
 }
 
 // NewDaemonState creates a new DaemonState instance (Issue #71).
@@ -598,6 +599,10 @@ type DaemonState struct {
 // IsSessionEnabled returns true for all sessions (#217).
 func NewDaemonState(drainWindowSeconds float64, contextID string) *DaemonState {
 	return newDaemonStateWithClock(drainWindowSeconds, contextID, time.Now)
+}
+
+func (ds *DaemonState) SetOwnershipBackend(backend multiplexer.OwnershipBackend) {
+	ds.ownershipBackend = backend
 }
 
 func newDaemonStateWithClock(drainWindowSeconds float64, contextID string, clock func() time.Time) *DaemonState {
@@ -899,12 +904,15 @@ func (ds *DaemonState) SetSessionEnabled(sessionName string, enabled bool) {
 }
 
 func (ds *DaemonState) persistSessionEnabledMarker(sessionName string, enabled bool) {
-	// Persist cross-daemon state in tmux server option (best-effort).
-	tmuxBackend := multiplexer.TmuxBackend{}
+	// Persist cross-daemon state in the configured ownership backend (best-effort).
+	backend := ds.ownershipBackend
+	if backend == nil {
+		backend = multiplexer.TmuxBackend{}
+	}
 	if enabled {
-		_ = tmuxBackend.SetSessionOwnerMarker(context.Background(), ds.contextID, sessionName, os.Getpid())
+		_ = backend.SetSessionOwnerMarker(context.Background(), ds.contextID, sessionName, os.Getpid())
 	} else {
-		_ = tmuxBackend.ClearSessionOwnerMarker(context.Background(), sessionName)
+		_ = backend.ClearSessionOwnerMarker(context.Background(), sessionName)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -593,6 +593,7 @@ type DaemonState struct {
 	nonDaemonDeliveryBudget       *nonDaemonDeliveryBudget   // Issue #572: bounded concurrency for post/auto-PING/manual-PING delivery
 	clock                         func() time.Time
 	ownershipBackend              multiplexer.OwnershipBackend
+	ownershipBackendForSession    func(string) multiplexer.OwnershipBackend
 }
 
 // NewDaemonState creates a new DaemonState instance (Issue #71).
@@ -604,6 +605,10 @@ func NewDaemonState(drainWindowSeconds float64, contextID string) *DaemonState {
 
 func (ds *DaemonState) SetOwnershipBackend(backend multiplexer.OwnershipBackend) {
 	ds.ownershipBackend = backend
+}
+
+func (ds *DaemonState) SetOwnershipBackendSelector(selector func(string) multiplexer.OwnershipBackend) {
+	ds.ownershipBackendForSession = selector
 }
 
 func newDaemonStateWithClock(drainWindowSeconds float64, contextID string, clock func() time.Time) *DaemonState {
@@ -910,15 +915,25 @@ func (ds *DaemonState) SetSessionEnabled(sessionName string, enabled bool) {
 
 func (ds *DaemonState) persistSessionEnabledMarker(sessionName string, enabled bool) {
 	// Persist cross-daemon state in the configured ownership backend (best-effort).
-	backend := ds.ownershipBackend
-	if backend == nil {
-		backend = multiplexer.TmuxBackend{}
-	}
+	backend := ds.ownershipBackendForSessionName(sessionName)
 	if enabled {
 		_ = backend.SetSessionOwnerMarker(context.Background(), ds.contextID, sessionName, os.Getpid())
 	} else {
 		_ = backend.ClearSessionOwnerMarker(context.Background(), sessionName)
 	}
+}
+
+func (ds *DaemonState) ownershipBackendForSessionName(sessionName string) multiplexer.OwnershipBackend {
+	if ds != nil && ds.ownershipBackendForSession != nil {
+		if backend := ds.ownershipBackendForSession(sessionName); backend != nil {
+			return backend
+		}
+	}
+	backend := ds.ownershipBackend
+	if backend == nil {
+		backend = multiplexer.TmuxBackend{}
+	}
+	return backend
 }
 
 // AutoEnableSessionIfNew enables a session if it has never been configured (Issue #91).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/envelope"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
@@ -748,6 +749,7 @@ func RunDaemonLoop(
 	idleTracker *idle.IdleTracker,
 	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo],
 	selfSession string,
+	herdrRuntime *herdrruntime.Runtime,
 ) {
 	runDaemonLoopWithWatcherEvents(
 		ctx,
@@ -769,6 +771,7 @@ func RunDaemonLoop(
 		idleTracker,
 		sharedNodes,
 		selfSession,
+		herdrRuntime,
 	)
 }
 
@@ -792,6 +795,7 @@ func runDaemonLoopWithWatcherEvents(
 	idleTracker *idle.IdleTracker,
 	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo],
 	selfSession string,
+	herdrRuntime *herdrruntime.Runtime,
 ) {
 	// Apply configurable queue warning threshold before any workers start.
 	if cfg != nil && cfg.DaemonSubmitQueueWarnThresholdMs > 0 {
@@ -820,6 +824,7 @@ func runDaemonLoopWithWatcherEvents(
 		idleTracker,
 		sharedNodes,
 		selfSession,
+		herdrRuntime,
 	)
 
 	scanTicker := time.NewTicker(time.Duration(cfg.ScanInterval * float64(time.Second)))

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -83,6 +83,31 @@ func TestDaemonStateSetSessionEnabledUsesInjectedOwnershipBackend(t *testing.T) 
 	}
 }
 
+func TestDaemonStateSetSessionEnabledSelectsOwnershipBackendPerSession(t *testing.T) {
+	ds := NewDaemonState(0, "ctx-main")
+	tmuxBackend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindTmux}
+	herdrBackend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindHerdr}
+	ds.SetOwnershipBackendSelector(func(sessionName string) multiplexer.OwnershipBackend {
+		if sessionName == "herdr-work" {
+			return herdrBackend
+		}
+		return tmuxBackend
+	})
+
+	ds.SetSessionEnabled("tmux-work", true)
+	if herdrBackend.setSessionCalls != 0 {
+		t.Fatalf("Herdr backend used for tmux session, calls=%d", herdrBackend.setSessionCalls)
+	}
+	if tmuxBackend.setSessionCalls != 1 || tmuxBackend.sessionName != "tmux-work" {
+		t.Fatalf("tmux backend calls=%d session=%q, want one tmux session write", tmuxBackend.setSessionCalls, tmuxBackend.sessionName)
+	}
+
+	ds.SetSessionEnabled("herdr-work", true)
+	if herdrBackend.setSessionCalls != 1 || herdrBackend.sessionName != "herdr-work" {
+		t.Fatalf("Herdr backend calls=%d session=%q, want one Herdr session write", herdrBackend.setSessionCalls, herdrBackend.sessionName)
+	}
+}
+
 func TestDaemonRuntimeClaimNewPanesUsesRegisteredHerdrOwnershipBackend(t *testing.T) {
 	backend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindHerdr}
 	unregister := multiplexer.RegisterOwnershipBackend(backend)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
 	"github.com/i9wa4/tmux-a2a-postman/internal/uinode"
 )
@@ -65,6 +67,53 @@ func TestDaemonStateDrainWindowUsesInjectedClock(t *testing.T) {
 	}
 }
 
+func TestDaemonStateSetSessionEnabledUsesInjectedOwnershipBackend(t *testing.T) {
+	ds := NewDaemonState(0, "ctx-main")
+	backend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindHerdr}
+	ds.SetOwnershipBackend(backend)
+
+	ds.SetSessionEnabled("work", true)
+	if backend.setSessionCalls != 1 || backend.contextID != "ctx-main" || backend.sessionName != "work" {
+		t.Fatalf("set session marker = calls:%d context:%q session:%q, want injected backend", backend.setSessionCalls, backend.contextID, backend.sessionName)
+	}
+
+	ds.SetSessionEnabled("work", false)
+	if backend.clearSessionCalls != 1 || backend.clearSessionName != "work" {
+		t.Fatalf("clear session marker = calls:%d session:%q, want injected backend", backend.clearSessionCalls, backend.clearSessionName)
+	}
+}
+
+func TestDaemonRuntimeClaimNewPanesUsesRegisteredHerdrOwnershipBackend(t *testing.T) {
+	backend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindHerdr}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	rt := &daemonRuntime{
+		contextID:    "ctx-main",
+		claimedPanes: make(map[string]bool),
+	}
+	rt.claimNewPanes(map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:      "workspace-1:pane-1",
+			SessionName: "work",
+			Backend:     string(multiplexer.BackendKindHerdr),
+		},
+	})
+
+	if backend.setPaneCalls != 1 {
+		t.Fatalf("set pane calls = %d, want 1", backend.setPaneCalls)
+	}
+	if backend.pane != multiplexer.HerdrPaneID("workspace-1:pane-1") {
+		t.Fatalf("pane = %#v, want Herdr pane resource", backend.pane)
+	}
+	if backend.paneContextID != "ctx-main" {
+		t.Fatalf("pane context = %q, want ctx-main", backend.paneContextID)
+	}
+	if !rt.claimedPanes["workspace-1:pane-1"] {
+		t.Fatal("Herdr pane was not recorded as claimed")
+	}
+}
+
 func TestReserveDeliveryRouteUsesExplicitClock(t *testing.T) {
 	ds := NewDaemonState(0, "ctx-main")
 	route := "orchestrator:messenger"
@@ -111,6 +160,56 @@ func TestReserveDeliveryRouteUsesExplicitClock(t *testing.T) {
 	if !reservedAt.Equal(start.Add(15 * time.Second)) {
 		t.Fatalf("post-gap reservedAt = %v, want %v", reservedAt, start.Add(15*time.Second))
 	}
+}
+
+type fakeDaemonOwnershipBackend struct {
+	kind multiplexer.BackendKind
+
+	setSessionCalls   int
+	contextID         string
+	sessionName       string
+	clearSessionCalls int
+	clearSessionName  string
+
+	setPaneCalls  int
+	pane          multiplexer.ResourceID
+	paneContextID string
+}
+
+func (f *fakeDaemonOwnershipBackend) Kind() multiplexer.BackendKind {
+	return f.kind
+}
+
+func (f *fakeDaemonOwnershipBackend) SessionOwnerMarker(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeDaemonOwnershipBackend) SetSessionOwnerMarker(_ context.Context, contextID, sessionName string, _ int) error {
+	f.setSessionCalls++
+	f.contextID = contextID
+	f.sessionName = sessionName
+	return nil
+}
+
+func (f *fakeDaemonOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, sessionName string) error {
+	f.clearSessionCalls++
+	f.clearSessionName = sessionName
+	return nil
+}
+
+func (f *fakeDaemonOwnershipBackend) PaneOwnerMarker(context.Context, multiplexer.ResourceID) (string, error) {
+	return "", nil
+}
+
+func (f *fakeDaemonOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID, contextID string) error {
+	f.setPaneCalls++
+	f.pane = pane
+	f.paneContextID = contextID
+	return nil
+}
+
+func (f *fakeDaemonOwnershipBackend) ClearPaneOwnerMarker(context.Context, multiplexer.ResourceID) error {
+	return nil
 }
 
 func TestReserveDeliveryRoute_BackoffWhenInFlightReservationOutlivesGap(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -196,13 +196,16 @@ func TestDaemonRuntimeClaimedPaneKeyIncludesBackendAndRuntimeIdentity(t *testing
 	}
 	herdrNodeB := herdrNodeA
 	herdrNodeB.HerdrSocketPath = "/tmp/herdr-b.sock"
+	herdrNodeC := herdrNodeA
+	herdrNodeC.HerdrTabID = "workspace-a:tab-2"
 
 	keys := map[string]bool{
 		claimedPaneKeyForNodeInfo(tmuxNode):   true,
 		claimedPaneKeyForNodeInfo(herdrNodeA): true,
 		claimedPaneKeyForNodeInfo(herdrNodeB): true,
+		claimedPaneKeyForNodeInfo(herdrNodeC): true,
 	}
-	if len(keys) != 3 {
+	if len(keys) != 4 {
 		t.Fatalf("claim keys collapsed across backend/runtime identities: %#v", keys)
 	}
 }
@@ -221,12 +224,16 @@ func TestDaemonRuntimePruneClaimedPanesUsesQualifiedIdentityForBackendTransition
 		HerdrWorkspaceID: "workspace-1",
 		HerdrTabID:       "workspace-1:tab-1",
 	}
+	herdrOtherTabNode := herdrNode
+	herdrOtherTabNode.HerdrTabID = "workspace-1:tab-2"
 	tmuxKey := claimedPaneKeyForNodeInfo(tmuxNode)
 	herdrKey := claimedPaneKeyForNodeInfo(herdrNode)
+	herdrOtherTabKey := claimedPaneKeyForNodeInfo(herdrOtherTabNode)
 	rt := &daemonRuntime{
 		claimedPanes: map[string]bool{
-			tmuxKey:  true,
-			herdrKey: true,
+			tmuxKey:          true,
+			herdrKey:         true,
+			herdrOtherTabKey: true,
 		},
 	}
 
@@ -237,6 +244,9 @@ func TestDaemonRuntimePruneClaimedPanesUsesQualifiedIdentityForBackendTransition
 	}
 	if !rt.claimedPanes[herdrKey] {
 		t.Fatalf("live Herdr claim was pruned: %#v", rt.claimedPanes)
+	}
+	if rt.claimedPanes[herdrOtherTabKey] {
+		t.Fatalf("stale Herdr claim from another tab survived prune: %#v", rt.claimedPanes)
 	}
 }
 
@@ -297,9 +307,15 @@ type fakeDaemonOwnershipBackend struct {
 	clearSessionCalls int
 	clearSessionName  string
 
-	setPaneCalls  int
-	pane          multiplexer.ResourceID
-	paneContextID string
+	setPaneCalls         int
+	pane                 multiplexer.ResourceID
+	paneContextID        string
+	paneMarkers          map[string]string
+	failSetByPaneContext map[string]error
+	failPaneNative       string
+	failSetFor           string
+	failSetErr           error
+	clearPaneErr         error
 }
 
 func (f *fakeDaemonOwnershipBackend) Kind() multiplexer.BackendKind {
@@ -323,7 +339,10 @@ func (f *fakeDaemonOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, 
 	return nil
 }
 
-func (f *fakeDaemonOwnershipBackend) PaneOwnerMarker(context.Context, multiplexer.ResourceID) (string, error) {
+func (f *fakeDaemonOwnershipBackend) PaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) (string, error) {
+	if f.paneMarkers != nil {
+		return f.paneMarkers[pane.Native], nil
+	}
 	return "", nil
 }
 
@@ -331,10 +350,27 @@ func (f *fakeDaemonOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane 
 	f.setPaneCalls++
 	f.pane = pane
 	f.paneContextID = contextID
+	if f.paneMarkers != nil {
+		f.paneMarkers[pane.Native] = contextID
+	}
+	if f.failSetByPaneContext != nil {
+		if err := f.failSetByPaneContext[pane.Native+"\x00"+contextID]; err != nil {
+			return err
+		}
+	}
+	if f.failSetErr != nil && (f.failPaneNative == "" || f.failPaneNative == pane.Native) && (f.failSetFor == "" || f.failSetFor == contextID) {
+		return f.failSetErr
+	}
 	return nil
 }
 
-func (f *fakeDaemonOwnershipBackend) ClearPaneOwnerMarker(context.Context, multiplexer.ResourceID) error {
+func (f *fakeDaemonOwnershipBackend) ClearPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) error {
+	if f.clearPaneErr != nil {
+		return f.clearPaneErr
+	}
+	if f.paneMarkers != nil {
+		delete(f.paneMarkers, pane.Native)
+	}
 	return nil
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -119,16 +119,26 @@ func TestDaemonRuntimeClaimNewPanesUsesRegisteredHerdrOwnershipBackend(t *testin
 	}
 	rt.claimNewPanes(map[string]discovery.NodeInfo{
 		"work:worker": {
-			PaneID:      "workspace-1:pane-1",
-			SessionName: "work",
-			Backend:     string(multiplexer.BackendKindHerdr),
+			PaneID:           "workspace-1:pane-1",
+			SessionName:      "work",
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  "/tmp/herdr.sock",
+			HerdrWorkspaceID: "workspace-1",
+			HerdrTabID:       "workspace-1:tab-1",
 		},
 	})
 
 	if backend.setPaneCalls != 1 {
 		t.Fatalf("set pane calls = %d, want 1", backend.setPaneCalls)
 	}
-	if backend.pane != multiplexer.HerdrPaneID("workspace-1:pane-1") {
+	wantPane := multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+		SocketPath:  "/tmp/herdr.sock",
+		SessionName: "work",
+		WorkspaceID: "workspace-1",
+		TabID:       "workspace-1:tab-1",
+		PaneID:      "workspace-1:pane-1",
+	}, "workspace-1:pane-1")
+	if backend.pane != wantPane {
 		t.Fatalf("pane = %#v, want Herdr pane resource", backend.pane)
 	}
 	if backend.paneContextID != "ctx-main" {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -144,8 +144,99 @@ func TestDaemonRuntimeClaimNewPanesUsesRegisteredHerdrOwnershipBackend(t *testin
 	if backend.paneContextID != "ctx-main" {
 		t.Fatalf("pane context = %q, want ctx-main", backend.paneContextID)
 	}
-	if !rt.claimedPanes["workspace-1:pane-1"] {
+	if !rt.claimedPanes[claimedPaneKeyForNodeInfo(discovery.NodeInfo{
+		PaneID:           "workspace-1:pane-1",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr.sock",
+		HerdrWorkspaceID: "workspace-1",
+		HerdrTabID:       "workspace-1:tab-1",
+	})] {
 		t.Fatal("Herdr pane was not recorded as claimed")
+	}
+}
+
+func TestDaemonRuntimeClaimNewPanesInitializesNilClaimMap(t *testing.T) {
+	backend := &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindHerdr}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	rt := &daemonRuntime{contextID: "ctx-main"}
+	nodeInfo := discovery.NodeInfo{
+		PaneID:           "workspace-1:pane-1",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr.sock",
+		HerdrWorkspaceID: "workspace-1",
+		HerdrTabID:       "workspace-1:tab-1",
+	}
+	rt.claimNewPanes(map[string]discovery.NodeInfo{"work:worker": nodeInfo})
+
+	if backend.setPaneCalls != 1 {
+		t.Fatalf("set pane calls = %d, want 1", backend.setPaneCalls)
+	}
+	if rt.claimedPanes == nil || !rt.claimedPanes[claimedPaneKeyForNodeInfo(nodeInfo)] {
+		t.Fatalf("claimedPanes = %#v, want initialized qualified claim", rt.claimedPanes)
+	}
+}
+
+func TestDaemonRuntimeClaimedPaneKeyIncludesBackendAndRuntimeIdentity(t *testing.T) {
+	tmuxNode := discovery.NodeInfo{
+		PaneID:      "%42",
+		SessionName: "work",
+		Backend:     string(multiplexer.BackendKindTmux),
+	}
+	herdrNodeA := discovery.NodeInfo{
+		PaneID:           "%42",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr-a.sock",
+		HerdrWorkspaceID: "workspace-a",
+		HerdrTabID:       "workspace-a:tab-1",
+	}
+	herdrNodeB := herdrNodeA
+	herdrNodeB.HerdrSocketPath = "/tmp/herdr-b.sock"
+
+	keys := map[string]bool{
+		claimedPaneKeyForNodeInfo(tmuxNode):   true,
+		claimedPaneKeyForNodeInfo(herdrNodeA): true,
+		claimedPaneKeyForNodeInfo(herdrNodeB): true,
+	}
+	if len(keys) != 3 {
+		t.Fatalf("claim keys collapsed across backend/runtime identities: %#v", keys)
+	}
+}
+
+func TestDaemonRuntimePruneClaimedPanesUsesQualifiedIdentityForBackendTransition(t *testing.T) {
+	tmuxNode := discovery.NodeInfo{
+		PaneID:      "%42",
+		SessionName: "work",
+		Backend:     string(multiplexer.BackendKindTmux),
+	}
+	herdrNode := discovery.NodeInfo{
+		PaneID:           "%42",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr.sock",
+		HerdrWorkspaceID: "workspace-1",
+		HerdrTabID:       "workspace-1:tab-1",
+	}
+	tmuxKey := claimedPaneKeyForNodeInfo(tmuxNode)
+	herdrKey := claimedPaneKeyForNodeInfo(herdrNode)
+	rt := &daemonRuntime{
+		claimedPanes: map[string]bool{
+			tmuxKey:  true,
+			herdrKey: true,
+		},
+	}
+
+	rt.pruneClaimedPanes(map[string]discovery.NodeInfo{"work:worker": herdrNode})
+
+	if rt.claimedPanes[tmuxKey] {
+		t.Fatalf("stale tmux claim survived backend transition: %#v", rt.claimedPanes)
+	}
+	if !rt.claimedPanes[herdrKey] {
+		t.Fatalf("live Herdr claim was pruned: %#v", rt.claimedPanes)
 	}
 }
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -19,6 +19,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
@@ -56,7 +57,8 @@ type daemonRuntime struct {
 	idleTracker                     *idle.IdleTracker
 	clock                           func() time.Time
 
-	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo]
+	sharedNodes  *atomic.Pointer[map[string]discovery.NodeInfo]
+	herdrRuntime *herdrruntime.Runtime
 
 	watchedDirs        map[string]bool
 	claimedPanes       map[string]bool
@@ -143,6 +145,7 @@ func newDaemonRuntime(
 	idleTracker *idle.IdleTracker,
 	sharedNodes *atomic.Pointer[map[string]discovery.NodeInfo],
 	selfSession string,
+	herdrRuntime *herdrruntime.Runtime,
 ) *daemonRuntime {
 	daemonSubmitWorkerLimit := daemonSubmitWorkerLimitFromConfig(cfg)
 	return &daemonRuntime{
@@ -162,6 +165,7 @@ func newDaemonRuntime(
 		daemonState:                   daemonState,
 		idleTracker:                   idleTracker,
 		sharedNodes:                   sharedNodes,
+		herdrRuntime:                  herdrRuntime,
 		watchedDirs:                   make(map[string]bool),
 		claimedPanes:                  make(map[string]bool),
 		prevSessionNodes:              make(map[string][]string),
@@ -329,10 +333,9 @@ func (rt *daemonRuntime) bootstrap() {
 
 func (rt *daemonRuntime) handleContextDone() {
 	rt.daemonState.enabledSessionsMu.RLock()
-	tmuxBackend := multiplexer.TmuxBackend{}
 	for sessionName, enabled := range rt.daemonState.enabledSessions {
 		if enabled {
-			_ = tmuxBackend.ClearSessionOwnerMarker(context.Background(), sessionName)
+			_ = rt.ownershipBackendForSession(sessionName).ClearSessionOwnerMarker(context.Background(), sessionName)
 		}
 	}
 	rt.daemonState.enabledSessionsMu.RUnlock()
@@ -1559,8 +1562,48 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 	if err != nil {
 		return nil, nil, err
 	}
+	if rt.herdrRuntime != nil {
+		herdrNodes, herdrCollisions, herdrErr := rt.herdrRuntime.Discover(context.Background(), rt.baseDir, rt.contextID)
+		if herdrErr != nil {
+			log.Printf("postman: WARNING: herdr node discovery failed: %v\n", herdrErr)
+		} else {
+			for nodeKey, nodeInfo := range herdrNodes {
+				freshNodes[nodeKey] = nodeInfo
+			}
+			collisions = append(collisions, herdrCollisions...)
+		}
+	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
 	return freshNodes, collisions, nil
+}
+
+func (rt *daemonRuntime) ownershipBackendForSession(sessionName string) multiplexer.OwnershipBackend {
+	if rt != nil && rt.herdrRuntime != nil && rt.herdrRuntime.OwnsSession(sessionName) {
+		if backend := rt.herdrRuntime.OwnershipBackend(); backend != nil {
+			return backend
+		}
+	}
+	if rt != nil && rt.daemonState != nil && rt.daemonState.ownershipBackend != nil {
+		return rt.daemonState.ownershipBackend
+	}
+	return multiplexer.TmuxBackend{}
+}
+
+func (rt *daemonRuntime) ownerForNodeSession(ctx context.Context, nodeInfo discovery.NodeInfo) string {
+	if multiplexer.BackendKindFromString(nodeInfo.Backend) != multiplexer.BackendKindHerdr {
+		return config.FindSessionOwner(rt.baseDir, nodeInfo.SessionName, rt.contextID)
+	}
+	backend := rt.ownershipBackendForSession(nodeInfo.SessionName)
+	marker, err := backend.SessionOwnerMarker(ctx, nodeInfo.SessionName)
+	if err != nil {
+		log.Printf("postman: WARNING: failed to read herdr session owner for %s: %v\n", nodeInfo.SessionName, err)
+		return ""
+	}
+	ownerContext, _, _ := strings.Cut(marker, ":")
+	if ownerContext != "" && ownerContext != rt.contextID {
+		return ownerContext
+	}
+	return ""
 }
 
 func (rt *daemonRuntime) storeSharedNodes() {
@@ -1865,7 +1908,7 @@ func (rt *daemonRuntime) dispatchPendingAutoPings(freshNodes map[string]discover
 				continue
 			}
 		}
-		if owner := config.FindSessionOwner(rt.baseDir, nodeInfo.SessionName, rt.contextID); owner != "" {
+		if owner := rt.ownerForNodeSession(context.Background(), nodeInfo); owner != "" {
 			continue
 		}
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1567,9 +1567,7 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		if herdrErr != nil {
 			log.Printf("postman: WARNING: herdr node discovery failed: %v\n", herdrErr)
 		} else {
-			for nodeKey, nodeInfo := range herdrNodes {
-				freshNodes[nodeKey] = nodeInfo
-			}
+			collisions = append(collisions, mergeRuntimeDiscoveredNodes(freshNodes, herdrNodes)...)
 			collisions = append(collisions, herdrCollisions...)
 		}
 	}
@@ -1583,10 +1581,29 @@ func (rt *daemonRuntime) ownershipBackendForSession(sessionName string) multiple
 			return backend
 		}
 	}
-	if rt != nil && rt.daemonState != nil && rt.daemonState.ownershipBackend != nil {
-		return rt.daemonState.ownershipBackend
+	if rt != nil && rt.daemonState != nil {
+		return rt.daemonState.ownershipBackendForSessionName(sessionName)
 	}
 	return multiplexer.TmuxBackend{}
+}
+
+func mergeRuntimeDiscoveredNodes(dst, src map[string]discovery.NodeInfo) []discovery.CollisionReport {
+	if dst == nil || len(src) == 0 {
+		return nil
+	}
+	var collisions []discovery.CollisionReport
+	for nodeKey, nodeInfo := range src {
+		if existing, exists := dst[nodeKey]; exists && multiplexer.BackendKindFromString(existing.Backend) != multiplexer.BackendKindFromString(nodeInfo.Backend) {
+			collisions = append(collisions, discovery.CollisionReport{
+				NodeKey:      nodeKey,
+				WinnerPaneID: existing.PaneID,
+				LoserPaneID:  nodeInfo.PaneID,
+			})
+			continue
+		}
+		dst[nodeKey] = nodeInfo
+	}
+	return collisions
 }
 
 func (rt *daemonRuntime) ownerForNodeSession(ctx context.Context, nodeInfo discovery.NodeInfo) string {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1695,12 +1695,18 @@ func (rt *daemonRuntime) pruneClaimedPanes(freshNodes map[string]discovery.NodeI
 }
 
 func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo) {
-	tmuxBackend := multiplexer.TmuxBackend{}
 	for _, nodeInfo := range freshNodes {
 		if nodeInfo.PaneID == "" || rt.claimedPanes[nodeInfo.PaneID] {
 			continue
 		}
-		if err := tmuxBackend.SetPaneOwnerMarker(context.Background(), multiplexer.TmuxPaneID(nodeInfo.PaneID), rt.contextID); err != nil {
+		backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+		backend, err := multiplexer.OwnershipBackendForKind(backendKind)
+		if err != nil {
+			log.Printf("postman: WARNING: failed to select ownership backend for pane %s: %v\n", nodeInfo.PaneID, err)
+			continue
+		}
+		pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+		if err := backend.SetPaneOwnerMarker(context.Background(), pane, rt.contextID); err != nil {
 			log.Printf("postman: WARNING: failed to claim pane %s: %v\n", nodeInfo.PaneID, err)
 			continue
 		}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -335,7 +335,9 @@ func (rt *daemonRuntime) handleContextDone() {
 	rt.daemonState.enabledSessionsMu.RLock()
 	for sessionName, enabled := range rt.daemonState.enabledSessions {
 		if enabled {
-			_ = rt.ownershipBackendForSession(sessionName).ClearSessionOwnerMarker(context.Background(), sessionName)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = rt.ownershipBackendForSession(sessionName).ClearSessionOwnerMarker(ctx, sessionName)
+			cancel()
 		}
 	}
 	rt.daemonState.enabledSessionsMu.RUnlock()
@@ -1563,7 +1565,9 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		return nil, nil, err
 	}
 	if rt.herdrRuntime != nil {
-		herdrNodes, herdrCollisions, herdrErr := rt.herdrRuntime.Discover(context.Background(), rt.baseDir, rt.contextID)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		herdrNodes, herdrCollisions, herdrErr := rt.herdrRuntime.Discover(ctx, rt.baseDir, rt.contextID)
+		cancel()
 		if herdrErr != nil {
 			log.Printf("postman: WARNING: herdr node discovery failed: %v\n", herdrErr)
 		} else {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1595,16 +1595,25 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 	if rt.herdrRuntime != nil {
 		claimedPanes := make([]string, 0)
 		prepare := func(publication *herdrruntime.FinalPublication) error {
-			for _, nodeInfo := range freshNodes {
+			nodeKeys := make([]string, 0, len(freshNodes))
+			for nodeKey := range freshNodes {
+				nodeKeys = append(nodeKeys, nodeKey)
+			}
+			sort.Strings(nodeKeys)
+			for _, nodeKey := range nodeKeys {
+				nodeInfo := freshNodes[nodeKey]
 				claimKey := claimedPaneKeyForNodeInfo(nodeInfo)
 				if claimKey == "" || rt.claimedPanes[claimKey] {
 					continue
 				}
 				backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
-				var backend multiplexer.OwnershipBackend
+				paneResource := paneResourceForNodeInfo(nodeInfo)
 				if backendKind == multiplexer.BackendKindHerdr {
-					backend = publication
+					if err := publication.SetPaneOwnerMarker(context.Background(), paneResource, rt.contextID); err != nil {
+						return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
+					}
 				} else {
+					var backend multiplexer.OwnershipBackend
 					if rt.daemonState != nil {
 						backend = rt.daemonState.ownershipBackendForSessionName(nodeInfo.SessionName)
 					} else {
@@ -1614,9 +1623,9 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 							return fmt.Errorf("selecting ownership backend for pane %s: %w", nodeInfo.PaneID, backendErr)
 						}
 					}
-				}
-				if err := backend.SetPaneOwnerMarker(context.Background(), paneResourceForNodeInfo(nodeInfo), rt.contextID); err != nil {
-					return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
+					if err := publication.SetPaneOwnerMarkerWithBackend(context.Background(), backend, paneResource, rt.contextID); err != nil {
+						return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
+					}
 				}
 				claimedPanes = append(claimedPanes, claimKey)
 			}
@@ -1845,13 +1854,14 @@ func claimedPaneKeyForNodeInfo(nodeInfo discovery.NodeInfo) string {
 		return ""
 	}
 	pane := paneResourceForNodeInfo(nodeInfo)
-	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s",
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s",
 		pane.Backend,
 		pane.Kind,
 		pane.Native,
 		pane.HerdrRuntime.SocketPath,
 		pane.HerdrRuntime.SessionName,
 		pane.HerdrRuntime.WorkspaceID,
+		pane.HerdrRuntime.TabID,
 		pane.HerdrRuntime.PaneID,
 	)
 }

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1571,13 +1571,17 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		freshNodes = make(map[string]discovery.NodeInfo)
 		collisions = nil
 	}
+	var herdrToken uint64
 	if rt.herdrRuntime != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		herdrNodes, herdrCollisions, herdrErr := rt.herdrRuntime.Discover(ctx, rt.baseDir, rt.contextID)
+		var herdrNodes map[string]discovery.NodeInfo
+		var herdrCollisions []discovery.CollisionReport
+		var herdrErr error
+		herdrNodes, herdrCollisions, herdrToken, herdrErr = rt.herdrRuntime.DiscoverForReconcile(ctx, rt.baseDir, rt.contextID)
 		cancel()
 		if herdrErr != nil {
 			log.Printf("postman: WARNING: herdr node discovery failed: %v\n", herdrErr)
-			rt.herdrRuntime.ClearPaneRoutes()
+			rt.herdrRuntime.ClearPaneRoutesForToken(herdrToken)
 		} else {
 			collisions = append(collisions, mergeRuntimeDiscoveredNodes(freshNodes, herdrNodes)...)
 			collisions = append(collisions, herdrCollisions...)
@@ -1585,7 +1589,7 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
 	if rt.herdrRuntime != nil {
-		rt.herdrRuntime.ReconcileFinalNodes(freshNodes)
+		rt.herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)
 	}
 	return freshNodes, collisions, nil
 }

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1592,9 +1592,43 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
 	if rt.herdrRuntime != nil {
-		if err := rt.herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, freshNodes, nil, func() {
+		claimedPanes := make([]string, 0)
+		prepare := func(publication *herdrruntime.FinalPublication) error {
+			for _, nodeInfo := range freshNodes {
+				if nodeInfo.PaneID == "" || rt.claimedPanes[nodeInfo.PaneID] {
+					continue
+				}
+				backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+				var backend multiplexer.OwnershipBackend
+				if backendKind == multiplexer.BackendKindHerdr {
+					backend = publication
+				} else {
+					if rt.daemonState != nil {
+						backend = rt.daemonState.ownershipBackendForSessionName(nodeInfo.SessionName)
+					} else {
+						var backendErr error
+						backend, backendErr = multiplexer.OwnershipBackendForKind(backendKind)
+						if backendErr != nil {
+							return fmt.Errorf("selecting ownership backend for pane %s: %w", nodeInfo.PaneID, backendErr)
+						}
+					}
+				}
+				if err := backend.SetPaneOwnerMarker(context.Background(), paneResourceForNodeInfo(nodeInfo), rt.contextID); err != nil {
+					return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
+				}
+				claimedPanes = append(claimedPanes, nodeInfo.PaneID)
+			}
+			return nil
+		}
+		if err := rt.herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, freshNodes, prepare, func() {
 			rt.nodes = freshNodes
 			rt.storeSharedNodesLocked()
+			if rt.claimedPanes == nil {
+				rt.claimedPanes = make(map[string]bool)
+			}
+			for _, paneID := range claimedPanes {
+				rt.claimedPanes[paneID] = true
+			}
 		}); err != nil {
 			return nil, nil, err
 		}
@@ -1787,6 +1821,20 @@ func (rt *daemonRuntime) pruneClaimedPanes(freshNodes map[string]discovery.NodeI
 	}
 }
 
+func paneResourceForNodeInfo(nodeInfo discovery.NodeInfo) multiplexer.ResourceID {
+	backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
+	if backendKind == multiplexer.BackendKindHerdr {
+		return multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  nodeInfo.HerdrSocketPath,
+			SessionName: nodeInfo.SessionName,
+			WorkspaceID: nodeInfo.HerdrWorkspaceID,
+			TabID:       nodeInfo.HerdrTabID,
+			PaneID:      nodeInfo.PaneID,
+		}, nodeInfo.PaneID)
+	}
+	return multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+}
+
 func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo) {
 	for _, nodeInfo := range freshNodes {
 		if nodeInfo.PaneID == "" || rt.claimedPanes[nodeInfo.PaneID] {
@@ -1798,17 +1846,7 @@ func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo)
 			log.Printf("postman: WARNING: failed to select ownership backend for pane %s: %v\n", nodeInfo.PaneID, err)
 			continue
 		}
-		pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
-		if backendKind == multiplexer.BackendKindHerdr && nodeInfo.HerdrSocketPath != "" && nodeInfo.HerdrWorkspaceID != "" {
-			pane = multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
-				SocketPath:  nodeInfo.HerdrSocketPath,
-				SessionName: nodeInfo.SessionName,
-				WorkspaceID: nodeInfo.HerdrWorkspaceID,
-				TabID:       nodeInfo.HerdrTabID,
-				PaneID:      nodeInfo.PaneID,
-			}, nodeInfo.PaneID)
-		}
-		if err := backend.SetPaneOwnerMarker(context.Background(), pane, rt.contextID); err != nil {
+		if err := backend.SetPaneOwnerMarker(context.Background(), paneResourceForNodeInfo(nodeInfo), rt.contextID); err != nil {
 			log.Printf("postman: WARNING: failed to claim pane %s: %v\n", nodeInfo.PaneID, err)
 			continue
 		}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1062,9 +1062,12 @@ func (rt *daemonRuntime) dispatchPostDelivery(eventPath, filename string, nodes 
 			// mutated afterward, so it is safe to read directly here.
 			var retryNodes map[string]discovery.NodeInfo
 			if rt.sharedNodes != nil {
-				if cached := rt.sharedNodes.Load(); cached != nil {
+				multiplexer.LockHerdrPublicationRead()
+				cached := rt.sharedNodes.Load()
+				if cached != nil {
 					retryNodes = *cached
 				}
+				multiplexer.UnlockHerdrPublicationRead()
 			}
 			if retryNodes == nil {
 				// Only reached when sharedNodes is unset (e.g. a
@@ -1589,10 +1592,9 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
 	if rt.herdrRuntime != nil {
-		if err := rt.herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrToken, freshNodes, func() error {
+		if err := rt.herdrRuntime.ReconcileFinalNodesForTokenAndCommit(herdrToken, freshNodes, nil, func() {
 			rt.nodes = freshNodes
-			rt.storeSharedNodes()
-			return nil
+			rt.storeSharedNodesLocked()
 		}); err != nil {
 			return nil, nil, err
 		}
@@ -1649,6 +1651,12 @@ func (rt *daemonRuntime) ownerForNodeSession(ctx context.Context, nodeInfo disco
 }
 
 func (rt *daemonRuntime) storeSharedNodes() {
+	multiplexer.LockHerdrPublicationWrite()
+	defer multiplexer.UnlockHerdrPublicationWrite()
+	rt.storeSharedNodesLocked()
+}
+
+func (rt *daemonRuntime) storeSharedNodesLocked() {
 	if rt.sharedNodes == nil {
 		return
 	}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1570,12 +1570,16 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		cancel()
 		if herdrErr != nil {
 			log.Printf("postman: WARNING: herdr node discovery failed: %v\n", herdrErr)
+			rt.herdrRuntime.ClearPaneRoutes()
 		} else {
 			collisions = append(collisions, mergeRuntimeDiscoveredNodes(freshNodes, herdrNodes)...)
 			collisions = append(collisions, herdrCollisions...)
 		}
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
+	if rt.herdrRuntime != nil {
+		rt.herdrRuntime.ReconcileFinalNodes(freshNodes)
+	}
 	return freshNodes, collisions, nil
 }
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -938,6 +938,7 @@ func (rt *daemonRuntime) processActivePostEvent(eventPath, filename string) {
 
 	freshNodes, _, err := rt.discoverNodes()
 	if err == nil {
+		rt.pruneClaimedPanes(freshNodes)
 		rt.pruneWatchedDirs(freshNodes)
 		rt.claimNewPanes(freshNodes)
 		rt.pruneKnownNodes(freshNodes)
@@ -1595,7 +1596,8 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		claimedPanes := make([]string, 0)
 		prepare := func(publication *herdrruntime.FinalPublication) error {
 			for _, nodeInfo := range freshNodes {
-				if nodeInfo.PaneID == "" || rt.claimedPanes[nodeInfo.PaneID] {
+				claimKey := claimedPaneKeyForNodeInfo(nodeInfo)
+				if claimKey == "" || rt.claimedPanes[claimKey] {
 					continue
 				}
 				backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
@@ -1616,7 +1618,7 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 				if err := backend.SetPaneOwnerMarker(context.Background(), paneResourceForNodeInfo(nodeInfo), rt.contextID); err != nil {
 					return fmt.Errorf("claiming pane %s: %w", nodeInfo.PaneID, err)
 				}
-				claimedPanes = append(claimedPanes, nodeInfo.PaneID)
+				claimedPanes = append(claimedPanes, claimKey)
 			}
 			return nil
 		}
@@ -1626,8 +1628,8 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 			if rt.claimedPanes == nil {
 				rt.claimedPanes = make(map[string]bool)
 			}
-			for _, paneID := range claimedPanes {
-				rt.claimedPanes[paneID] = true
+			for _, claimKey := range claimedPanes {
+				rt.claimedPanes[claimKey] = true
 			}
 		}); err != nil {
 			return nil, nil, err
@@ -1808,15 +1810,18 @@ func (rt *daemonRuntime) pruneKnownNodes(freshNodes map[string]discovery.NodeInf
 }
 
 func (rt *daemonRuntime) pruneClaimedPanes(freshNodes map[string]discovery.NodeInfo) {
-	livePaneIDs := make(map[string]bool, len(freshNodes))
+	if rt.claimedPanes == nil {
+		return
+	}
+	liveClaimKeys := make(map[string]bool, len(freshNodes))
 	for _, nodeInfo := range freshNodes {
-		if nodeInfo.PaneID != "" {
-			livePaneIDs[nodeInfo.PaneID] = true
+		if claimKey := claimedPaneKeyForNodeInfo(nodeInfo); claimKey != "" {
+			liveClaimKeys[claimKey] = true
 		}
 	}
-	for paneID := range rt.claimedPanes {
-		if !livePaneIDs[paneID] {
-			delete(rt.claimedPanes, paneID)
+	for claimKey := range rt.claimedPanes {
+		if !liveClaimKeys[claimKey] {
+			delete(rt.claimedPanes, claimKey)
 		}
 	}
 }
@@ -1835,9 +1840,29 @@ func paneResourceForNodeInfo(nodeInfo discovery.NodeInfo) multiplexer.ResourceID
 	return multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
 }
 
+func claimedPaneKeyForNodeInfo(nodeInfo discovery.NodeInfo) string {
+	if nodeInfo.PaneID == "" {
+		return ""
+	}
+	pane := paneResourceForNodeInfo(nodeInfo)
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s",
+		pane.Backend,
+		pane.Kind,
+		pane.Native,
+		pane.HerdrRuntime.SocketPath,
+		pane.HerdrRuntime.SessionName,
+		pane.HerdrRuntime.WorkspaceID,
+		pane.HerdrRuntime.PaneID,
+	)
+}
+
 func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo) {
+	if rt.claimedPanes == nil {
+		rt.claimedPanes = make(map[string]bool)
+	}
 	for _, nodeInfo := range freshNodes {
-		if nodeInfo.PaneID == "" || rt.claimedPanes[nodeInfo.PaneID] {
+		claimKey := claimedPaneKeyForNodeInfo(nodeInfo)
+		if claimKey == "" || rt.claimedPanes[claimKey] {
 			continue
 		}
 		backendKind := multiplexer.BackendKindFromString(nodeInfo.Backend)
@@ -1850,7 +1875,7 @@ func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo)
 			log.Printf("postman: WARNING: failed to claim pane %s: %v\n", nodeInfo.PaneID, err)
 			continue
 		}
-		rt.claimedPanes[nodeInfo.PaneID] = true
+		rt.claimedPanes[claimKey] = true
 	}
 }
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1588,8 +1588,14 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		}
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
-	if rt.herdrRuntime != nil && !rt.herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes) {
-		return nil, nil, fmt.Errorf("stale Herdr final reconcile token")
+	if rt.herdrRuntime != nil {
+		if err := rt.herdrRuntime.ReconcileFinalNodesForTokenAndPublish(herdrToken, freshNodes, func() error {
+			rt.nodes = freshNodes
+			rt.storeSharedNodes()
+			return nil
+		}); err != nil {
+			return nil, nil, err
+		}
 	}
 	return freshNodes, collisions, nil
 }
@@ -1785,6 +1791,15 @@ func (rt *daemonRuntime) claimNewPanes(freshNodes map[string]discovery.NodeInfo)
 			continue
 		}
 		pane := multiplexer.PaneIDForBackend(backendKind, nodeInfo.PaneID)
+		if backendKind == multiplexer.BackendKindHerdr && nodeInfo.HerdrSocketPath != "" && nodeInfo.HerdrWorkspaceID != "" {
+			pane = multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+				SocketPath:  nodeInfo.HerdrSocketPath,
+				SessionName: nodeInfo.SessionName,
+				WorkspaceID: nodeInfo.HerdrWorkspaceID,
+				TabID:       nodeInfo.HerdrTabID,
+				PaneID:      nodeInfo.PaneID,
+			}, nodeInfo.PaneID)
+		}
 		if err := backend.SetPaneOwnerMarker(context.Background(), pane, rt.contextID); err != nil {
 			log.Printf("postman: WARNING: failed to claim pane %s: %v\n", nodeInfo.PaneID, err)
 			continue

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1588,8 +1588,8 @@ func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []disco
 		}
 	}
 	filterNodesByRuntimeConfig(freshNodes, rt.cfg)
-	if rt.herdrRuntime != nil {
-		rt.herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes)
+	if rt.herdrRuntime != nil && !rt.herdrRuntime.ReconcileFinalNodesForToken(herdrToken, freshNodes) {
+		return nil, nil, fmt.Errorf("stale Herdr final reconcile token")
 	}
 	return freshNodes, collisions, nil
 }

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -36,6 +36,8 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/uinode"
 )
 
+var discoverNodesWithCollisionsForRuntime = discovery.DiscoverNodesWithCollisions
+
 type daemonRuntime struct {
 	baseDir     string
 	sessionDir  string
@@ -1560,9 +1562,14 @@ func (rt *daemonRuntime) handleInboxCheckTick() {
 }
 
 func (rt *daemonRuntime) discoverNodes() (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
-	freshNodes, collisions, err := discovery.DiscoverNodesWithCollisions(rt.baseDir, rt.contextID, rt.selfSession)
+	freshNodes, collisions, err := discoverNodesWithCollisionsForRuntime(rt.baseDir, rt.contextID, rt.selfSession)
 	if err != nil {
-		return nil, nil, err
+		if rt.herdrRuntime == nil {
+			return nil, nil, err
+		}
+		log.Printf("postman: WARNING: tmux node discovery failed; continuing Herdr reconciliation: %v\n", err)
+		freshNodes = make(map[string]discovery.NodeInfo)
+		collisions = nil
 	}
 	if rt.herdrRuntime != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -435,6 +435,7 @@ func TestNewDaemonRuntimeConfiguresDaemonSubmitWorkerLimit(t *testing.T) {
 				nil,
 				nil,
 				"",
+				nil,
 			)
 			if got := cap(rt.daemonSubmitSem); got != tt.want {
 				t.Fatalf("daemonSubmitSem cap = %d, want %d", got, tt.want)

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/msgtrace"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/status"
 	"github.com/i9wa4/tmux-a2a-postman/internal/tui"
@@ -2415,6 +2416,33 @@ func TestNewAutoPingDispatchSnapshot_ClonesDispatchInputs(t *testing.T) {
 	}
 	if got := snapshot.adjacency["review:worker"][0]; got != "review:critic" {
 		t.Fatalf("snapshot adjacency = %q, want review:critic", got)
+	}
+}
+
+func TestMergeRuntimeDiscoveredNodesReportsCrossBackendCollisionWithoutOverwrite(t *testing.T) {
+	nodes := map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:      "%1",
+			SessionName: "work",
+			Backend:     string(multiplexer.BackendKindTmux),
+		},
+	}
+	collisions := mergeRuntimeDiscoveredNodes(nodes, map[string]discovery.NodeInfo{
+		"work:worker": {
+			PaneID:      "workspace-1:pane-1",
+			SessionName: "work",
+			Backend:     string(multiplexer.BackendKindHerdr),
+		},
+	})
+
+	if got := nodes["work:worker"].PaneID; got != "%1" {
+		t.Fatalf("node pane = %q, want original tmux pane", got)
+	}
+	if len(collisions) != 1 {
+		t.Fatalf("collisions = %#v, want one cross-backend collision", collisions)
+	}
+	if collisions[0].NodeKey != "work:worker" || collisions[0].WinnerPaneID != "%1" || collisions[0].LoserPaneID != "workspace-1:pane-1" {
+		t.Fatalf("collision = %#v, want tmux winner and Herdr loser", collisions[0])
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -2466,9 +2466,11 @@ func TestDiscoverNodesContinuesHerdrReconciliationWhenTmuxDiscoveryFails(t *test
 		t.Fatalf("herdrruntime.New() error = %v", err)
 	}
 	t.Cleanup(herdrRuntime.Close)
-	if _, _, err := herdrRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+	initialNodes, _, err := herdrRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("initial Herdr Discover() error = %v", err)
 	}
+	herdrRuntime.ReconcileFinalNodes(initialNodes)
 	target := controlplane.TargetForNode("work:worker", discovery.NodeInfo{
 		PaneID:           "workspace-1:pane-1",
 		SessionName:      "work",
@@ -2507,6 +2509,73 @@ func TestDiscoverNodesContinuesHerdrReconciliationWhenTmuxDiscoveryFails(t *test
 	}
 	if err := herdrRuntime.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr ownership route remained after tmux failure plus Herdr reconciliation")
+	}
+}
+
+func TestDiscoverNodesDoesNotPublishHerdrCollisionLoserDuringFinalization(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	sessionDir := filepath.Join(baseDir, contextID, sessionName)
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeDaemonHerdrClient{snapshot: daemonHerdrSnapshot("")}
+	cfg := config.DefaultConfig()
+	cfg.Nodes = map[string]config.NodeConfig{"worker": {}}
+	cfg.Herdr = daemonHerdrConfig()
+	herdrRuntime, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("herdrruntime.New() error = %v", err)
+	}
+	t.Cleanup(herdrRuntime.Close)
+
+	originalDiscover := discoverNodesWithCollisionsForRuntime
+	discoverNodesWithCollisionsForRuntime = func(string, string, string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"work:worker": {
+				PaneID:      "%tmux-winner",
+				SessionName: "work",
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindTmux),
+			},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesWithCollisionsForRuntime = originalDiscover })
+	rt := &daemonRuntime{
+		baseDir:      baseDir,
+		contextID:    contextID,
+		selfSession:  sessionName,
+		cfg:          cfg,
+		herdrRuntime: herdrRuntime,
+	}
+
+	nodes, collisions, err := rt.discoverNodes()
+	if err != nil {
+		t.Fatalf("discoverNodes() error = %v", err)
+	}
+	if got := nodes["work:worker"].PaneID; got != "%tmux-winner" {
+		t.Fatalf("work:worker pane = %q, want tmux winner", got)
+	}
+	if len(collisions) != 1 || collisions[0].NodeKey != "work:worker" || collisions[0].LoserPaneID != "workspace-1:pane-1" {
+		t.Fatalf("collisions = %#v, want Herdr loser collision", collisions)
+	}
+	loserTarget := controlplane.TargetForNode("work:worker", discovery.NodeInfo{
+		PaneID:           "workspace-1:pane-1",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  cfg.Herdr.SocketPath,
+		HerdrWorkspaceID: cfg.Herdr.WorkspaceID,
+		HerdrTabID:       "workspace-1:tab-1",
+	})
+	if _, err := controlplane.DefaultHandAdapter(loserTarget); err == nil {
+		t.Fatal("daemon Herdr collision loser was addressable during finalization")
+	}
+	if err := herdrRuntime.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("daemon Herdr collision loser ownership route was addressable during finalization")
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -2588,6 +2589,154 @@ func TestDiscoverNodesDoesNotPublishHerdrCollisionLoserDuringFinalization(t *tes
 	}
 	if err := herdrRuntime.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("daemon Herdr collision loser ownership route was addressable during finalization")
+	}
+}
+
+func TestDiscoverNodesRollsBackNonHerdrPrepareClaimOnLaterFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	sessionDir := filepath.Join(baseDir, contextID, sessionName)
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeDaemonHerdrClient{snapshot: daemonEmptyHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Nodes = map[string]config.NodeConfig{"alpha": {}, "zeta": {}}
+	cfg.Herdr = daemonHerdrConfig()
+	herdrRuntime, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("herdrruntime.New() error = %v", err)
+	}
+	t.Cleanup(herdrRuntime.Close)
+
+	claimErr := errors.New("claim failed")
+	backend := &fakeDaemonOwnershipBackend{
+		kind:           multiplexer.BackendKindTmux,
+		paneMarkers:    map[string]string{"%1": "ctx-old"},
+		failPaneNative: "%2",
+		failSetFor:     contextID,
+		failSetErr:     claimErr,
+	}
+	originalDiscover := discoverNodesWithCollisionsForRuntime
+	discoverNodesWithCollisionsForRuntime = func(string, string, string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"work:alpha": {
+				PaneID:      "%1",
+				SessionName: sessionName,
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindTmux),
+			},
+			"work:zeta": {
+				PaneID:      "%2",
+				SessionName: sessionName,
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindTmux),
+			},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesWithCollisionsForRuntime = originalDiscover })
+
+	rt := &daemonRuntime{
+		baseDir:      baseDir,
+		contextID:    contextID,
+		selfSession:  sessionName,
+		cfg:          cfg,
+		herdrRuntime: herdrRuntime,
+		daemonState: &DaemonState{
+			contextID:        contextID,
+			enabledSessions:  map[string]bool{sessionName: true},
+			ownershipBackend: backend,
+		},
+		claimedPanes: map[string]bool{},
+	}
+
+	if _, _, err := rt.discoverNodes(); !errors.Is(err, claimErr) {
+		t.Fatalf("discoverNodes() error = %v, want claim failure", err)
+	}
+	if got := backend.paneMarkers["%1"]; got != "ctx-old" {
+		t.Fatalf("marker for earlier pane = %q, want restored ctx-old", got)
+	}
+	if got := backend.paneMarkers["%2"]; got != "" {
+		t.Fatalf("marker for failed pane = %q, want cleared", got)
+	}
+	if len(rt.nodes) != 0 {
+		t.Fatalf("runtime nodes committed after failed prepare: %#v", rt.nodes)
+	}
+	if len(rt.claimedPanes) != 0 {
+		t.Fatalf("claimedPanes committed after failed prepare: %#v", rt.claimedPanes)
+	}
+}
+
+func TestDiscoverNodesPropagatesNonHerdrPrepareRollbackFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	sessionDir := filepath.Join(baseDir, contextID, sessionName)
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeDaemonHerdrClient{snapshot: daemonEmptyHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Nodes = map[string]config.NodeConfig{"alpha": {}, "zeta": {}}
+	cfg.Herdr = daemonHerdrConfig()
+	herdrRuntime, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("herdrruntime.New() error = %v", err)
+	}
+	t.Cleanup(herdrRuntime.Close)
+
+	claimErr := errors.New("claim failed")
+	rollbackErr := errors.New("rollback failed")
+	backend := &fakeDaemonOwnershipBackend{
+		kind:        multiplexer.BackendKindTmux,
+		paneMarkers: map[string]string{"%1": "ctx-old"},
+		failSetByPaneContext: map[string]error{
+			"%1\x00ctx-old":      rollbackErr,
+			"%2\x00" + contextID: claimErr,
+		},
+	}
+	originalDiscover := discoverNodesWithCollisionsForRuntime
+	discoverNodesWithCollisionsForRuntime = func(string, string, string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"work:alpha": {
+				PaneID:      "%1",
+				SessionName: sessionName,
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindTmux),
+			},
+			"work:zeta": {
+				PaneID:      "%2",
+				SessionName: sessionName,
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindTmux),
+			},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesWithCollisionsForRuntime = originalDiscover })
+
+	rt := &daemonRuntime{
+		baseDir:      baseDir,
+		contextID:    contextID,
+		selfSession:  sessionName,
+		cfg:          cfg,
+		herdrRuntime: herdrRuntime,
+		daemonState: &DaemonState{
+			contextID:        contextID,
+			enabledSessions:  map[string]bool{sessionName: true},
+			ownershipBackend: backend,
+		},
+		claimedPanes: map[string]bool{},
+	}
+
+	if _, _, err := rt.discoverNodes(); !errors.Is(err, claimErr) || !errors.Is(err, rollbackErr) {
+		t.Fatalf("discoverNodes() error = %v, want claim and rollback failures", err)
 	}
 }
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -2495,6 +2495,12 @@ func TestDiscoverNodesContinuesHerdrReconciliationWhenTmuxDiscoveryFails(t *test
 		selfSession:  sessionName,
 		cfg:          cfg,
 		herdrRuntime: herdrRuntime,
+		daemonState: &DaemonState{
+			contextID:        contextID,
+			enabledSessions:  map[string]bool{sessionName: true},
+			ownershipBackend: &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindTmux},
+		},
+		claimedPanes: map[string]bool{},
 	}
 
 	nodes, collisions, err := rt.discoverNodes()
@@ -2551,6 +2557,12 @@ func TestDiscoverNodesDoesNotPublishHerdrCollisionLoserDuringFinalization(t *tes
 		selfSession:  sessionName,
 		cfg:          cfg,
 		herdrRuntime: herdrRuntime,
+		daemonState: &DaemonState{
+			contextID:        contextID,
+			enabledSessions:  map[string]bool{sessionName: true},
+			ownershipBackend: &fakeDaemonOwnershipBackend{kind: multiplexer.BackendKindTmux},
+		},
+		claimedPanes: map[string]bool{},
 	}
 
 	nodes, collisions, err := rt.discoverNodes()
@@ -2679,7 +2691,9 @@ func newControlledDaemonSnapshot(snapshot multiplexer.HerdrSessionSnapshot, err 
 }
 
 type sequencedDaemonHerdrClient struct {
-	calls chan *controlledDaemonSnapshot
+	calls  chan *controlledDaemonSnapshot
+	mu     sync.Mutex
+	latest multiplexer.HerdrSessionSnapshot
 }
 
 func (s *sequencedDaemonHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
@@ -2687,13 +2701,22 @@ func (s *sequencedDaemonHerdrClient) Ping(context.Context) (multiplexer.HerdrRes
 }
 
 func (s *sequencedDaemonHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
-	call := <-s.calls
-	close(call.started)
-	<-call.release
-	if call.err != nil {
-		return multiplexer.HerdrSessionSnapshot{}, call.err
+	select {
+	case call := <-s.calls:
+		close(call.started)
+		<-call.release
+		if call.err != nil {
+			return multiplexer.HerdrSessionSnapshot{}, call.err
+		}
+		s.mu.Lock()
+		s.latest = call.snapshot
+		s.mu.Unlock()
+		return call.snapshot, nil
+	default:
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.latest, nil
 	}
-	return call.snapshot, nil
 }
 
 func (s *sequencedDaemonHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -2579,6 +2579,155 @@ func TestDiscoverNodesDoesNotPublishHerdrCollisionLoserDuringFinalization(t *tes
 	}
 }
 
+func TestDiscoverNodesRejectsStaleDaemonRefreshSnapshot(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	oldCall := newControlledDaemonSnapshot(daemonHerdrSnapshotForPane("workspace-1:pane-old"), nil)
+	newCall := newControlledDaemonSnapshot(daemonHerdrSnapshotForPane("workspace-1:pane-new"), nil)
+	client := &sequencedDaemonHerdrClient{calls: make(chan *controlledDaemonSnapshot, 2)}
+	client.calls <- oldCall
+	client.calls <- newCall
+	cfg := config.DefaultConfig()
+	cfg.Nodes = map[string]config.NodeConfig{"worker": {}}
+	cfg.Herdr = daemonHerdrConfig()
+	herdrRuntime, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("herdrruntime.New() error = %v", err)
+	}
+	t.Cleanup(herdrRuntime.Close)
+
+	originalDiscover := discoverNodesWithCollisionsForRuntime
+	discoverNodesWithCollisionsForRuntime = func(string, string, string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesWithCollisionsForRuntime = originalDiscover })
+	rt := &daemonRuntime{
+		baseDir:      baseDir,
+		contextID:    contextID,
+		selfSession:  sessionName,
+		cfg:          cfg,
+		herdrRuntime: herdrRuntime,
+	}
+
+	oldResult := make(chan daemonDiscoverResult, 1)
+	go func() {
+		nodes, collisions, err := rt.discoverNodes()
+		oldResult <- daemonDiscoverResult{nodes: nodes, collisions: collisions, err: err}
+	}()
+	<-oldCall.started
+
+	newResult := make(chan daemonDiscoverResult, 1)
+	go func() {
+		nodes, collisions, err := rt.discoverNodes()
+		newResult <- daemonDiscoverResult{nodes: nodes, collisions: collisions, err: err}
+	}()
+	<-newCall.started
+	close(newCall.release)
+	newer := <-newResult
+	if newer.err != nil {
+		t.Fatalf("newer discoverNodes() error = %v", newer.err)
+	}
+	if got := newer.nodes["work:worker"].PaneID; got != "workspace-1:pane-new" {
+		t.Fatalf("newer work:worker pane = %q, want newest pane", got)
+	}
+
+	close(oldCall.release)
+	older := <-oldResult
+	if older.err == nil || !strings.Contains(older.err.Error(), "stale Herdr final reconcile token") {
+		t.Fatalf("older discoverNodes() error = %v, want stale token error", older.err)
+	}
+	if older.nodes != nil || older.collisions != nil {
+		t.Fatalf("older discoverNodes() nodes=%#v collisions=%#v, want no stale publication", older.nodes, older.collisions)
+	}
+	oldTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-old"}}
+	if _, err := controlplane.DefaultHandAdapter(oldTarget); err == nil {
+		t.Fatal("stale daemon refresh registered old Herdr route")
+	}
+	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("new daemon route missing after stale discoverNodes result: %v", err)
+	}
+}
+
+type daemonDiscoverResult struct {
+	nodes      map[string]discovery.NodeInfo
+	collisions []discovery.CollisionReport
+	err        error
+}
+
+type controlledDaemonSnapshot struct {
+	started  chan struct{}
+	release  chan struct{}
+	snapshot multiplexer.HerdrSessionSnapshot
+	err      error
+}
+
+func newControlledDaemonSnapshot(snapshot multiplexer.HerdrSessionSnapshot, err error) *controlledDaemonSnapshot {
+	return &controlledDaemonSnapshot{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		snapshot: snapshot,
+		err:      err,
+	}
+}
+
+type sequencedDaemonHerdrClient struct {
+	calls chan *controlledDaemonSnapshot
+}
+
+func (s *sequencedDaemonHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	call := <-s.calls
+	close(call.started)
+	<-call.release
+	if call.err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, call.err
+	}
+	return call.snapshot, nil
+}
+
+func (s *sequencedDaemonHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) WritePaneText(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) SendPaneKey(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedDaemonHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
 type fakeDaemonHerdrClient struct {
 	snapshot multiplexer.HerdrSessionSnapshot
 }
@@ -2652,16 +2801,26 @@ func daemonHerdrSnapshot(sessionOwner string) multiplexer.HerdrSessionSnapshot {
 	if sessionOwner != "" {
 		snapshot.Workspaces[0].Metadata["postman.session_owner.work"] = sessionOwner
 	}
-	snapshot.Panes = []multiplexer.HerdrPaneSnapshot{{
-		ID:             "workspace-1:pane-1",
+	snapshot.Panes = []multiplexer.HerdrPaneSnapshot{daemonHerdrPane("workspace-1:pane-1")}
+	return snapshot
+}
+
+func daemonHerdrSnapshotForPane(paneID string) multiplexer.HerdrSessionSnapshot {
+	snapshot := daemonEmptyHerdrSnapshot()
+	snapshot.Panes = []multiplexer.HerdrPaneSnapshot{daemonHerdrPane(paneID)}
+	return snapshot
+}
+
+func daemonHerdrPane(paneID string) multiplexer.HerdrPaneSnapshot {
+	return multiplexer.HerdrPaneSnapshot{
+		ID:             paneID,
 		WorkspaceID:    "workspace-1",
 		TabID:          "workspace-1:tab-1",
 		Metadata:       map[string]string{"postman.node": "worker"},
 		ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
 		PostmanNode:    "worker",
 		PostmanSession: "work",
-	}}
-	return snapshot
+	}
 }
 
 func daemonEmptyHerdrSnapshot() multiplexer.HerdrSessionSnapshot {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -20,6 +21,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/msgtrace"
@@ -2443,6 +2445,167 @@ func TestMergeRuntimeDiscoveredNodesReportsCrossBackendCollisionWithoutOverwrite
 	}
 	if collisions[0].NodeKey != "work:worker" || collisions[0].WinnerPaneID != "%1" || collisions[0].LoserPaneID != "workspace-1:pane-1" {
 		t.Fatalf("collision = %#v, want tmux winner and Herdr loser", collisions[0])
+	}
+}
+
+func TestDiscoverNodesContinuesHerdrReconciliationWhenTmuxDiscoveryFails(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeDaemonHerdrClient{snapshot: daemonHerdrSnapshot("ctx-work:1")}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = daemonHerdrConfig()
+	herdrRuntime, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("herdrruntime.New() error = %v", err)
+	}
+	t.Cleanup(herdrRuntime.Close)
+	if _, _, err := herdrRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("initial Herdr Discover() error = %v", err)
+	}
+	target := controlplane.TargetForNode("work:worker", discovery.NodeInfo{
+		PaneID:           "workspace-1:pane-1",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr-daemon.sock",
+		HerdrWorkspaceID: "workspace-1",
+		HerdrTabID:       "workspace-1:tab-1",
+	})
+	if _, err := controlplane.DefaultHandAdapter(target); err != nil {
+		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
+	}
+
+	originalDiscover := discoverNodesWithCollisionsForRuntime
+	discoverNodesWithCollisionsForRuntime = func(string, string, string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return nil, nil, fmt.Errorf("tmux temporarily unavailable")
+	}
+	t.Cleanup(func() { discoverNodesWithCollisionsForRuntime = originalDiscover })
+	client.snapshot = daemonEmptyHerdrSnapshot()
+	rt := &daemonRuntime{
+		baseDir:      baseDir,
+		contextID:    contextID,
+		selfSession:  sessionName,
+		cfg:          cfg,
+		herdrRuntime: herdrRuntime,
+	}
+
+	nodes, collisions, err := rt.discoverNodes()
+	if err != nil {
+		t.Fatalf("discoverNodes() error = %v", err)
+	}
+	if len(nodes) != 0 || len(collisions) != 0 {
+		t.Fatalf("discoverNodes() nodes=%#v collisions=%#v, want empty after tmux failure and empty Herdr", nodes, collisions)
+	}
+	if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+		t.Fatal("stale Herdr adapter remained registered after tmux failure plus Herdr reconciliation")
+	}
+	if err := herdrRuntime.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("stale Herdr ownership route remained after tmux failure plus Herdr reconciliation")
+	}
+}
+
+type fakeDaemonHerdrClient struct {
+	snapshot multiplexer.HerdrSessionSnapshot
+}
+
+func (f *fakeDaemonHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}, nil
+}
+
+func (f *fakeDaemonHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeDaemonHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) WritePaneText(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) SendPaneKey(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeDaemonHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func daemonHerdrConfig() config.HerdrConfig {
+	now := time.Now().UTC().Truncate(time.Second)
+	return config.HerdrConfig{
+		Enabled:                     true,
+		SocketPath:                  "/tmp/herdr-daemon.sock",
+		SessionName:                 "work",
+		WorkspaceID:                 "workspace-1",
+		AllowedSocketPaths:          []string{"/tmp/herdr-daemon.sock"},
+		AllowedSessions:             []string{"work"},
+		AllowedWorkspaceIDs:         []string{"workspace-1"},
+		AllowedProtocolVersions:     []string{"1"},
+		AllowedSchemaVersions:       []int{1},
+		ReadEnabled:                 true,
+		WriteEnabled:                true,
+		InputSanitizerReady:         true,
+		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionRecorded),
+		ComplianceAuthorizedBy:      "test-authority",
+		ComplianceDecisionID:        "test-decision",
+		ComplianceDecidedAt:         now.Add(-2 * time.Hour).Format(time.RFC3339),
+		ComplianceRevalidatedAt:     now.Add(-time.Hour).Format(time.RFC3339),
+		ComplianceCurrentReferences: []string{"https://github.com/ogulcancelik/herdr/blob/master/LICENSE"},
+	}
+}
+
+func daemonHerdrSnapshot(sessionOwner string) multiplexer.HerdrSessionSnapshot {
+	snapshot := daemonEmptyHerdrSnapshot()
+	if sessionOwner != "" {
+		snapshot.Workspaces[0].Metadata["postman.session_owner.work"] = sessionOwner
+	}
+	snapshot.Panes = []multiplexer.HerdrPaneSnapshot{{
+		ID:             "workspace-1:pane-1",
+		WorkspaceID:    "workspace-1",
+		TabID:          "workspace-1:tab-1",
+		Metadata:       map[string]string{"postman.node": "worker"},
+		ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+		PostmanNode:    "worker",
+		PostmanSession: "work",
+	}}
+	return snapshot
+}
+
+func daemonEmptyHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
+	return multiplexer.HerdrSessionSnapshot{
+		Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
+		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
+			ID:       "workspace-1",
+			Metadata: map[string]string{},
+		}},
+		Tabs: []multiplexer.HerdrTabSnapshot{{
+			ID:          "workspace-1:tab-1",
+			WorkspaceID: "workspace-1",
+		}},
 	}
 }
 

--- a/internal/daemon/watcher_event_test.go
+++ b/internal/daemon/watcher_event_test.go
@@ -341,6 +341,7 @@ func TestRunDaemonLoop_WatcherErrorIsNonFatalAndLaterReadEventIsProcessed(t *tes
 			idle.NewIdleTracker(),
 			nil,
 			sessionName,
+			nil,
 		)
 	}()
 	t.Cleanup(func() {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -17,6 +17,8 @@ type NodeInfo struct {
 	PaneID      string
 	SessionName string
 	SessionDir  string
+	Backend     string
+	Runtime     string
 }
 
 // CollisionReport describes a pane collision where two panes share the same nodeKey.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -14,11 +14,14 @@ import (
 
 // NodeInfo holds information about a discovered node.
 type NodeInfo struct {
-	PaneID      string
-	SessionName string
-	SessionDir  string
-	Backend     string
-	Runtime     string
+	PaneID           string
+	SessionName      string
+	SessionDir       string
+	Backend          string
+	Runtime          string
+	HerdrSocketPath  string
+	HerdrWorkspaceID string
+	HerdrTabID       string
 }
 
 // CollisionReport describes a pane collision where two panes share the same nodeKey.

--- a/internal/herdrruntime/ownership_internal_test.go
+++ b/internal/herdrruntime/ownership_internal_test.go
@@ -1,0 +1,38 @@
+package herdrruntime
+
+import (
+	"testing"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+)
+
+func TestOwnershipMuxDeletePaneBackendRebuildsClearBackendFromLiveSurvivor(t *testing.T) {
+	mux := newOwnershipMux("work")
+	clearSelected := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
+		SessionName: "work",
+		PaneID:      "workspace-1:pane-clear",
+	}}}
+	survivor := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
+		SessionName: "work",
+		PaneID:      "workspace-1:pane-survivor",
+	}}}
+
+	mux.setPaneBackend("workspace-1:pane-survivor", survivor)
+	mux.setPaneBackend("workspace-1:pane-clear", clearSelected)
+	mux.deletePaneBackend("workspace-1:pane-clear")
+
+	clearBackend, err := mux.backendForSessionClear("work")
+	if err != nil {
+		t.Fatalf("backendForSessionClear() error = %v", err)
+	}
+	if got := clearBackend.Config.Runtime.PaneID; got != "workspace-1:pane-survivor" {
+		t.Fatalf("clear backend pane = %q, want live survivor", got)
+	}
+	sessionBackend, err := mux.backendForSession("work")
+	if err != nil {
+		t.Fatalf("backendForSession() error = %v", err)
+	}
+	if got := sessionBackend.Config.Runtime.PaneID; got != "workspace-1:pane-survivor" {
+		t.Fatalf("session backend pane = %q, want same live survivor", got)
+	}
+}

--- a/internal/herdrruntime/ownership_internal_test.go
+++ b/internal/herdrruntime/ownership_internal_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestOwnershipMuxReplaceSnapshotBuildsClearBackendFromDeterministicLiveSurvivor(t *testing.T) {
-	mux := newOwnershipMux("work")
+	mux := newOwnershipMux("work", true)
 	later := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
 		SessionName: "work",
 		PaneID:      "workspace-1:pane-z",

--- a/internal/herdrruntime/ownership_internal_test.go
+++ b/internal/herdrruntime/ownership_internal_test.go
@@ -6,33 +6,34 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 )
 
-func TestOwnershipMuxDeletePaneBackendRebuildsClearBackendFromLiveSurvivor(t *testing.T) {
+func TestOwnershipMuxReplaceSnapshotBuildsClearBackendFromDeterministicLiveSurvivor(t *testing.T) {
 	mux := newOwnershipMux("work")
-	clearSelected := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
+	later := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
 		SessionName: "work",
-		PaneID:      "workspace-1:pane-clear",
+		PaneID:      "workspace-1:pane-z",
 	}}}
 	survivor := multiplexer.HerdrBackend{Config: multiplexer.HerdrReadConfig{Runtime: multiplexer.HerdrRuntimeIdentity{
 		SessionName: "work",
-		PaneID:      "workspace-1:pane-survivor",
+		PaneID:      "workspace-1:pane-a",
 	}}}
 
-	mux.setPaneBackend("workspace-1:pane-survivor", survivor)
-	mux.setPaneBackend("workspace-1:pane-clear", clearSelected)
-	mux.deletePaneBackend("workspace-1:pane-clear")
+	mux.replaceSnapshot(map[string]multiplexer.HerdrBackend{
+		"workspace-1:pane-z": later,
+		"workspace-1:pane-a": survivor,
+	}, multiplexer.HerdrBackend{})
 
 	clearBackend, err := mux.backendForSessionClear("work")
 	if err != nil {
 		t.Fatalf("backendForSessionClear() error = %v", err)
 	}
-	if got := clearBackend.Config.Runtime.PaneID; got != "workspace-1:pane-survivor" {
+	if got := clearBackend.Config.Runtime.PaneID; got != "workspace-1:pane-a" {
 		t.Fatalf("clear backend pane = %q, want live survivor", got)
 	}
 	sessionBackend, err := mux.backendForSession("work")
 	if err != nil {
 		t.Fatalf("backendForSession() error = %v", err)
 	}
-	if got := sessionBackend.Config.Runtime.PaneID; got != "workspace-1:pane-survivor" {
+	if got := sessionBackend.Config.Runtime.PaneID; got != "workspace-1:pane-a" {
 		t.Fatalf("session backend pane = %q, want same live survivor", got)
 	}
 }

--- a/internal/herdrruntime/ownership_internal_test.go
+++ b/internal/herdrruntime/ownership_internal_test.go
@@ -17,9 +17,9 @@ func TestOwnershipMuxReplaceSnapshotBuildsClearBackendFromDeterministicLiveSurvi
 		PaneID:      "workspace-1:pane-a",
 	}}}
 
-	mux.replaceSnapshot(map[string]multiplexer.HerdrBackend{
-		"workspace-1:pane-z": later,
-		"workspace-1:pane-a": survivor,
+	mux.replaceSnapshot(map[herdrOwnershipKey]multiplexer.HerdrBackend{
+		herdrOwnershipKeyForBackend(later, "workspace-1:pane-z"):    later,
+		herdrOwnershipKeyForBackend(survivor, "workspace-1:pane-a"): survivor,
 	}, multiplexer.HerdrBackend{})
 
 	clearBackend, err := mux.backendForSessionClear("work")

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -22,8 +22,10 @@ type Runtime struct {
 	client           multiplexer.HerdrReadClient
 	ownershipBackend *ownershipMux
 
-	mu       sync.Mutex
-	cleanups []func()
+	mu              sync.Mutex
+	cleanups        []func()
+	paneCleanups    map[string]func()
+	registeredPanes map[string]bool
 }
 
 func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
@@ -44,6 +46,8 @@ func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
 		cfg:              cfg.Herdr,
 		client:           client,
 		ownershipBackend: newOwnershipMux(cfg.Herdr.SessionName),
+		paneCleanups:     make(map[string]func()),
+		registeredPanes:  make(map[string]bool),
 	}
 	rt.cleanups = append(rt.cleanups, multiplexer.RegisterOwnershipBackend(rt.ownershipBackend))
 	return rt, nil
@@ -113,6 +117,7 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 		}
 	}
 
+	livePanes := make(map[string]bool)
 	for _, group := range result.Layout.Groups {
 		tabID := group.ID.Native
 		for _, item := range group.Items {
@@ -122,6 +127,7 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
 			paneBackend := rt.backendForPane(tabID, item.ID.Native)
 			rt.registerPaneBackend(item.ID.Native, paneBackend)
+			livePanes[item.ID.Native] = true
 			nodes[nodeKey] = discovery.NodeInfo{
 				PaneID:      item.ID.Native,
 				SessionName: rt.cfg.SessionName,
@@ -131,6 +137,7 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			}
 		}
 	}
+	rt.reconcilePaneBackends(livePanes)
 	return nodes, collisions, nil
 }
 
@@ -144,6 +151,13 @@ func (rt *Runtime) Close() {
 		rt.cleanups[i]()
 	}
 	rt.cleanups = nil
+	for paneID, cleanup := range rt.paneCleanups {
+		if cleanup != nil {
+			cleanup()
+		}
+		delete(rt.paneCleanups, paneID)
+	}
+	rt.registeredPanes = make(map[string]bool)
 	rt.ownershipBackend.clear()
 }
 
@@ -163,12 +177,32 @@ func (rt *Runtime) registerPaneBackend(paneID string, backend multiplexer.HerdrB
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	rt.ownershipBackend.setPaneBackend(paneID, backend)
-	rt.cleanups = append(rt.cleanups, controlplane.RegisterHerdrHandAdapter(paneID, controlplane.HerdrHandAdapter{
+	rt.registeredPanes[paneID] = true
+	if cleanup, ok := rt.paneCleanups[paneID]; ok {
+		cleanup()
+	}
+	rt.paneCleanups[paneID] = controlplane.RegisterHerdrHandAdapter(paneID, controlplane.HerdrHandAdapter{
 		HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
 			Backend:        backend,
 			InputSanitizer: notification.PrepareInteractivePaneMessage,
 		},
-	}))
+	})
+}
+
+func (rt *Runtime) reconcilePaneBackends(livePanes map[string]bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for paneID := range rt.registeredPanes {
+		if livePanes[paneID] {
+			continue
+		}
+		if cleanup := rt.paneCleanups[paneID]; cleanup != nil {
+			cleanup()
+		}
+		delete(rt.paneCleanups, paneID)
+		delete(rt.registeredPanes, paneID)
+		rt.ownershipBackend.deletePaneBackend(paneID)
+	}
 }
 
 type ownershipMux struct {
@@ -189,6 +223,12 @@ func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.byPane[paneID] = backend
+}
+
+func (m *ownershipMux) deletePaneBackend(paneID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.byPane, paneID)
 }
 
 func (m *ownershipMux) clear() {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -116,6 +116,13 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			})
 		}
 	}
+	collidedNodeKeys := make(map[string]bool, len(result.Collisions))
+	for _, collision := range result.Collisions {
+		if strings.TrimSpace(collision.SessionName) == "" || strings.TrimSpace(collision.NodeName) == "" {
+			continue
+		}
+		collidedNodeKeys[collision.SessionName+":"+collision.NodeName] = true
+	}
 
 	livePanes := make(map[string]bool)
 	for _, group := range result.Layout.Groups {
@@ -125,6 +132,9 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 				continue
 			}
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
+			if collidedNodeKeys[nodeKey] {
+				continue
+			}
 			paneBackend := rt.backendForPane(tabID, item.ID.Native)
 			rt.registerPaneBackend(item.ID.Native, paneBackend)
 			livePanes[item.ID.Native] = true
@@ -206,9 +216,10 @@ func (rt *Runtime) reconcilePaneBackends(livePanes map[string]bool) {
 }
 
 type ownershipMux struct {
-	sessionName string
-	mu          sync.RWMutex
-	byPane      map[string]multiplexer.HerdrBackend
+	sessionName    string
+	mu             sync.RWMutex
+	byPane         map[string]multiplexer.HerdrBackend
+	sessionBackend *multiplexer.HerdrBackend
 }
 
 func newOwnershipMux(sessionName string) *ownershipMux {
@@ -223,6 +234,8 @@ func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.byPane[paneID] = backend
+	sessionBackend := backend
+	m.sessionBackend = &sessionBackend
 }
 
 func (m *ownershipMux) deletePaneBackend(paneID string) {
@@ -235,6 +248,7 @@ func (m *ownershipMux) clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.byPane = make(map[string]multiplexer.HerdrBackend)
+	m.sessionBackend = nil
 }
 
 func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrBackend, error) {
@@ -243,6 +257,9 @@ func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrB
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.sessionBackend != nil {
+		return *m.sessionBackend, nil
+	}
 	keys := make([]string, 0, len(m.byPane))
 	for paneID := range m.byPane {
 		keys = append(keys, paneID)

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -1,0 +1,276 @@
+package herdrruntime
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+	"github.com/i9wa4/tmux-a2a-postman/internal/notification"
+)
+
+type ClientFactory func(config.HerdrConfig) (multiplexer.HerdrReadClient, error)
+
+type Runtime struct {
+	cfg              config.HerdrConfig
+	client           multiplexer.HerdrReadClient
+	ownershipBackend *ownershipMux
+
+	mu       sync.Mutex
+	cleanups []func()
+}
+
+func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
+	if cfg == nil || !cfg.Herdr.Enabled {
+		return nil, nil
+	}
+	if factory == nil {
+		return nil, fmt.Errorf("%w: herdr client factory not configured", multiplexer.ErrHerdrBackendUnavailable)
+	}
+	client, err := factory(cfg.Herdr)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, multiplexer.ErrHerdrReadClientMissing
+	}
+	rt := &Runtime{
+		cfg:              cfg.Herdr,
+		client:           client,
+		ownershipBackend: newOwnershipMux(cfg.Herdr.SessionName),
+	}
+	rt.cleanups = append(rt.cleanups, multiplexer.RegisterOwnershipBackend(rt.ownershipBackend))
+	return rt, nil
+}
+
+func (rt *Runtime) Enabled() bool {
+	return rt != nil
+}
+
+func (rt *Runtime) OwnsSession(sessionName string) bool {
+	return rt != nil && strings.TrimSpace(sessionName) == strings.TrimSpace(rt.cfg.SessionName)
+}
+
+func (rt *Runtime) OwnershipBackend() multiplexer.OwnershipBackend {
+	if rt == nil {
+		return nil
+	}
+	return rt.ownershipBackend
+}
+
+func (rt *Runtime) SetSessionEnabledMarker(ctx context.Context, contextID, sessionName string, enabled bool) error {
+	if rt == nil || !rt.OwnsSession(sessionName) {
+		return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
+	}
+	if enabled {
+		return rt.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, 0)
+	}
+	return rt.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName)
+}
+
+func (rt *Runtime) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	if rt == nil || !rt.OwnsSession(sessionName) {
+		return "", nil
+	}
+	return rt.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+}
+
+func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+	if rt == nil {
+		return nil, nil, nil
+	}
+	readConfig := rt.cfg.ReadConfig()
+	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopeDiscovery
+	backend, err := multiplexer.NewHerdrBackend(readConfig, rt.client)
+	if err != nil {
+		return nil, nil, err
+	}
+	result, err := backend.Discover(ctx, rt.cfg.SessionName)
+	if err != nil {
+		return nil, nil, err
+	}
+	nodes := make(map[string]discovery.NodeInfo)
+	var collisions []discovery.CollisionReport
+	sessionDir := filepath.Join(baseDir, contextID, rt.cfg.SessionName)
+	for _, collision := range result.Collisions {
+		paneIDs := append([]string(nil), collision.PaneIDs...)
+		sort.Strings(paneIDs)
+		if len(paneIDs) < 2 {
+			continue
+		}
+		for _, loser := range paneIDs[:len(paneIDs)-1] {
+			collisions = append(collisions, discovery.CollisionReport{
+				NodeKey:      collision.SessionName + ":" + collision.NodeName,
+				WinnerPaneID: paneIDs[len(paneIDs)-1],
+				LoserPaneID:  loser,
+			})
+		}
+	}
+
+	for _, group := range result.Layout.Groups {
+		tabID := group.ID.Native
+		for _, item := range group.Items {
+			if item.LogicalName == "" || item.ID.Native == "" {
+				continue
+			}
+			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
+			paneBackend := rt.backendForPane(tabID, item.ID.Native)
+			rt.registerPaneBackend(item.ID.Native, paneBackend)
+			nodes[nodeKey] = discovery.NodeInfo{
+				PaneID:      item.ID.Native,
+				SessionName: rt.cfg.SessionName,
+				SessionDir:  sessionDir,
+				Backend:     string(multiplexer.BackendKindHerdr),
+				Runtime:     item.CurrentCommand,
+			}
+		}
+	}
+	return nodes, collisions, nil
+}
+
+func (rt *Runtime) Close() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for i := len(rt.cleanups) - 1; i >= 0; i-- {
+		rt.cleanups[i]()
+	}
+	rt.cleanups = nil
+	rt.ownershipBackend.clear()
+}
+
+func (rt *Runtime) backendForPane(tabID, paneID string) multiplexer.HerdrBackend {
+	readConfig := rt.cfg.ReadConfig()
+	readConfig.Runtime.TabID = tabID
+	readConfig.Runtime.PaneID = paneID
+	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopePane
+	return multiplexer.HerdrBackend{
+		Config:         readConfig,
+		Client:         rt.client,
+		InputSanitizer: notification.PrepareInteractivePaneMessage,
+	}
+}
+
+func (rt *Runtime) registerPaneBackend(paneID string, backend multiplexer.HerdrBackend) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.ownershipBackend.setPaneBackend(paneID, backend)
+	rt.cleanups = append(rt.cleanups, controlplane.RegisterHerdrHandAdapter(paneID, controlplane.HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
+			Backend:        backend,
+			InputSanitizer: notification.PrepareInteractivePaneMessage,
+		},
+	}))
+}
+
+type ownershipMux struct {
+	sessionName string
+	mu          sync.RWMutex
+	byPane      map[string]multiplexer.HerdrBackend
+}
+
+func newOwnershipMux(sessionName string) *ownershipMux {
+	return &ownershipMux{sessionName: sessionName, byPane: make(map[string]multiplexer.HerdrBackend)}
+}
+
+func (m *ownershipMux) Kind() multiplexer.BackendKind {
+	return multiplexer.BackendKindHerdr
+}
+
+func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBackend) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byPane[paneID] = backend
+}
+
+func (m *ownershipMux) clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byPane = make(map[string]multiplexer.HerdrBackend)
+}
+
+func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrBackend, error) {
+	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
+		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	keys := make([]string, 0, len(m.byPane))
+	for paneID := range m.byPane {
+		keys = append(keys, paneID)
+	}
+	sort.Strings(keys)
+	for _, paneID := range keys {
+		return m.byPane[paneID], nil
+	}
+	return multiplexer.HerdrBackend{}, fmt.Errorf("%w: no herdr pane backend registered for session %q", multiplexer.ErrHerdrReadClientMissing, sessionName)
+}
+
+func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.HerdrBackend, error) {
+	if pane.Backend != multiplexer.BackendKindHerdr {
+		return multiplexer.HerdrBackend{}, fmt.Errorf("herdr ownership requires herdr pane resource: %#v", pane)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	backend, ok := m.byPane[pane.Native]
+	if !ok {
+		return multiplexer.HerdrBackend{}, fmt.Errorf("herdr pane backend not registered for %q", pane.Native)
+	}
+	return backend, nil
+}
+
+func (m *ownershipMux) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	backend, err := m.backendForSession(sessionName)
+	if err != nil {
+		return "", err
+	}
+	return backend.SessionOwnerMarker(ctx, sessionName)
+}
+
+func (m *ownershipMux) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	backend, err := m.backendForSession(sessionName)
+	if err != nil {
+		return err
+	}
+	return backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid)
+}
+
+func (m *ownershipMux) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	backend, err := m.backendForSession(sessionName)
+	if err != nil {
+		return err
+	}
+	return backend.ClearSessionOwnerMarker(ctx, sessionName)
+}
+
+func (m *ownershipMux) PaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) (string, error) {
+	backend, err := m.backendForPane(pane)
+	if err != nil {
+		return "", err
+	}
+	return backend.PaneOwnerMarker(ctx, pane)
+}
+
+func (m *ownershipMux) SetPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID, contextID string) error {
+	backend, err := m.backendForPane(pane)
+	if err != nil {
+		return err
+	}
+	return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+}
+
+func (m *ownershipMux) ClearPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) error {
+	backend, err := m.backendForPane(pane)
+	if err != nil {
+		return err
+	}
+	return backend.ClearPaneOwnerMarker(ctx, pane)
+}

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -132,10 +132,11 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 				continue
 			}
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
+			paneBackend := rt.backendForPane(tabID, item.ID.Native)
+			rt.ownershipBackend.setSessionBackend(paneBackend)
 			if collidedNodeKeys[nodeKey] {
 				continue
 			}
-			paneBackend := rt.backendForPane(tabID, item.ID.Native)
 			rt.registerPaneBackend(item.ID.Native, paneBackend)
 			livePanes[item.ID.Native] = true
 			nodes[nodeKey] = discovery.NodeInfo{
@@ -234,6 +235,16 @@ func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.byPane[paneID] = backend
+	m.setSessionBackendLocked(backend)
+}
+
+func (m *ownershipMux) setSessionBackend(backend multiplexer.HerdrBackend) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setSessionBackendLocked(backend)
+}
+
+func (m *ownershipMux) setSessionBackendLocked(backend multiplexer.HerdrBackend) {
 	sessionBackend := backend
 	m.sessionBackend = &sessionBackend
 }

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -23,6 +23,8 @@ type Runtime struct {
 	ownershipBackend *ownershipMux
 
 	mu              sync.Mutex
+	closed          bool
+	generation      uint64
 	cleanups        []func()
 	paneCleanups    map[string]func()
 	registeredPanes map[string]bool
@@ -89,6 +91,10 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 	if rt == nil {
 		return nil, nil, nil
 	}
+	generation, closed := rt.beginDiscover()
+	if closed {
+		return nil, nil, fmt.Errorf("herdr runtime closed")
+	}
 	readConfig := rt.cfg.ReadConfig()
 	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopeDiscovery
 	backend, err := multiplexer.NewHerdrBackend(readConfig, rt.client)
@@ -100,6 +106,9 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 	if err != nil {
 		rt.ClearPaneRoutes()
 		return nil, nil, err
+	}
+	if !rt.discoverStillCurrent(generation) {
+		return nil, nil, fmt.Errorf("herdr runtime closed")
 	}
 	nodes := make(map[string]discovery.NodeInfo)
 	var collisions []discovery.CollisionReport
@@ -135,23 +144,44 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			}
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
 			paneBackend := rt.backendForPane(tabID, item.ID.Native)
-			rt.ownershipBackend.setClearBackend(paneBackend)
+			if !rt.setClearBackend(generation, paneBackend) {
+				return nil, nil, fmt.Errorf("herdr runtime closed")
+			}
 			if collidedNodeKeys[nodeKey] {
 				continue
 			}
-			rt.registerPaneBackend(item.ID.Native, paneBackend)
+			if !rt.registerPaneBackend(generation, item.ID.Native, paneBackend) {
+				return nil, nil, fmt.Errorf("herdr runtime closed")
+			}
 			livePanes[item.ID.Native] = true
 			nodes[nodeKey] = discovery.NodeInfo{
-				PaneID:      item.ID.Native,
-				SessionName: rt.cfg.SessionName,
-				SessionDir:  sessionDir,
-				Backend:     string(multiplexer.BackendKindHerdr),
-				Runtime:     item.CurrentCommand,
+				PaneID:           item.ID.Native,
+				SessionName:      rt.cfg.SessionName,
+				SessionDir:       sessionDir,
+				Backend:          string(multiplexer.BackendKindHerdr),
+				Runtime:          item.CurrentCommand,
+				HerdrSocketPath:  rt.cfg.SocketPath,
+				HerdrWorkspaceID: rt.cfg.WorkspaceID,
+				HerdrTabID:       tabID,
 			}
 		}
 	}
-	rt.reconcilePaneBackends(livePanes)
+	if !rt.reconcilePaneBackends(generation, livePanes) {
+		return nil, nil, fmt.Errorf("herdr runtime closed")
+	}
 	return nodes, collisions, nil
+}
+
+func (rt *Runtime) beginDiscover() (uint64, bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.generation, rt.closed
+}
+
+func (rt *Runtime) discoverStillCurrent(generation uint64) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return !rt.closed && rt.generation == generation
 }
 
 func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
@@ -165,14 +195,14 @@ func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
 		}
 		livePanes[nodeInfo.PaneID] = true
 	}
-	rt.reconcilePaneBackends(livePanes)
+	rt.reconcilePaneBackends(0, livePanes)
 }
 
 func (rt *Runtime) ClearPaneRoutes() {
 	if rt == nil {
 		return
 	}
-	rt.reconcilePaneBackends(nil)
+	rt.reconcilePaneBackends(0, nil)
 }
 
 func (rt *Runtime) Close() {
@@ -181,6 +211,11 @@ func (rt *Runtime) Close() {
 	}
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	if rt.closed {
+		return
+	}
+	rt.closed = true
+	rt.generation++
 	for paneID, cleanup := range rt.paneCleanups {
 		if cleanup != nil {
 			cleanup()
@@ -207,9 +242,12 @@ func (rt *Runtime) backendForPane(tabID, paneID string) multiplexer.HerdrBackend
 	}
 }
 
-func (rt *Runtime) registerPaneBackend(paneID string, backend multiplexer.HerdrBackend) {
+func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend multiplexer.HerdrBackend) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	if rt.closed || (generation != 0 && rt.generation != generation) {
+		return false
+	}
 	rt.ownershipBackend.setPaneBackend(paneID, backend)
 	rt.registeredPanes[paneID] = true
 	if cleanup, ok := rt.paneCleanups[paneID]; ok {
@@ -221,11 +259,25 @@ func (rt *Runtime) registerPaneBackend(paneID string, backend multiplexer.HerdrB
 			InputSanitizer: notification.PrepareInteractivePaneMessage,
 		},
 	})
+	return true
 }
 
-func (rt *Runtime) reconcilePaneBackends(livePanes map[string]bool) {
+func (rt *Runtime) setClearBackend(generation uint64, backend multiplexer.HerdrBackend) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	if rt.closed || (generation != 0 && rt.generation != generation) {
+		return false
+	}
+	rt.ownershipBackend.setClearBackend(backend)
+	return true
+}
+
+func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string]bool) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.closed || (generation != 0 && rt.generation != generation) {
+		return false
+	}
 	for paneID := range rt.registeredPanes {
 		if livePanes[paneID] {
 			continue
@@ -237,6 +289,7 @@ func (rt *Runtime) reconcilePaneBackends(livePanes map[string]bool) {
 		delete(rt.registeredPanes, paneID)
 		rt.ownershipBackend.deletePaneBackend(paneID)
 	}
+	return true
 }
 
 type ownershipMux struct {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -699,6 +699,21 @@ func (m *ownershipMux) HerdrRuntimeIdentity() multiplexer.HerdrRuntimeIdentity {
 	return m.runtime
 }
 
+func (m *ownershipMux) HerdrRuntimeOwnershipIdentities() []multiplexer.HerdrRuntimeIdentity {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	seen := map[multiplexer.HerdrRuntimeIdentity]bool{}
+	for key := range m.snapshot.byPane {
+		r := multiplexer.HerdrRuntimeIdentity{SocketPath: key.SocketPath, SessionName: key.SessionName, WorkspaceID: key.WorkspaceID, TabID: key.TabID, PaneID: key.PaneID}
+		seen[r] = true
+	}
+	out := make([]multiplexer.HerdrRuntimeIdentity, 0, len(seen))
+	for r := range seen {
+		out = append(out, r)
+	}
+	return out
+}
+
 func (m *ownershipMux) clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -135,7 +135,6 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 		collidedNodeKeys[collision.SessionName+":"+collision.NodeName] = true
 	}
 
-	livePanes := make(map[string]bool)
 	for _, group := range result.Layout.Groups {
 		tabID := group.ID.Native
 		for _, item := range group.Items {
@@ -150,10 +149,6 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			if collidedNodeKeys[nodeKey] {
 				continue
 			}
-			if !rt.registerPaneBackend(generation, item.ID.Native, paneBackend) {
-				return nil, nil, fmt.Errorf("herdr runtime closed")
-			}
-			livePanes[item.ID.Native] = true
 			nodes[nodeKey] = discovery.NodeInfo{
 				PaneID:           item.ID.Native,
 				SessionName:      rt.cfg.SessionName,
@@ -165,9 +160,6 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 				HerdrTabID:       tabID,
 			}
 		}
-	}
-	if !rt.reconcilePaneBackends(generation, livePanes) {
-		return nil, nil, fmt.Errorf("herdr runtime closed")
 	}
 	return nodes, collisions, nil
 }
@@ -194,6 +186,9 @@ func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
 			continue
 		}
 		livePanes[nodeInfo.PaneID] = true
+		if !rt.registerPaneBackend(0, nodeInfo.PaneID, rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)) {
+			return
+		}
 	}
 	rt.reconcilePaneBackends(0, livePanes)
 }

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -29,6 +29,71 @@ type Runtime struct {
 	adapterCleanup func()
 }
 
+type FinalPublication struct {
+	ownershipBackend *ownershipMux
+	runtime          *Runtime
+}
+
+func (p *FinalPublication) Kind() multiplexer.BackendKind {
+	return multiplexer.BackendKindHerdr
+}
+
+func (p *FinalPublication) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	if p == nil || p.ownershipBackend == nil {
+		return "", fmt.Errorf("herdr final publication missing")
+	}
+	return p.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+}
+
+func (p *FinalPublication) SetSessionEnabledMarker(ctx context.Context, contextID, sessionName string, enabled bool) error {
+	if p == nil || p.ownershipBackend == nil || p.runtime == nil || !p.runtime.OwnsSession(sessionName) {
+		return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
+	}
+	if enabled {
+		return p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, 0)
+	}
+	return p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName)
+}
+
+func (p *FinalPublication) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	if p == nil || p.ownershipBackend == nil {
+		return fmt.Errorf("herdr final publication missing")
+	}
+	return p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid)
+}
+
+func (p *FinalPublication) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	if p == nil || p.ownershipBackend == nil {
+		return fmt.Errorf("herdr final publication missing")
+	}
+	return p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName)
+}
+
+func (p *FinalPublication) PaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) (string, error) {
+	if p == nil || p.ownershipBackend == nil {
+		return "", fmt.Errorf("herdr final publication missing")
+	}
+	return p.ownershipBackend.PaneOwnerMarker(ctx, pane)
+}
+
+func (p *FinalPublication) SetPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID, contextID string) error {
+	if p == nil || p.ownershipBackend == nil || pane.Backend != multiplexer.BackendKindHerdr {
+		backend, err := multiplexer.OwnershipBackendForKind(pane.Backend)
+		if err != nil {
+			return err
+		}
+		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+	}
+	return p.ownershipBackend.SetPaneOwnerMarker(ctx, pane, contextID)
+}
+
+func (p *FinalPublication) ClearPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) error {
+	if p == nil || p.ownershipBackend == nil {
+		return fmt.Errorf("herdr final publication missing")
+	}
+	return p.ownershipBackend.ClearPaneOwnerMarker(ctx, pane)
+}
+
 func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
 	if cfg == nil || !cfg.Herdr.Enabled {
 		return nil, nil
@@ -196,6 +261,16 @@ func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[stri
 }
 
 func (rt *Runtime) ReconcileFinalNodesForTokenAndPublish(generation uint64, nodes map[string]discovery.NodeInfo, publish func() error) error {
+	var prepare func(*FinalPublication) error
+	if publish != nil {
+		prepare = func(*FinalPublication) error {
+			return publish()
+		}
+	}
+	return rt.ReconcileFinalNodesForTokenAndCommit(generation, nodes, prepare, nil)
+}
+
+func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes map[string]discovery.NodeInfo, prepare func(*FinalPublication) error, commit func()) error {
 	if rt == nil {
 		return fmt.Errorf("herdr runtime missing")
 	}
@@ -215,22 +290,25 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndPublish(generation uint64, node
 		}
 	}
 	workspaceBackend := rt.backendForWorkspace()
+	stagedOwnership := newOwnershipMux(rt.cfg.SessionName)
+	stagedOwnership.replaceSnapshot(paneBackends, workspaceBackend)
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.closed || (generation != 0 && rt.generation != generation) {
 		return fmt.Errorf("stale Herdr final reconcile token")
 	}
-	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
-	if rt.adapterCleanup != nil {
-		rt.adapterCleanup()
-		rt.adapterCleanup = nil
-	}
-	rt.adapterCleanup = controlplane.ReplaceHerdrHandAdaptersForOwner(rt.handAdapterOwnerID(), handAdapters)
-	if publish != nil {
-		if err := publish(); err != nil {
+	if prepare != nil {
+		if err := prepare(&FinalPublication{ownershipBackend: stagedOwnership, runtime: rt}); err != nil {
 			return err
 		}
+	}
+	multiplexer.LockHerdrPublicationWrite()
+	defer multiplexer.UnlockHerdrPublicationWrite()
+	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
+	rt.adapterCleanup = controlplane.ReplaceHerdrHandAdaptersForOwner(rt.handAdapterOwnerID(), handAdapters)
+	if commit != nil {
+		commit()
 	}
 	return nil
 }
@@ -257,6 +335,8 @@ func (rt *Runtime) Close() {
 	}
 	rt.closed = true
 	rt.generation++
+	multiplexer.LockHerdrPublicationWrite()
+	defer multiplexer.UnlockHerdrPublicationWrite()
 	if rt.adapterCleanup != nil {
 		rt.adapterCleanup()
 		rt.adapterCleanup = nil
@@ -297,6 +377,8 @@ func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string
 		return false
 	}
 	if livePanes == nil {
+		multiplexer.LockHerdrPublicationWrite()
+		defer multiplexer.UnlockHerdrPublicationWrite()
 		rt.ownershipBackend.replaceSnapshot(nil, multiplexer.HerdrBackend{})
 		if rt.adapterCleanup != nil {
 			rt.adapterCleanup()
@@ -387,6 +469,8 @@ func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrB
 	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
 		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
 	}
+	multiplexer.LockHerdrPublicationRead()
+	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.snapshot.sessionBackend != nil {
@@ -399,6 +483,8 @@ func (m *ownershipMux) backendForSessionClear(sessionName string) (multiplexer.H
 	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
 		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
 	}
+	multiplexer.LockHerdrPublicationRead()
+	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.snapshot.clearBackend != nil {
@@ -411,6 +497,8 @@ func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.
 	if pane.Backend != multiplexer.BackendKindHerdr {
 		return multiplexer.HerdrBackend{}, fmt.Errorf("herdr ownership requires herdr pane resource: %#v", pane)
 	}
+	multiplexer.LockHerdrPublicationRead()
+	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	backend, ok := m.snapshot.byPane[herdrOwnershipKeyForResource(pane)]

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -457,15 +457,16 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 	if rt == nil {
 		return fmt.Errorf("herdr runtime missing")
 	}
-	paneBackends := make(map[string]multiplexer.HerdrBackend)
-	handAdapters := make(map[string]controlplane.HerdrHandAdapter)
+	paneBackends := make(map[herdrOwnershipKey]multiplexer.HerdrBackend)
+	handAdapters := make(map[multiplexer.HerdrRuntimeIdentity]controlplane.HerdrHandAdapter)
 	for _, nodeInfo := range nodes {
 		if multiplexer.BackendKindFromString(nodeInfo.Backend) != multiplexer.BackendKindHerdr || nodeInfo.PaneID == "" {
 			continue
 		}
 		backend := rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)
-		paneBackends[nodeInfo.PaneID] = backend
-		handAdapters[nodeInfo.PaneID] = controlplane.HerdrHandAdapter{
+		runtime := backend.Config.Runtime
+		paneBackends[herdrOwnershipKeyForRuntime(runtime, nodeInfo.PaneID)] = backend
+		handAdapters[runtime] = controlplane.HerdrHandAdapter{
 			HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
 				Backend:        backend,
 				InputSanitizer: notification.PrepareInteractivePaneMessage,
@@ -502,7 +503,7 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 		}
 	}
 	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
-	replacement := controlplane.ReplaceHerdrHandAdaptersForOwnerCollect(rt.handAdapterOwnerID(), handAdapters)
+	replacement := controlplane.ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(rt.handAdapterOwnerID(), handAdapters)
 	rt.adapterCleanup = replacement.Cleanup
 	if commit != nil {
 		commit()
@@ -614,6 +615,7 @@ type herdrOwnershipKey struct {
 	SocketPath  string
 	SessionName string
 	WorkspaceID string
+	TabID       string
 	PaneID      string
 }
 
@@ -646,18 +648,19 @@ func (m *ownershipMux) clear() {
 	m.runtime = multiplexer.HerdrRuntimeIdentity{}
 }
 
-func (m *ownershipMux) replaceSnapshot(panes map[string]multiplexer.HerdrBackend, workspaceBackend multiplexer.HerdrBackend) {
+func (m *ownershipMux) replaceSnapshot(panes map[herdrOwnershipKey]multiplexer.HerdrBackend, workspaceBackend multiplexer.HerdrBackend) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	snapshot := ownershipSnapshot{byPane: make(map[herdrOwnershipKey]multiplexer.HerdrBackend, len(panes))}
-	keys := make([]string, 0, len(panes))
-	for paneID := range panes {
-		keys = append(keys, paneID)
+	keys := make([]herdrOwnershipKey, 0, len(panes))
+	for key := range panes {
+		keys = append(keys, key)
 	}
-	sort.Strings(keys)
-	for _, paneID := range keys {
-		backend := panes[paneID]
-		snapshot.byPane[herdrOwnershipKeyForBackend(backend, paneID)] = backend
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	for _, key := range keys {
+		snapshot.byPane[key] = panes[key]
 	}
 	if len(panes) == 0 {
 		sessionBackend := workspaceBackend
@@ -737,6 +740,10 @@ func (m *ownershipMux) backendForLegacyPaneLocked(paneID string) (multiplexer.He
 
 func herdrOwnershipKeyForBackend(backend multiplexer.HerdrBackend, paneID string) herdrOwnershipKey {
 	runtime := backend.Config.Runtime
+	return herdrOwnershipKeyForRuntime(runtime, paneID)
+}
+
+func herdrOwnershipKeyForRuntime(runtime multiplexer.HerdrRuntimeIdentity, paneID string) herdrOwnershipKey {
 	if runtime.PaneID == "" {
 		runtime.PaneID = paneID
 	}
@@ -744,6 +751,7 @@ func herdrOwnershipKeyForBackend(backend multiplexer.HerdrBackend, paneID string
 		SocketPath:  strings.TrimSpace(runtime.SocketPath),
 		SessionName: strings.TrimSpace(runtime.SessionName),
 		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		TabID:       strings.TrimSpace(runtime.TabID),
 		PaneID:      strings.TrimSpace(runtime.PaneID),
 	}
 }
@@ -757,8 +765,13 @@ func herdrOwnershipKeyForResource(pane multiplexer.ResourceID) herdrOwnershipKey
 		SocketPath:  strings.TrimSpace(runtime.SocketPath),
 		SessionName: strings.TrimSpace(runtime.SessionName),
 		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		TabID:       strings.TrimSpace(runtime.TabID),
 		PaneID:      strings.TrimSpace(runtime.PaneID),
 	}
+}
+
+func (k herdrOwnershipKey) String() string {
+	return k.SocketPath + "\x00" + k.SessionName + "\x00" + k.WorkspaceID + "\x00" + k.TabID + "\x00" + k.PaneID
 }
 
 func (m *ownershipMux) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -17,6 +17,8 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/notification"
 )
 
+var ErrStaleFinalReconcileToken = errors.New("stale Herdr final reconcile token")
+
 type ClientFactory func(config.HerdrConfig) (multiplexer.HerdrReadClient, error)
 
 type Runtime struct {
@@ -103,6 +105,23 @@ func (p *FinalPublication) SetPaneOwnerMarker(ctx context.Context, pane multiple
 	backend, err := p.ownershipBackendForPane(pane)
 	if err != nil {
 		return err
+	}
+	return p.setPaneOwnerMarkerWithBackend(ctx, backend, pane, contextID)
+}
+
+func (p *FinalPublication) SetPaneOwnerMarkerWithBackend(ctx context.Context, backend multiplexer.OwnershipBackend, pane multiplexer.ResourceID, contextID string) error {
+	if p == nil {
+		if backend == nil {
+			return fmt.Errorf("ownership backend missing for pane %s", pane.Native)
+		}
+		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+	}
+	if backend == nil {
+		var err error
+		backend, err = p.ownershipBackendForPane(pane)
+		if err != nil {
+			return err
+		}
 	}
 	return p.setPaneOwnerMarkerWithBackend(ctx, backend, pane, contextID)
 }
@@ -460,7 +479,7 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.closed || (generation != 0 && rt.generation != generation) {
-		return fmt.Errorf("stale Herdr final reconcile token")
+		return ErrStaleFinalReconcileToken
 	}
 	multiplexer.LockHerdrPublicationWrite()
 	var displacedCleanup func()

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -784,7 +784,7 @@ func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	backend, ok := m.snapshot.byPane[herdrOwnershipKeyForResource(pane)]
-	if !ok && pane.HerdrRuntime.SocketPath == "" && pane.HerdrRuntime.WorkspaceID == "" {
+	if !ok && !hasHerdrRuntimeQualifier(pane.HerdrRuntime) {
 		backend, ok = m.backendForLegacyPaneLocked(pane.Native)
 	}
 	if !ok {
@@ -841,6 +841,14 @@ func herdrOwnershipKeyForResource(pane multiplexer.ResourceID) herdrOwnershipKey
 		TabID:       strings.TrimSpace(runtime.TabID),
 		PaneID:      strings.TrimSpace(runtime.PaneID),
 	}
+}
+
+func hasHerdrRuntimeQualifier(runtime multiplexer.HerdrRuntimeIdentity) bool {
+	return strings.TrimSpace(runtime.SocketPath) != "" ||
+		strings.TrimSpace(runtime.SessionName) != "" ||
+		strings.TrimSpace(runtime.WorkspaceID) != "" ||
+		strings.TrimSpace(runtime.TabID) != "" ||
+		strings.TrimSpace(runtime.PaneID) != ""
 }
 
 func (k herdrOwnershipKey) String() string {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -26,11 +26,11 @@ type Runtime struct {
 	client           multiplexer.HerdrReadClient
 	ownershipBackend *ownershipMux
 
-	mu             sync.Mutex
-	closed         bool
-	generation     uint64
-	cleanups       []func()
-	adapterCleanup func()
+	mu              sync.Mutex
+	closed          bool
+	generation      uint64
+	cleanups        []func()
+	adapterCleanups map[string]func()
 }
 
 type FinalPublication struct {
@@ -483,14 +483,16 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 		return ErrStaleFinalReconcileToken
 	}
 	multiplexer.LockHerdrPublicationWrite()
-	var displacedCleanup func()
+	var displacedCleanups []func()
 	unlockPublication := true
 	defer func() {
 		if unlockPublication {
 			multiplexer.UnlockHerdrPublicationWrite()
 		}
-		if displacedCleanup != nil {
-			displacedCleanup()
+		for _, cleanup := range displacedCleanups {
+			if cleanup != nil {
+				cleanup()
+			}
 		}
 	}()
 	publication := &FinalPublication{ownershipBackend: stagedOwnership, runtime: rt}
@@ -503,13 +505,33 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 		}
 	}
 	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
-	replacement := controlplane.ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(rt.handAdapterOwnerID(), handAdapters)
-	rt.adapterCleanup = replacement.Cleanup
+	nextAdapterCleanups := make(map[string]func())
+	adapterGroups := rt.handAdapterGroupsByOwner(handAdapters)
+	owners := make([]string, 0, len(adapterGroups))
+	for owner := range adapterGroups {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+	for _, owner := range owners {
+		replacement := controlplane.ReplaceHerdrHandAdaptersForOwnerRuntimeCollect(owner, adapterGroups[owner])
+		nextAdapterCleanups[owner] = replacement.Cleanup
+		if replacement.DisplacedCleanup != nil {
+			displacedCleanups = append(displacedCleanups, replacement.DisplacedCleanup)
+		}
+	}
+	for owner, cleanup := range rt.adapterCleanups {
+		if _, ok := nextAdapterCleanups[owner]; ok {
+			continue
+		}
+		if cleanup != nil {
+			displacedCleanups = append(displacedCleanups, cleanup)
+		}
+	}
+	rt.adapterCleanups = nextAdapterCleanups
 	if commit != nil {
 		commit()
 	}
 	multiplexer.AdvanceHerdrPublicationGenerationLocked()
-	displacedCleanup = replacement.DisplacedCleanup
 	multiplexer.UnlockHerdrPublicationWrite()
 	unlockPublication = false
 	return nil
@@ -537,17 +559,19 @@ func (rt *Runtime) Close() {
 	}
 	rt.closed = true
 	rt.generation++
-	var adapterCleanup func()
+	var adapterCleanups []func()
 	multiplexer.LockHerdrPublicationWrite()
-	if rt.adapterCleanup != nil {
-		adapterCleanup = rt.adapterCleanup
-		rt.adapterCleanup = nil
+	for owner, cleanup := range rt.adapterCleanups {
+		if cleanup != nil {
+			adapterCleanups = append(adapterCleanups, cleanup)
+		}
+		delete(rt.adapterCleanups, owner)
 	}
 	rt.ownershipBackend.clear()
 	multiplexer.AdvanceHerdrPublicationGenerationLocked()
 	multiplexer.UnlockHerdrPublicationWrite()
-	if adapterCleanup != nil {
-		adapterCleanup()
+	for _, cleanup := range adapterCleanups {
+		cleanup()
 	}
 	for i := len(rt.cleanups) - 1; i >= 0; i-- {
 		rt.cleanups[i]()
@@ -584,25 +608,59 @@ func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string
 		return false
 	}
 	if livePanes == nil {
-		var adapterCleanup func()
+		var adapterCleanups []func()
 		multiplexer.LockHerdrPublicationWrite()
 		rt.ownershipBackend.replaceSnapshot(nil, multiplexer.HerdrBackend{})
-		if rt.adapterCleanup != nil {
-			adapterCleanup = rt.adapterCleanup
-			rt.adapterCleanup = nil
+		for owner, cleanup := range rt.adapterCleanups {
+			if cleanup != nil {
+				adapterCleanups = append(adapterCleanups, cleanup)
+			}
+			delete(rt.adapterCleanups, owner)
 		}
 		multiplexer.AdvanceHerdrPublicationGenerationLocked()
 		multiplexer.UnlockHerdrPublicationWrite()
-		if adapterCleanup != nil {
-			adapterCleanup()
+		for _, cleanup := range adapterCleanups {
+			cleanup()
 		}
 	}
 	return true
 }
 
-func (rt *Runtime) handAdapterOwnerID() string {
-	runtime := rt.cfg.ReadConfig().Runtime
-	return strings.TrimSpace(runtime.SocketPath) + "\x00" + strings.TrimSpace(runtime.SessionName) + "\x00" + strings.TrimSpace(runtime.WorkspaceID)
+func (rt *Runtime) handAdapterGroupsByOwner(adapters map[multiplexer.HerdrRuntimeIdentity]controlplane.HerdrHandAdapter) map[string]map[multiplexer.HerdrRuntimeIdentity]controlplane.HerdrHandAdapter {
+	groups := make(map[string]map[multiplexer.HerdrRuntimeIdentity]controlplane.HerdrHandAdapter)
+	for runtime, adapter := range adapters {
+		owner := rt.handAdapterOwnerIDForRuntime(runtime)
+		if owner == "" {
+			continue
+		}
+		group := groups[owner]
+		if group == nil {
+			group = make(map[multiplexer.HerdrRuntimeIdentity]controlplane.HerdrHandAdapter)
+			groups[owner] = group
+		}
+		group[runtime] = adapter
+	}
+	return groups
+}
+
+func (rt *Runtime) handAdapterOwnerIDForRuntime(runtime multiplexer.HerdrRuntimeIdentity) string {
+	configRuntime := rt.cfg.ReadConfig().Runtime
+	if runtime.SocketPath == "" {
+		runtime.SocketPath = configRuntime.SocketPath
+	}
+	if runtime.SessionName == "" {
+		runtime.SessionName = configRuntime.SessionName
+	}
+	if runtime.WorkspaceID == "" {
+		runtime.WorkspaceID = configRuntime.WorkspaceID
+	}
+	if runtime.TabID == "" {
+		runtime.TabID = configRuntime.TabID
+	}
+	return strings.TrimSpace(runtime.SocketPath) + "\x00" +
+		strings.TrimSpace(runtime.SessionName) + "\x00" +
+		strings.TrimSpace(runtime.WorkspaceID) + "\x00" +
+		strings.TrimSpace(runtime.TabID)
 }
 
 type ownershipSnapshot struct {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -88,27 +88,32 @@ func (rt *Runtime) SessionOwnerMarker(ctx context.Context, sessionName string) (
 }
 
 func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+	nodes, collisions, _, err := rt.DiscoverForReconcile(ctx, baseDir, contextID)
+	return nodes, collisions, err
+}
+
+func (rt *Runtime) DiscoverForReconcile(ctx context.Context, baseDir, contextID string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, uint64, error) {
 	if rt == nil {
-		return nil, nil, nil
+		return nil, nil, 0, nil
 	}
 	generation, closed := rt.beginDiscover()
 	if closed {
-		return nil, nil, fmt.Errorf("herdr runtime closed")
+		return nil, nil, generation, fmt.Errorf("herdr runtime closed")
 	}
 	readConfig := rt.cfg.ReadConfig()
 	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopeDiscovery
 	backend, err := multiplexer.NewHerdrBackend(readConfig, rt.client)
 	if err != nil {
-		rt.ClearPaneRoutes()
-		return nil, nil, err
+		rt.ClearPaneRoutesForToken(generation)
+		return nil, nil, generation, err
 	}
 	result, err := backend.Discover(ctx, rt.cfg.SessionName)
 	if err != nil {
-		rt.ClearPaneRoutes()
-		return nil, nil, err
+		rt.ClearPaneRoutesForToken(generation)
+		return nil, nil, generation, err
 	}
-	if !rt.discoverStillCurrent(generation) {
-		return nil, nil, fmt.Errorf("herdr runtime closed")
+	if !rt.discoverStillOpen() {
+		return nil, nil, generation, fmt.Errorf("herdr runtime closed")
 	}
 	nodes := make(map[string]discovery.NodeInfo)
 	var collisions []discovery.CollisionReport
@@ -142,10 +147,6 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 				continue
 			}
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
-			paneBackend := rt.backendForPane(tabID, item.ID.Native)
-			if !rt.setClearBackend(generation, paneBackend) {
-				return nil, nil, fmt.Errorf("herdr runtime closed")
-			}
 			if collidedNodeKeys[nodeKey] {
 				continue
 			}
@@ -161,12 +162,16 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			}
 		}
 	}
-	return nodes, collisions, nil
+	return nodes, collisions, generation, nil
 }
 
 func (rt *Runtime) beginDiscover() (uint64, bool) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	if rt.closed {
+		return rt.generation, true
+	}
+	rt.generation++
 	return rt.generation, rt.closed
 }
 
@@ -176,28 +181,60 @@ func (rt *Runtime) discoverStillCurrent(generation uint64) bool {
 	return !rt.closed && rt.generation == generation
 }
 
+func (rt *Runtime) discoverStillOpen() bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return !rt.closed
+}
+
 func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
+	rt.ReconcileFinalNodesForToken(0, nodes)
+}
+
+func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[string]discovery.NodeInfo) {
 	if rt == nil {
 		return
 	}
 	livePanes := make(map[string]bool)
+	paneBackends := make(map[string]multiplexer.HerdrBackend)
 	for _, nodeInfo := range nodes {
 		if multiplexer.BackendKindFromString(nodeInfo.Backend) != multiplexer.BackendKindHerdr || nodeInfo.PaneID == "" {
 			continue
 		}
 		livePanes[nodeInfo.PaneID] = true
-		if !rt.registerPaneBackend(0, nodeInfo.PaneID, rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)) {
+		paneBackends[nodeInfo.PaneID] = rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)
+	}
+	if len(paneBackends) == 0 {
+		if !rt.reconcilePaneBackends(generation, livePanes) {
+			return
+		}
+		if !rt.setWorkspaceSessionBackend(generation, rt.backendForWorkspace()) {
+			return
+		}
+		return
+	}
+	paneIDs := make([]string, 0, len(paneBackends))
+	for paneID := range paneBackends {
+		paneIDs = append(paneIDs, paneID)
+	}
+	sort.Strings(paneIDs)
+	for _, paneID := range paneIDs {
+		if !rt.registerPaneBackend(generation, paneID, paneBackends[paneID]) {
 			return
 		}
 	}
-	rt.reconcilePaneBackends(0, livePanes)
+	rt.reconcilePaneBackends(generation, livePanes)
 }
 
 func (rt *Runtime) ClearPaneRoutes() {
+	rt.ClearPaneRoutesForToken(0)
+}
+
+func (rt *Runtime) ClearPaneRoutesForToken(generation uint64) {
 	if rt == nil {
 		return
 	}
-	rt.reconcilePaneBackends(0, nil)
+	rt.reconcilePaneBackends(generation, nil)
 }
 
 func (rt *Runtime) Close() {
@@ -237,6 +274,26 @@ func (rt *Runtime) backendForPane(tabID, paneID string) multiplexer.HerdrBackend
 	}
 }
 
+func (rt *Runtime) backendForWorkspace() multiplexer.HerdrBackend {
+	readConfig := rt.cfg.ReadConfig()
+	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopeDiscovery
+	return multiplexer.HerdrBackend{
+		Config:         readConfig,
+		Client:         rt.client,
+		InputSanitizer: notification.PrepareInteractivePaneMessage,
+	}
+}
+
+func (rt *Runtime) setWorkspaceSessionBackend(generation uint64, backend multiplexer.HerdrBackend) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.closed || (generation != 0 && rt.generation != generation) {
+		return false
+	}
+	rt.ownershipBackend.setWorkspaceSessionBackend(backend)
+	return true
+}
+
 func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend multiplexer.HerdrBackend) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -254,16 +311,6 @@ func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend
 			InputSanitizer: notification.PrepareInteractivePaneMessage,
 		},
 	})
-	return true
-}
-
-func (rt *Runtime) setClearBackend(generation uint64, backend multiplexer.HerdrBackend) bool {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	if rt.closed || (generation != 0 && rt.generation != generation) {
-		return false
-	}
-	rt.ownershipBackend.setClearBackend(backend)
 	return true
 }
 
@@ -311,9 +358,10 @@ func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBa
 	m.setClearBackendLocked(backend)
 }
 
-func (m *ownershipMux) setClearBackend(backend multiplexer.HerdrBackend) {
+func (m *ownershipMux) setWorkspaceSessionBackend(backend multiplexer.HerdrBackend) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.setSessionBackendLocked(backend)
 	m.setClearBackendLocked(backend)
 }
 

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -135,7 +135,7 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 			}
 			nodeKey := rt.cfg.SessionName + ":" + item.LogicalName
 			paneBackend := rt.backendForPane(tabID, item.ID.Native)
-			rt.ownershipBackend.setSessionBackend(paneBackend)
+			rt.ownershipBackend.setClearBackend(paneBackend)
 			if collidedNodeKeys[nodeKey] {
 				continue
 			}
@@ -244,6 +244,7 @@ type ownershipMux struct {
 	mu             sync.RWMutex
 	byPane         map[string]multiplexer.HerdrBackend
 	sessionBackend *multiplexer.HerdrBackend
+	clearBackend   *multiplexer.HerdrBackend
 }
 
 func newOwnershipMux(sessionName string) *ownershipMux {
@@ -259,12 +260,13 @@ func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBa
 	defer m.mu.Unlock()
 	m.byPane[paneID] = backend
 	m.setSessionBackendLocked(backend)
+	m.setClearBackendLocked(backend)
 }
 
-func (m *ownershipMux) setSessionBackend(backend multiplexer.HerdrBackend) {
+func (m *ownershipMux) setClearBackend(backend multiplexer.HerdrBackend) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.setSessionBackendLocked(backend)
+	m.setClearBackendLocked(backend)
 }
 
 func (m *ownershipMux) setSessionBackendLocked(backend multiplexer.HerdrBackend) {
@@ -272,10 +274,29 @@ func (m *ownershipMux) setSessionBackendLocked(backend multiplexer.HerdrBackend)
 	m.sessionBackend = &sessionBackend
 }
 
+func (m *ownershipMux) setClearBackendLocked(backend multiplexer.HerdrBackend) {
+	clearBackend := backend
+	m.clearBackend = &clearBackend
+}
+
 func (m *ownershipMux) deletePaneBackend(paneID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.byPane, paneID)
+	m.rebuildSessionBackendLocked()
+}
+
+func (m *ownershipMux) rebuildSessionBackendLocked() {
+	keys := make([]string, 0, len(m.byPane))
+	for paneID := range m.byPane {
+		keys = append(keys, paneID)
+	}
+	sort.Strings(keys)
+	m.sessionBackend = nil
+	for _, paneID := range keys {
+		m.setSessionBackendLocked(m.byPane[paneID])
+		return
+	}
 }
 
 func (m *ownershipMux) clear() {
@@ -283,6 +304,7 @@ func (m *ownershipMux) clear() {
 	defer m.mu.Unlock()
 	m.byPane = make(map[string]multiplexer.HerdrBackend)
 	m.sessionBackend = nil
+	m.clearBackend = nil
 }
 
 func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrBackend, error) {
@@ -294,15 +316,19 @@ func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrB
 	if m.sessionBackend != nil {
 		return *m.sessionBackend, nil
 	}
-	keys := make([]string, 0, len(m.byPane))
-	for paneID := range m.byPane {
-		keys = append(keys, paneID)
-	}
-	sort.Strings(keys)
-	for _, paneID := range keys {
-		return m.byPane[paneID], nil
-	}
 	return multiplexer.HerdrBackend{}, fmt.Errorf("%w: no herdr pane backend registered for session %q", multiplexer.ErrHerdrReadClientMissing, sessionName)
+}
+
+func (m *ownershipMux) backendForSessionClear(sessionName string) (multiplexer.HerdrBackend, error) {
+	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
+		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.clearBackend != nil {
+		return *m.clearBackend, nil
+	}
+	return multiplexer.HerdrBackend{}, fmt.Errorf("%w: no herdr session clear backend registered for session %q", multiplexer.ErrHerdrReadClientMissing, sessionName)
 }
 
 func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.HerdrBackend, error) {
@@ -335,7 +361,7 @@ func (m *ownershipMux) SetSessionOwnerMarker(ctx context.Context, contextID, ses
 }
 
 func (m *ownershipMux) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
-	backend, err := m.backendForSession(sessionName)
+	backend, err := m.backendForSessionClear(sessionName)
 	if err != nil {
 		return err
 	}

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -181,10 +181,6 @@ func (rt *Runtime) Close() {
 	}
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	for i := len(rt.cleanups) - 1; i >= 0; i-- {
-		rt.cleanups[i]()
-	}
-	rt.cleanups = nil
 	for paneID, cleanup := range rt.paneCleanups {
 		if cleanup != nil {
 			cleanup()
@@ -193,6 +189,10 @@ func (rt *Runtime) Close() {
 	}
 	rt.registeredPanes = make(map[string]bool)
 	rt.ownershipBackend.clear()
+	for i := len(rt.cleanups) - 1; i >= 0; i-- {
+		rt.cleanups[i]()
+	}
+	rt.cleanups = nil
 }
 
 func (rt *Runtime) backendForPane(tabID, paneID string) multiplexer.HerdrBackend {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -331,10 +331,10 @@ func (m *ownershipMux) deletePaneBackend(paneID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.byPane, paneID)
-	m.rebuildSessionBackendLocked()
+	m.rebuildLiveSessionBackendsLocked()
 }
 
-func (m *ownershipMux) rebuildSessionBackendLocked() {
+func (m *ownershipMux) rebuildLiveSessionBackendsLocked() {
 	keys := make([]string, 0, len(m.byPane))
 	for paneID := range m.byPane {
 		keys = append(keys, paneID)
@@ -342,7 +342,9 @@ func (m *ownershipMux) rebuildSessionBackendLocked() {
 	sort.Strings(keys)
 	m.sessionBackend = nil
 	for _, paneID := range keys {
-		m.setSessionBackendLocked(m.byPane[paneID])
+		backend := m.byPane[paneID]
+		m.setSessionBackendLocked(backend)
+		m.setClearBackendLocked(backend)
 		return
 	}
 }

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -2,7 +2,9 @@ package herdrruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -32,8 +34,16 @@ type Runtime struct {
 type FinalPublication struct {
 	ownershipBackend *ownershipMux
 	runtime          *Runtime
-	rollbacks        []func()
+	rollbacks        []func(context.Context) error
 	rolledBack       bool
+}
+
+func NewFinalPublication() *FinalPublication {
+	return &FinalPublication{}
+}
+
+func (p *FinalPublication) Rollback() error {
+	return p.rollback()
 }
 
 func (p *FinalPublication) Kind() multiplexer.BackendKind {
@@ -48,13 +58,17 @@ func (p *FinalPublication) SessionOwnerMarker(ctx context.Context, sessionName s
 }
 
 func (p *FinalPublication) SetSessionEnabledMarker(ctx context.Context, contextID, sessionName string, enabled bool) error {
-	if p == nil || p.ownershipBackend == nil || p.runtime == nil || !p.runtime.OwnsSession(sessionName) {
+	if p == nil {
 		return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
 	}
-	if enabled {
-		return p.setSessionOwnerMarker(ctx, contextID, sessionName, 0)
+	backend := multiplexer.OwnershipBackend(multiplexer.TmuxBackend{})
+	if p.ownershipBackend != nil && p.runtime != nil && p.runtime.OwnsSession(sessionName) {
+		backend = p.ownershipBackend
 	}
-	return p.clearSessionOwnerMarker(ctx, sessionName)
+	if enabled {
+		return p.setSessionOwnerMarkerWithBackend(ctx, backend, contextID, sessionName, os.Getpid())
+	}
+	return p.clearSessionOwnerMarkerWithBackend(ctx, backend, sessionName)
 }
 
 func (p *FinalPublication) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
@@ -79,76 +93,76 @@ func (p *FinalPublication) PaneOwnerMarker(ctx context.Context, pane multiplexer
 }
 
 func (p *FinalPublication) SetPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID, contextID string) error {
-	if p == nil || p.ownershipBackend == nil || pane.Backend != multiplexer.BackendKindHerdr {
+	if p == nil {
 		backend, err := multiplexer.OwnershipBackendForKind(pane.Backend)
 		if err != nil {
 			return err
 		}
-		if p == nil {
-			return backend.SetPaneOwnerMarker(ctx, pane, contextID)
-		}
-		return p.setPaneOwnerMarkerWithBackend(ctx, backend, pane, contextID)
+		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
 	}
-	return p.setPaneOwnerMarkerWithBackend(ctx, p.ownershipBackend, pane, contextID)
+	backend, err := p.ownershipBackendForPane(pane)
+	if err != nil {
+		return err
+	}
+	return p.setPaneOwnerMarkerWithBackend(ctx, backend, pane, contextID)
 }
 
 func (p *FinalPublication) ClearPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) error {
-	if p == nil || p.ownershipBackend == nil {
+	if p == nil {
 		return fmt.Errorf("herdr final publication missing")
 	}
-	backend := multiplexer.OwnershipBackend(p.ownershipBackend)
-	if pane.Backend != multiplexer.BackendKindHerdr {
-		var err error
-		backend, err = multiplexer.OwnershipBackendForKind(pane.Backend)
-		if err != nil {
-			return err
-		}
+	backend, err := p.ownershipBackendForPane(pane)
+	if err != nil {
+		return err
 	}
 	return p.clearPaneOwnerMarkerWithBackend(ctx, backend, pane)
 }
 
+func (p *FinalPublication) ownershipBackendForPane(pane multiplexer.ResourceID) (multiplexer.OwnershipBackend, error) {
+	if pane.Backend == multiplexer.BackendKindHerdr && p.ownershipBackend != nil {
+		return p.ownershipBackend, nil
+	}
+	return multiplexer.OwnershipBackendForKind(pane.Backend)
+}
+
 func (p *FinalPublication) setSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
-	previous, readErr := p.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+	return p.setSessionOwnerMarkerWithBackend(ctx, p.ownershipBackend, contextID, sessionName, pid)
+}
+
+func (p *FinalPublication) setSessionOwnerMarkerWithBackend(ctx context.Context, backend multiplexer.OwnershipBackend, contextID, sessionName string, pid int) error {
+	previous, readErr := backend.SessionOwnerMarker(ctx, sessionName)
 	if readErr != nil {
 		return readErr
 	}
-	if err := p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err != nil {
+	if err := backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err != nil {
+		if rollbackErr := restoreSessionOwnerMarker(context.Background(), backend, sessionName, previous); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback after failed session owner marker write: %w", rollbackErr))
+		}
 		return err
 	}
-	p.rollbacks = append(p.rollbacks, func() {
-		rollbackCtx := context.Background()
-		if previous == "" {
-			_ = p.ownershipBackend.ClearSessionOwnerMarker(rollbackCtx, sessionName)
-			return
-		}
-		previousContext, previousPIDText, _ := strings.Cut(previous, ":")
-		previousPID := 0
-		if previousPIDText != "" {
-			_, _ = fmt.Sscanf(previousPIDText, "%d", &previousPID)
-		}
-		_ = p.ownershipBackend.SetSessionOwnerMarker(rollbackCtx, previousContext, sessionName, previousPID)
+	p.rollbacks = append(p.rollbacks, func(rollbackCtx context.Context) error {
+		return restoreSessionOwnerMarker(rollbackCtx, backend, sessionName, previous)
 	})
 	return nil
 }
 
 func (p *FinalPublication) clearSessionOwnerMarker(ctx context.Context, sessionName string) error {
-	previous, readErr := p.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+	return p.clearSessionOwnerMarkerWithBackend(ctx, p.ownershipBackend, sessionName)
+}
+
+func (p *FinalPublication) clearSessionOwnerMarkerWithBackend(ctx context.Context, backend multiplexer.OwnershipBackend, sessionName string) error {
+	previous, readErr := backend.SessionOwnerMarker(ctx, sessionName)
 	if readErr != nil {
 		return readErr
 	}
-	if err := p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName); err != nil {
+	if err := backend.ClearSessionOwnerMarker(ctx, sessionName); err != nil {
+		if rollbackErr := restoreSessionOwnerMarker(context.Background(), backend, sessionName, previous); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback after failed session owner marker clear: %w", rollbackErr))
+		}
 		return err
 	}
-	p.rollbacks = append(p.rollbacks, func() {
-		if previous == "" {
-			return
-		}
-		previousContext, previousPIDText, _ := strings.Cut(previous, ":")
-		previousPID := 0
-		if previousPIDText != "" {
-			_, _ = fmt.Sscanf(previousPIDText, "%d", &previousPID)
-		}
-		_ = p.ownershipBackend.SetSessionOwnerMarker(context.Background(), previousContext, sessionName, previousPID)
+	p.rollbacks = append(p.rollbacks, func(rollbackCtx context.Context) error {
+		return restoreSessionOwnerMarker(rollbackCtx, backend, sessionName, previous)
 	})
 	return nil
 }
@@ -159,15 +173,13 @@ func (p *FinalPublication) setPaneOwnerMarkerWithBackend(ctx context.Context, ba
 		return readErr
 	}
 	if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
+		if rollbackErr := restorePaneOwnerMarker(context.Background(), backend, pane, previous); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback after failed pane owner marker write: %w", rollbackErr))
+		}
 		return err
 	}
-	p.rollbacks = append(p.rollbacks, func() {
-		rollbackCtx := context.Background()
-		if previous == "" {
-			_ = backend.ClearPaneOwnerMarker(rollbackCtx, pane)
-			return
-		}
-		_ = backend.SetPaneOwnerMarker(rollbackCtx, pane, previous)
+	p.rollbacks = append(p.rollbacks, func(rollbackCtx context.Context) error {
+		return restorePaneOwnerMarker(rollbackCtx, backend, pane, previous)
 	})
 	return nil
 }
@@ -178,25 +190,72 @@ func (p *FinalPublication) clearPaneOwnerMarkerWithBackend(ctx context.Context, 
 		return readErr
 	}
 	if err := backend.ClearPaneOwnerMarker(ctx, pane); err != nil {
+		if rollbackErr := restorePaneOwnerMarker(context.Background(), backend, pane, previous); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback after failed pane owner marker clear: %w", rollbackErr))
+		}
 		return err
 	}
-	p.rollbacks = append(p.rollbacks, func() {
-		if previous == "" {
-			return
-		}
-		_ = backend.SetPaneOwnerMarker(context.Background(), pane, previous)
+	p.rollbacks = append(p.rollbacks, func(rollbackCtx context.Context) error {
+		return restorePaneOwnerMarker(rollbackCtx, backend, pane, previous)
 	})
 	return nil
 }
 
-func (p *FinalPublication) rollback() {
+func restoreSessionOwnerMarker(ctx context.Context, backend multiplexer.OwnershipBackend, sessionName, previous string) error {
+	if previous == "" {
+		if err := backend.ClearSessionOwnerMarker(ctx, sessionName); err != nil {
+			return err
+		}
+	} else {
+		previousContext, previousPIDText, _ := strings.Cut(previous, ":")
+		previousPID := 0
+		if previousPIDText != "" {
+			_, _ = fmt.Sscanf(previousPIDText, "%d", &previousPID)
+		}
+		if err := backend.SetSessionOwnerMarker(ctx, previousContext, sessionName, previousPID); err != nil {
+			return err
+		}
+	}
+	current, err := backend.SessionOwnerMarker(ctx, sessionName)
+	if err != nil {
+		return err
+	}
+	if current != previous {
+		return fmt.Errorf("session owner marker rollback verification failed for %s: got %q want %q", sessionName, current, previous)
+	}
+	return nil
+}
+
+func restorePaneOwnerMarker(ctx context.Context, backend multiplexer.OwnershipBackend, pane multiplexer.ResourceID, previous string) error {
+	if previous == "" {
+		if err := backend.ClearPaneOwnerMarker(ctx, pane); err != nil {
+			return err
+		}
+	} else if err := backend.SetPaneOwnerMarker(ctx, pane, previous); err != nil {
+		return err
+	}
+	current, err := backend.PaneOwnerMarker(ctx, pane)
+	if err != nil {
+		return err
+	}
+	if current != previous {
+		return fmt.Errorf("pane owner marker rollback verification failed for %s: got %q want %q", pane.Native, current, previous)
+	}
+	return nil
+}
+
+func (p *FinalPublication) rollback() error {
 	if p == nil || p.rolledBack {
-		return
+		return nil
 	}
 	p.rolledBack = true
+	var rollbackErr error
 	for i := len(p.rollbacks) - 1; i >= 0; i-- {
-		p.rollbacks[i]()
+		if err := p.rollbacks[i](context.Background()); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+		}
 	}
+	return rollbackErr
 }
 
 func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
@@ -417,7 +476,9 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 	publication := &FinalPublication{ownershipBackend: stagedOwnership, runtime: rt}
 	if prepare != nil {
 		if err := prepare(publication); err != nil {
-			publication.rollback()
+			if rollbackErr := publication.rollback(); rollbackErr != nil {
+				return errors.Join(err, fmt.Errorf("rollback failed: %w", rollbackErr))
+			}
 			return err
 		}
 	}

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -93,10 +93,12 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 	readConfig.Policy.ReadScope = multiplexer.HerdrReadScopeDiscovery
 	backend, err := multiplexer.NewHerdrBackend(readConfig, rt.client)
 	if err != nil {
+		rt.ClearPaneRoutes()
 		return nil, nil, err
 	}
 	result, err := backend.Discover(ctx, rt.cfg.SessionName)
 	if err != nil {
+		rt.ClearPaneRoutes()
 		return nil, nil, err
 	}
 	nodes := make(map[string]discovery.NodeInfo)
@@ -150,6 +152,27 @@ func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map
 	}
 	rt.reconcilePaneBackends(livePanes)
 	return nodes, collisions, nil
+}
+
+func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
+	if rt == nil {
+		return
+	}
+	livePanes := make(map[string]bool)
+	for _, nodeInfo := range nodes {
+		if multiplexer.BackendKindFromString(nodeInfo.Backend) != multiplexer.BackendKindHerdr || nodeInfo.PaneID == "" {
+			continue
+		}
+		livePanes[nodeInfo.PaneID] = true
+	}
+	rt.reconcilePaneBackends(livePanes)
+}
+
+func (rt *Runtime) ClearPaneRoutes() {
+	if rt == nil {
+		return
+	}
+	rt.reconcilePaneBackends(nil)
 }
 
 func (rt *Runtime) Close() {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -22,12 +22,11 @@ type Runtime struct {
 	client           multiplexer.HerdrReadClient
 	ownershipBackend *ownershipMux
 
-	mu              sync.Mutex
-	closed          bool
-	generation      uint64
-	cleanups        []func()
-	paneCleanups    map[string]func()
-	registeredPanes map[string]bool
+	mu             sync.Mutex
+	closed         bool
+	generation     uint64
+	cleanups       []func()
+	adapterCleanup func()
 }
 
 func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
@@ -48,8 +47,6 @@ func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
 		cfg:              cfg.Herdr,
 		client:           client,
 		ownershipBackend: newOwnershipMux(cfg.Herdr.SessionName),
-		paneCleanups:     make(map[string]func()),
-		registeredPanes:  make(map[string]bool),
 	}
 	rt.cleanups = append(rt.cleanups, multiplexer.RegisterOwnershipBackend(rt.ownershipBackend))
 	return rt, nil
@@ -88,7 +85,10 @@ func (rt *Runtime) SessionOwnerMarker(ctx context.Context, sessionName string) (
 }
 
 func (rt *Runtime) Discover(ctx context.Context, baseDir, contextID string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
-	nodes, collisions, _, err := rt.DiscoverForReconcile(ctx, baseDir, contextID)
+	nodes, collisions, generation, err := rt.DiscoverForReconcile(ctx, baseDir, contextID)
+	if err == nil && !rt.discoverStillCurrent(generation) {
+		return nil, nil, fmt.Errorf("stale Herdr discovery token")
+	}
 	return nodes, collisions, err
 }
 
@@ -192,39 +192,47 @@ func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) bool
 }
 
 func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[string]discovery.NodeInfo) bool {
+	return rt.ReconcileFinalNodesForTokenAndPublish(generation, nodes, nil) == nil
+}
+
+func (rt *Runtime) ReconcileFinalNodesForTokenAndPublish(generation uint64, nodes map[string]discovery.NodeInfo, publish func() error) error {
 	if rt == nil {
-		return false
+		return fmt.Errorf("herdr runtime missing")
 	}
-	livePanes := make(map[string]bool)
 	paneBackends := make(map[string]multiplexer.HerdrBackend)
+	handAdapters := make(map[string]controlplane.HerdrHandAdapter)
 	for _, nodeInfo := range nodes {
 		if multiplexer.BackendKindFromString(nodeInfo.Backend) != multiplexer.BackendKindHerdr || nodeInfo.PaneID == "" {
 			continue
 		}
-		livePanes[nodeInfo.PaneID] = true
-		paneBackends[nodeInfo.PaneID] = rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)
+		backend := rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)
+		paneBackends[nodeInfo.PaneID] = backend
+		handAdapters[nodeInfo.PaneID] = controlplane.HerdrHandAdapter{
+			HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
+				Backend:        backend,
+				InputSanitizer: notification.PrepareInteractivePaneMessage,
+			},
+		}
 	}
-	paneIDs := make([]string, 0, len(paneBackends))
-	for paneID := range paneBackends {
-		paneIDs = append(paneIDs, paneID)
-	}
-	sort.Strings(paneIDs)
+	workspaceBackend := rt.backendForWorkspace()
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.closed || (generation != 0 && rt.generation != generation) {
-		return false
+		return fmt.Errorf("stale Herdr final reconcile token")
 	}
-	if len(paneBackends) == 0 {
-		rt.prunePaneBackendsLocked(livePanes)
-		rt.ownershipBackend.setWorkspaceSessionBackend(rt.backendForWorkspace())
-		return true
+	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
+	if rt.adapterCleanup != nil {
+		rt.adapterCleanup()
+		rt.adapterCleanup = nil
 	}
-	for _, paneID := range paneIDs {
-		rt.registerPaneBackendLocked(paneID, paneBackends[paneID])
+	rt.adapterCleanup = controlplane.ReplaceHerdrHandAdaptersForOwner(rt.handAdapterOwnerID(), handAdapters)
+	if publish != nil {
+		if err := publish(); err != nil {
+			return err
+		}
 	}
-	rt.prunePaneBackendsLocked(livePanes)
-	return true
+	return nil
 }
 
 func (rt *Runtime) ClearPaneRoutes() {
@@ -249,13 +257,10 @@ func (rt *Runtime) Close() {
 	}
 	rt.closed = true
 	rt.generation++
-	for paneID, cleanup := range rt.paneCleanups {
-		if cleanup != nil {
-			cleanup()
-		}
-		delete(rt.paneCleanups, paneID)
+	if rt.adapterCleanup != nil {
+		rt.adapterCleanup()
+		rt.adapterCleanup = nil
 	}
-	rt.registeredPanes = make(map[string]bool)
 	rt.ownershipBackend.clear()
 	for i := len(rt.cleanups) - 1; i >= 0; i-- {
 		rt.cleanups[i]()
@@ -285,133 +290,97 @@ func (rt *Runtime) backendForWorkspace() multiplexer.HerdrBackend {
 	}
 }
 
-func (rt *Runtime) setWorkspaceSessionBackend(generation uint64, backend multiplexer.HerdrBackend) bool {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	if rt.closed || (generation != 0 && rt.generation != generation) {
-		return false
-	}
-	rt.ownershipBackend.setWorkspaceSessionBackend(backend)
-	return true
-}
-
-func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend multiplexer.HerdrBackend) bool {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	if rt.closed || (generation != 0 && rt.generation != generation) {
-		return false
-	}
-	rt.registerPaneBackendLocked(paneID, backend)
-	return true
-}
-
-func (rt *Runtime) registerPaneBackendLocked(paneID string, backend multiplexer.HerdrBackend) {
-	rt.ownershipBackend.setPaneBackend(paneID, backend)
-	rt.registeredPanes[paneID] = true
-	if cleanup, ok := rt.paneCleanups[paneID]; ok {
-		cleanup()
-	}
-	rt.paneCleanups[paneID] = controlplane.RegisterHerdrHandAdapter(paneID, controlplane.HerdrHandAdapter{
-		HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
-			Backend:        backend,
-			InputSanitizer: notification.PrepareInteractivePaneMessage,
-		},
-	})
-}
-
 func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string]bool) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.closed || (generation != 0 && rt.generation != generation) {
 		return false
 	}
-	rt.prunePaneBackendsLocked(livePanes)
+	if livePanes == nil {
+		rt.ownershipBackend.replaceSnapshot(nil, multiplexer.HerdrBackend{})
+		if rt.adapterCleanup != nil {
+			rt.adapterCleanup()
+			rt.adapterCleanup = nil
+		}
+	}
 	return true
 }
 
-func (rt *Runtime) prunePaneBackendsLocked(livePanes map[string]bool) {
-	for paneID := range rt.registeredPanes {
-		if livePanes[paneID] {
-			continue
-		}
-		if cleanup := rt.paneCleanups[paneID]; cleanup != nil {
-			cleanup()
-		}
-		delete(rt.paneCleanups, paneID)
-		delete(rt.registeredPanes, paneID)
-		rt.ownershipBackend.deletePaneBackend(paneID)
-	}
+func (rt *Runtime) handAdapterOwnerID() string {
+	runtime := rt.cfg.ReadConfig().Runtime
+	return strings.TrimSpace(runtime.SocketPath) + "\x00" + strings.TrimSpace(runtime.SessionName) + "\x00" + strings.TrimSpace(runtime.WorkspaceID)
 }
 
-type ownershipMux struct {
-	sessionName    string
-	mu             sync.RWMutex
-	byPane         map[string]multiplexer.HerdrBackend
+type ownershipSnapshot struct {
+	byPane         map[herdrOwnershipKey]multiplexer.HerdrBackend
 	sessionBackend *multiplexer.HerdrBackend
 	clearBackend   *multiplexer.HerdrBackend
 }
 
+type herdrOwnershipKey struct {
+	SocketPath  string
+	SessionName string
+	WorkspaceID string
+	PaneID      string
+}
+
+type ownershipMux struct {
+	sessionName string
+	runtime     multiplexer.HerdrRuntimeIdentity
+	mu          sync.RWMutex
+	snapshot    ownershipSnapshot
+}
+
 func newOwnershipMux(sessionName string) *ownershipMux {
-	return &ownershipMux{sessionName: sessionName, byPane: make(map[string]multiplexer.HerdrBackend)}
+	return &ownershipMux{sessionName: sessionName}
 }
 
 func (m *ownershipMux) Kind() multiplexer.BackendKind {
 	return multiplexer.BackendKindHerdr
 }
 
-func (m *ownershipMux) setPaneBackend(paneID string, backend multiplexer.HerdrBackend) {
+func (m *ownershipMux) HerdrRuntimeIdentity() multiplexer.HerdrRuntimeIdentity {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.byPane[paneID] = backend
-	m.setSessionBackendLocked(backend)
-	m.setClearBackendLocked(backend)
-}
-
-func (m *ownershipMux) setWorkspaceSessionBackend(backend multiplexer.HerdrBackend) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.setSessionBackendLocked(backend)
-	m.setClearBackendLocked(backend)
-}
-
-func (m *ownershipMux) setSessionBackendLocked(backend multiplexer.HerdrBackend) {
-	sessionBackend := backend
-	m.sessionBackend = &sessionBackend
-}
-
-func (m *ownershipMux) setClearBackendLocked(backend multiplexer.HerdrBackend) {
-	clearBackend := backend
-	m.clearBackend = &clearBackend
-}
-
-func (m *ownershipMux) deletePaneBackend(paneID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.byPane, paneID)
-	m.rebuildLiveSessionBackendsLocked()
-}
-
-func (m *ownershipMux) rebuildLiveSessionBackendsLocked() {
-	keys := make([]string, 0, len(m.byPane))
-	for paneID := range m.byPane {
-		keys = append(keys, paneID)
-	}
-	sort.Strings(keys)
-	m.sessionBackend = nil
-	for _, paneID := range keys {
-		backend := m.byPane[paneID]
-		m.setSessionBackendLocked(backend)
-		m.setClearBackendLocked(backend)
-		return
-	}
+	return m.runtime
 }
 
 func (m *ownershipMux) clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.byPane = make(map[string]multiplexer.HerdrBackend)
-	m.sessionBackend = nil
-	m.clearBackend = nil
+	m.snapshot = ownershipSnapshot{}
+	m.runtime = multiplexer.HerdrRuntimeIdentity{}
+}
+
+func (m *ownershipMux) replaceSnapshot(panes map[string]multiplexer.HerdrBackend, workspaceBackend multiplexer.HerdrBackend) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	snapshot := ownershipSnapshot{byPane: make(map[herdrOwnershipKey]multiplexer.HerdrBackend, len(panes))}
+	keys := make([]string, 0, len(panes))
+	for paneID := range panes {
+		keys = append(keys, paneID)
+	}
+	sort.Strings(keys)
+	for _, paneID := range keys {
+		backend := panes[paneID]
+		snapshot.byPane[herdrOwnershipKeyForBackend(backend, paneID)] = backend
+	}
+	if len(panes) == 0 {
+		sessionBackend := workspaceBackend
+		clearBackend := workspaceBackend
+		snapshot.sessionBackend = &sessionBackend
+		snapshot.clearBackend = &clearBackend
+		m.runtime = workspaceBackend.Config.Runtime
+		m.snapshot = snapshot
+		return
+	}
+	firstBackend := panes[keys[0]]
+	sessionBackend := firstBackend
+	clearBackend := firstBackend
+	snapshot.sessionBackend = &sessionBackend
+	snapshot.clearBackend = &clearBackend
+	m.runtime = firstBackend.Config.Runtime
+	m.snapshot = snapshot
 }
 
 func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrBackend, error) {
@@ -420,8 +389,8 @@ func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrB
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if m.sessionBackend != nil {
-		return *m.sessionBackend, nil
+	if m.snapshot.sessionBackend != nil {
+		return *m.snapshot.sessionBackend, nil
 	}
 	return multiplexer.HerdrBackend{}, fmt.Errorf("%w: no herdr pane backend registered for session %q", multiplexer.ErrHerdrReadClientMissing, sessionName)
 }
@@ -432,8 +401,8 @@ func (m *ownershipMux) backendForSessionClear(sessionName string) (multiplexer.H
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if m.clearBackend != nil {
-		return *m.clearBackend, nil
+	if m.snapshot.clearBackend != nil {
+		return *m.snapshot.clearBackend, nil
 	}
 	return multiplexer.HerdrBackend{}, fmt.Errorf("%w: no herdr session clear backend registered for session %q", multiplexer.ErrHerdrReadClientMissing, sessionName)
 }
@@ -444,11 +413,58 @@ func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	backend, ok := m.byPane[pane.Native]
+	backend, ok := m.snapshot.byPane[herdrOwnershipKeyForResource(pane)]
+	if !ok && pane.HerdrRuntime.SocketPath == "" && pane.HerdrRuntime.WorkspaceID == "" {
+		backend, ok = m.backendForLegacyPaneLocked(pane.Native)
+	}
 	if !ok {
 		return multiplexer.HerdrBackend{}, fmt.Errorf("herdr pane backend not registered for %q", pane.Native)
 	}
 	return backend, nil
+}
+
+func (m *ownershipMux) backendForLegacyPaneLocked(paneID string) (multiplexer.HerdrBackend, bool) {
+	var (
+		backend multiplexer.HerdrBackend
+		found   bool
+	)
+	for key, candidate := range m.snapshot.byPane {
+		if key.PaneID != paneID {
+			continue
+		}
+		if found {
+			return multiplexer.HerdrBackend{}, false
+		}
+		backend = candidate
+		found = true
+	}
+	return backend, found
+}
+
+func herdrOwnershipKeyForBackend(backend multiplexer.HerdrBackend, paneID string) herdrOwnershipKey {
+	runtime := backend.Config.Runtime
+	if runtime.PaneID == "" {
+		runtime.PaneID = paneID
+	}
+	return herdrOwnershipKey{
+		SocketPath:  strings.TrimSpace(runtime.SocketPath),
+		SessionName: strings.TrimSpace(runtime.SessionName),
+		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		PaneID:      strings.TrimSpace(runtime.PaneID),
+	}
+}
+
+func herdrOwnershipKeyForResource(pane multiplexer.ResourceID) herdrOwnershipKey {
+	runtime := pane.HerdrRuntime
+	if runtime.PaneID == "" {
+		runtime.PaneID = pane.Native
+	}
+	return herdrOwnershipKey{
+		SocketPath:  strings.TrimSpace(runtime.SocketPath),
+		SessionName: strings.TrimSpace(runtime.SessionName),
+		WorkspaceID: strings.TrimSpace(runtime.WorkspaceID),
+		PaneID:      strings.TrimSpace(runtime.PaneID),
+	}
 }
 
 func (m *ownershipMux) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -187,13 +187,13 @@ func (rt *Runtime) discoverStillOpen() bool {
 	return !rt.closed
 }
 
-func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) {
-	rt.ReconcileFinalNodesForToken(0, nodes)
+func (rt *Runtime) ReconcileFinalNodes(nodes map[string]discovery.NodeInfo) bool {
+	return rt.ReconcileFinalNodesForToken(0, nodes)
 }
 
-func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[string]discovery.NodeInfo) {
+func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[string]discovery.NodeInfo) bool {
 	if rt == nil {
-		return
+		return false
 	}
 	livePanes := make(map[string]bool)
 	paneBackends := make(map[string]multiplexer.HerdrBackend)
@@ -204,26 +204,27 @@ func (rt *Runtime) ReconcileFinalNodesForToken(generation uint64, nodes map[stri
 		livePanes[nodeInfo.PaneID] = true
 		paneBackends[nodeInfo.PaneID] = rt.backendForPane(nodeInfo.HerdrTabID, nodeInfo.PaneID)
 	}
-	if len(paneBackends) == 0 {
-		if !rt.reconcilePaneBackends(generation, livePanes) {
-			return
-		}
-		if !rt.setWorkspaceSessionBackend(generation, rt.backendForWorkspace()) {
-			return
-		}
-		return
-	}
 	paneIDs := make([]string, 0, len(paneBackends))
 	for paneID := range paneBackends {
 		paneIDs = append(paneIDs, paneID)
 	}
 	sort.Strings(paneIDs)
-	for _, paneID := range paneIDs {
-		if !rt.registerPaneBackend(generation, paneID, paneBackends[paneID]) {
-			return
-		}
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.closed || (generation != 0 && rt.generation != generation) {
+		return false
 	}
-	rt.reconcilePaneBackends(generation, livePanes)
+	if len(paneBackends) == 0 {
+		rt.prunePaneBackendsLocked(livePanes)
+		rt.ownershipBackend.setWorkspaceSessionBackend(rt.backendForWorkspace())
+		return true
+	}
+	for _, paneID := range paneIDs {
+		rt.registerPaneBackendLocked(paneID, paneBackends[paneID])
+	}
+	rt.prunePaneBackendsLocked(livePanes)
+	return true
 }
 
 func (rt *Runtime) ClearPaneRoutes() {
@@ -300,6 +301,11 @@ func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend
 	if rt.closed || (generation != 0 && rt.generation != generation) {
 		return false
 	}
+	rt.registerPaneBackendLocked(paneID, backend)
+	return true
+}
+
+func (rt *Runtime) registerPaneBackendLocked(paneID string, backend multiplexer.HerdrBackend) {
 	rt.ownershipBackend.setPaneBackend(paneID, backend)
 	rt.registeredPanes[paneID] = true
 	if cleanup, ok := rt.paneCleanups[paneID]; ok {
@@ -311,7 +317,6 @@ func (rt *Runtime) registerPaneBackend(generation uint64, paneID string, backend
 			InputSanitizer: notification.PrepareInteractivePaneMessage,
 		},
 	})
-	return true
 }
 
 func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string]bool) bool {
@@ -320,6 +325,11 @@ func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string
 	if rt.closed || (generation != 0 && rt.generation != generation) {
 		return false
 	}
+	rt.prunePaneBackendsLocked(livePanes)
+	return true
+}
+
+func (rt *Runtime) prunePaneBackendsLocked(livePanes map[string]bool) {
 	for paneID := range rt.registeredPanes {
 		if livePanes[paneID] {
 			continue
@@ -331,7 +341,6 @@ func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string
 		delete(rt.registeredPanes, paneID)
 		rt.ownershipBackend.deletePaneBackend(paneID)
 	}
-	return true
 }
 
 type ownershipMux struct {

--- a/internal/herdrruntime/runtime.go
+++ b/internal/herdrruntime/runtime.go
@@ -32,6 +32,8 @@ type Runtime struct {
 type FinalPublication struct {
 	ownershipBackend *ownershipMux
 	runtime          *Runtime
+	rollbacks        []func()
+	rolledBack       bool
 }
 
 func (p *FinalPublication) Kind() multiplexer.BackendKind {
@@ -50,23 +52,23 @@ func (p *FinalPublication) SetSessionEnabledMarker(ctx context.Context, contextI
 		return config.SetSessionEnabledMarker(contextID, sessionName, enabled)
 	}
 	if enabled {
-		return p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, 0)
+		return p.setSessionOwnerMarker(ctx, contextID, sessionName, 0)
 	}
-	return p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName)
+	return p.clearSessionOwnerMarker(ctx, sessionName)
 }
 
 func (p *FinalPublication) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
 	if p == nil || p.ownershipBackend == nil {
 		return fmt.Errorf("herdr final publication missing")
 	}
-	return p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid)
+	return p.setSessionOwnerMarker(ctx, contextID, sessionName, pid)
 }
 
 func (p *FinalPublication) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
 	if p == nil || p.ownershipBackend == nil {
 		return fmt.Errorf("herdr final publication missing")
 	}
-	return p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName)
+	return p.clearSessionOwnerMarker(ctx, sessionName)
 }
 
 func (p *FinalPublication) PaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) (string, error) {
@@ -82,16 +84,119 @@ func (p *FinalPublication) SetPaneOwnerMarker(ctx context.Context, pane multiple
 		if err != nil {
 			return err
 		}
-		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+		if p == nil {
+			return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+		}
+		return p.setPaneOwnerMarkerWithBackend(ctx, backend, pane, contextID)
 	}
-	return p.ownershipBackend.SetPaneOwnerMarker(ctx, pane, contextID)
+	return p.setPaneOwnerMarkerWithBackend(ctx, p.ownershipBackend, pane, contextID)
 }
 
 func (p *FinalPublication) ClearPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) error {
 	if p == nil || p.ownershipBackend == nil {
 		return fmt.Errorf("herdr final publication missing")
 	}
-	return p.ownershipBackend.ClearPaneOwnerMarker(ctx, pane)
+	backend := multiplexer.OwnershipBackend(p.ownershipBackend)
+	if pane.Backend != multiplexer.BackendKindHerdr {
+		var err error
+		backend, err = multiplexer.OwnershipBackendForKind(pane.Backend)
+		if err != nil {
+			return err
+		}
+	}
+	return p.clearPaneOwnerMarkerWithBackend(ctx, backend, pane)
+}
+
+func (p *FinalPublication) setSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	previous, readErr := p.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+	if readErr != nil {
+		return readErr
+	}
+	if err := p.ownershipBackend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err != nil {
+		return err
+	}
+	p.rollbacks = append(p.rollbacks, func() {
+		rollbackCtx := context.Background()
+		if previous == "" {
+			_ = p.ownershipBackend.ClearSessionOwnerMarker(rollbackCtx, sessionName)
+			return
+		}
+		previousContext, previousPIDText, _ := strings.Cut(previous, ":")
+		previousPID := 0
+		if previousPIDText != "" {
+			_, _ = fmt.Sscanf(previousPIDText, "%d", &previousPID)
+		}
+		_ = p.ownershipBackend.SetSessionOwnerMarker(rollbackCtx, previousContext, sessionName, previousPID)
+	})
+	return nil
+}
+
+func (p *FinalPublication) clearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	previous, readErr := p.ownershipBackend.SessionOwnerMarker(ctx, sessionName)
+	if readErr != nil {
+		return readErr
+	}
+	if err := p.ownershipBackend.ClearSessionOwnerMarker(ctx, sessionName); err != nil {
+		return err
+	}
+	p.rollbacks = append(p.rollbacks, func() {
+		if previous == "" {
+			return
+		}
+		previousContext, previousPIDText, _ := strings.Cut(previous, ":")
+		previousPID := 0
+		if previousPIDText != "" {
+			_, _ = fmt.Sscanf(previousPIDText, "%d", &previousPID)
+		}
+		_ = p.ownershipBackend.SetSessionOwnerMarker(context.Background(), previousContext, sessionName, previousPID)
+	})
+	return nil
+}
+
+func (p *FinalPublication) setPaneOwnerMarkerWithBackend(ctx context.Context, backend multiplexer.OwnershipBackend, pane multiplexer.ResourceID, contextID string) error {
+	previous, readErr := backend.PaneOwnerMarker(ctx, pane)
+	if readErr != nil {
+		return readErr
+	}
+	if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err != nil {
+		return err
+	}
+	p.rollbacks = append(p.rollbacks, func() {
+		rollbackCtx := context.Background()
+		if previous == "" {
+			_ = backend.ClearPaneOwnerMarker(rollbackCtx, pane)
+			return
+		}
+		_ = backend.SetPaneOwnerMarker(rollbackCtx, pane, previous)
+	})
+	return nil
+}
+
+func (p *FinalPublication) clearPaneOwnerMarkerWithBackend(ctx context.Context, backend multiplexer.OwnershipBackend, pane multiplexer.ResourceID) error {
+	previous, readErr := backend.PaneOwnerMarker(ctx, pane)
+	if readErr != nil {
+		return readErr
+	}
+	if err := backend.ClearPaneOwnerMarker(ctx, pane); err != nil {
+		return err
+	}
+	p.rollbacks = append(p.rollbacks, func() {
+		if previous == "" {
+			return
+		}
+		_ = backend.SetPaneOwnerMarker(context.Background(), pane, previous)
+	})
+	return nil
+}
+
+func (p *FinalPublication) rollback() {
+	if p == nil || p.rolledBack {
+		return
+	}
+	p.rolledBack = true
+	for i := len(p.rollbacks) - 1; i >= 0; i-- {
+		p.rollbacks[i]()
+	}
 }
 
 func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
@@ -111,7 +216,7 @@ func New(cfg *config.Config, factory ClientFactory) (*Runtime, error) {
 	rt := &Runtime{
 		cfg:              cfg.Herdr,
 		client:           client,
-		ownershipBackend: newOwnershipMux(cfg.Herdr.SessionName),
+		ownershipBackend: newOwnershipMux(cfg.Herdr.SessionName, true),
 	}
 	rt.cleanups = append(rt.cleanups, multiplexer.RegisterOwnershipBackend(rt.ownershipBackend))
 	return rt, nil
@@ -290,7 +395,7 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 		}
 	}
 	workspaceBackend := rt.backendForWorkspace()
-	stagedOwnership := newOwnershipMux(rt.cfg.SessionName)
+	stagedOwnership := newOwnershipMux(rt.cfg.SessionName, false)
 	stagedOwnership.replaceSnapshot(paneBackends, workspaceBackend)
 
 	rt.mu.Lock()
@@ -298,18 +403,34 @@ func (rt *Runtime) ReconcileFinalNodesForTokenAndCommit(generation uint64, nodes
 	if rt.closed || (generation != 0 && rt.generation != generation) {
 		return fmt.Errorf("stale Herdr final reconcile token")
 	}
+	multiplexer.LockHerdrPublicationWrite()
+	var displacedCleanup func()
+	unlockPublication := true
+	defer func() {
+		if unlockPublication {
+			multiplexer.UnlockHerdrPublicationWrite()
+		}
+		if displacedCleanup != nil {
+			displacedCleanup()
+		}
+	}()
+	publication := &FinalPublication{ownershipBackend: stagedOwnership, runtime: rt}
 	if prepare != nil {
-		if err := prepare(&FinalPublication{ownershipBackend: stagedOwnership, runtime: rt}); err != nil {
+		if err := prepare(publication); err != nil {
+			publication.rollback()
 			return err
 		}
 	}
-	multiplexer.LockHerdrPublicationWrite()
-	defer multiplexer.UnlockHerdrPublicationWrite()
 	rt.ownershipBackend.replaceSnapshot(paneBackends, workspaceBackend)
-	rt.adapterCleanup = controlplane.ReplaceHerdrHandAdaptersForOwner(rt.handAdapterOwnerID(), handAdapters)
+	replacement := controlplane.ReplaceHerdrHandAdaptersForOwnerCollect(rt.handAdapterOwnerID(), handAdapters)
+	rt.adapterCleanup = replacement.Cleanup
 	if commit != nil {
 		commit()
 	}
+	multiplexer.AdvanceHerdrPublicationGenerationLocked()
+	displacedCleanup = replacement.DisplacedCleanup
+	multiplexer.UnlockHerdrPublicationWrite()
+	unlockPublication = false
 	return nil
 }
 
@@ -335,13 +456,18 @@ func (rt *Runtime) Close() {
 	}
 	rt.closed = true
 	rt.generation++
+	var adapterCleanup func()
 	multiplexer.LockHerdrPublicationWrite()
-	defer multiplexer.UnlockHerdrPublicationWrite()
 	if rt.adapterCleanup != nil {
-		rt.adapterCleanup()
+		adapterCleanup = rt.adapterCleanup
 		rt.adapterCleanup = nil
 	}
 	rt.ownershipBackend.clear()
+	multiplexer.AdvanceHerdrPublicationGenerationLocked()
+	multiplexer.UnlockHerdrPublicationWrite()
+	if adapterCleanup != nil {
+		adapterCleanup()
+	}
 	for i := len(rt.cleanups) - 1; i >= 0; i-- {
 		rt.cleanups[i]()
 	}
@@ -377,12 +503,17 @@ func (rt *Runtime) reconcilePaneBackends(generation uint64, livePanes map[string
 		return false
 	}
 	if livePanes == nil {
+		var adapterCleanup func()
 		multiplexer.LockHerdrPublicationWrite()
-		defer multiplexer.UnlockHerdrPublicationWrite()
 		rt.ownershipBackend.replaceSnapshot(nil, multiplexer.HerdrBackend{})
 		if rt.adapterCleanup != nil {
-			rt.adapterCleanup()
+			adapterCleanup = rt.adapterCleanup
 			rt.adapterCleanup = nil
+		}
+		multiplexer.AdvanceHerdrPublicationGenerationLocked()
+		multiplexer.UnlockHerdrPublicationWrite()
+		if adapterCleanup != nil {
+			adapterCleanup()
 		}
 	}
 	return true
@@ -408,13 +539,14 @@ type herdrOwnershipKey struct {
 
 type ownershipMux struct {
 	sessionName string
+	gateReads   bool
 	runtime     multiplexer.HerdrRuntimeIdentity
 	mu          sync.RWMutex
 	snapshot    ownershipSnapshot
 }
 
-func newOwnershipMux(sessionName string) *ownershipMux {
-	return &ownershipMux{sessionName: sessionName}
+func newOwnershipMux(sessionName string, gateReads bool) *ownershipMux {
+	return &ownershipMux{sessionName: sessionName, gateReads: gateReads}
 }
 
 func (m *ownershipMux) Kind() multiplexer.BackendKind {
@@ -469,8 +601,6 @@ func (m *ownershipMux) backendForSession(sessionName string) (multiplexer.HerdrB
 	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
 		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
 	}
-	multiplexer.LockHerdrPublicationRead()
-	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.snapshot.sessionBackend != nil {
@@ -483,8 +613,6 @@ func (m *ownershipMux) backendForSessionClear(sessionName string) (multiplexer.H
 	if strings.TrimSpace(sessionName) != strings.TrimSpace(m.sessionName) {
 		return multiplexer.HerdrBackend{}, multiplexer.ErrHerdrSessionNameMismatch
 	}
-	multiplexer.LockHerdrPublicationRead()
-	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.snapshot.clearBackend != nil {
@@ -497,8 +625,6 @@ func (m *ownershipMux) backendForPane(pane multiplexer.ResourceID) (multiplexer.
 	if pane.Backend != multiplexer.BackendKindHerdr {
 		return multiplexer.HerdrBackend{}, fmt.Errorf("herdr ownership requires herdr pane resource: %#v", pane)
 	}
-	multiplexer.LockHerdrPublicationRead()
-	defer multiplexer.UnlockHerdrPublicationRead()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	backend, ok := m.snapshot.byPane[herdrOwnershipKeyForResource(pane)]
@@ -556,6 +682,10 @@ func herdrOwnershipKeyForResource(pane multiplexer.ResourceID) herdrOwnershipKey
 }
 
 func (m *ownershipMux) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForSession(sessionName)
 	if err != nil {
 		return "", err
@@ -564,6 +694,10 @@ func (m *ownershipMux) SessionOwnerMarker(ctx context.Context, sessionName strin
 }
 
 func (m *ownershipMux) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForSession(sessionName)
 	if err != nil {
 		return err
@@ -572,6 +706,10 @@ func (m *ownershipMux) SetSessionOwnerMarker(ctx context.Context, contextID, ses
 }
 
 func (m *ownershipMux) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForSessionClear(sessionName)
 	if err != nil {
 		return err
@@ -580,6 +718,10 @@ func (m *ownershipMux) ClearSessionOwnerMarker(ctx context.Context, sessionName 
 }
 
 func (m *ownershipMux) PaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) (string, error) {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForPane(pane)
 	if err != nil {
 		return "", err
@@ -588,6 +730,10 @@ func (m *ownershipMux) PaneOwnerMarker(ctx context.Context, pane multiplexer.Res
 }
 
 func (m *ownershipMux) SetPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID, contextID string) error {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForPane(pane)
 	if err != nil {
 		return err
@@ -596,6 +742,10 @@ func (m *ownershipMux) SetPaneOwnerMarker(ctx context.Context, pane multiplexer.
 }
 
 func (m *ownershipMux) ClearPaneOwnerMarker(ctx context.Context, pane multiplexer.ResourceID) error {
+	if m.gateReads {
+		multiplexer.LockHerdrPublicationRead()
+		defer multiplexer.UnlockHerdrPublicationRead()
+	}
 	backend, err := m.backendForPane(pane)
 	if err != nil {
 		return err

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -220,6 +220,12 @@ func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
 	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
 		t.Fatalf("collisions = %#v, want duplicate Herdr collision", collisions)
 	}
+	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
+		t.Fatalf("SetSessionEnabledMarker() duplicate-only Herdr cold start error = %v", err)
+	}
+	if client.setWorkspaceMetadataWorkspace != "workspace-1" || client.setWorkspaceMetadataValue == "" {
+		t.Fatalf("set workspace metadata workspace=%q value=%q, want duplicate-only cold start session marker", client.setWorkspaceMetadataWorkspace, client.setWorkspaceMetadataValue)
+	}
 	for _, paneID := range []string{"workspace-1:pane-1", "workspace-1:pane-2"} {
 		target := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: paneID}}
 		if _, err := controlplane.DefaultHandAdapter(target); err == nil {
@@ -419,6 +425,8 @@ type fakeRuntimeHerdrClient struct {
 	setPaneMetadataKey   string
 	setPaneMetadataValue string
 
+	setWorkspaceMetadataWorkspace   string
+	setWorkspaceMetadataValue       string
 	clearWorkspaceMetadataWorkspace string
 	clearWorkspaceMetadataKey       string
 }
@@ -454,7 +462,9 @@ func (f *fakeRuntimeHerdrClient) SendPaneKey(_ context.Context, _ string, key st
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 
-func (f *fakeRuntimeHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+func (f *fakeRuntimeHerdrClient) SetWorkspaceMetadata(_ context.Context, workspaceID string, _ string, value string) (multiplexer.HerdrWriteResult, error) {
+	f.setWorkspaceMetadataWorkspace = workspaceID
+	f.setWorkspaceMetadataValue = value
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -1,0 +1,193 @@
+package herdrruntime_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
+	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
+	"github.com/i9wa4/tmux-a2a-postman/internal/message"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+)
+
+func TestRuntimeDiscoverRegistersProductionHerdrDeliveryAndOwnership(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	sessionDir := filepath.Join(baseDir, contextID, sessionName)
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.NotificationTemplate = "notice {node}"
+	cfg.Nodes = map[string]config.NodeConfig{"worker": {}}
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, collisions, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(collisions) != 0 {
+		t.Fatalf("Discover() collisions = %#v, want none", collisions)
+	}
+	nodeInfo, ok := nodes[sessionName+":worker"]
+	if !ok {
+		t.Fatalf("Discover() nodes = %#v, want work:worker", nodes)
+	}
+	if nodeInfo.Backend != string(multiplexer.BackendKindHerdr) || nodeInfo.Runtime != "codex" {
+		t.Fatalf("nodeInfo = %#v, want Herdr codex node", nodeInfo)
+	}
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err != nil {
+		t.Fatalf("SetPaneOwnerMarker() error = %v", err)
+	}
+	if client.setPaneMetadataPane != "workspace-1:pane-1" || client.setPaneMetadataValue != contextID {
+		t.Fatalf("pane owner mutation pane=%q value=%q, want production Herdr ownership claim", client.setPaneMetadataPane, client.setPaneMetadataValue)
+	}
+
+	result, err := message.DeliverSystemMessageDirectResult(
+		"20260414-120000-r1234-from-postman-to-worker.md",
+		nodeInfo,
+		"worker",
+		"postman",
+		contextID,
+		"body",
+		cfg,
+		nil,
+		map[string]discovery.NodeInfo{sessionName + ":worker": nodeInfo},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("DeliverSystemMessageDirectResult() error = %v", err)
+	}
+	if !result.Delivered {
+		t.Fatal("DeliverSystemMessageDirectResult() delivered = false, want true")
+	}
+	if client.writeTextCalls != 1 || client.writeTextPane != "workspace-1:pane-1" {
+		t.Fatalf("Herdr write calls = %d pane=%q, want bootstrap-registered delivery", client.writeTextCalls, client.writeTextPane)
+	}
+	if client.sendKeyCalls != 2 || client.sendKeyKey != multiplexer.HerdrKeySubmit {
+		t.Fatalf("Herdr submit calls = %d key=%q, want Codex default submit count", client.sendKeyCalls, client.sendKeyKey)
+	}
+}
+
+func validRuntimeHerdrConfig() config.HerdrConfig {
+	return config.HerdrConfig{
+		Enabled:                 true,
+		SocketPath:              "/tmp/herdr.sock",
+		SessionName:             "work",
+		WorkspaceID:             "workspace-1",
+		AllowedSocketPaths:      []string{"/tmp/herdr.sock"},
+		AllowedSessions:         []string{"work"},
+		AllowedWorkspaceIDs:     []string{"workspace-1"},
+		AllowedProtocolVersions: []string{"1"},
+		AllowedSchemaVersions:   []int{1},
+		ReadEnabled:             true,
+		WriteEnabled:            true,
+		InputSanitizerReady:     true,
+		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionAGPL),
+	}
+}
+
+func validRuntimeHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
+	return multiplexer.HerdrSessionSnapshot{
+		Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
+		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
+			ID:       "workspace-1",
+			Metadata: map[string]string{},
+		}},
+		Tabs: []multiplexer.HerdrTabSnapshot{{
+			ID:          "workspace-1:tab-1",
+			WorkspaceID: "workspace-1",
+			Metadata:    map[string]string{},
+		}},
+		Panes: []multiplexer.HerdrPaneSnapshot{{
+			ID:             "workspace-1:pane-1",
+			WorkspaceID:    "workspace-1",
+			TabID:          "workspace-1:tab-1",
+			Metadata:       map[string]string{"postman.node": "worker"},
+			Env:            map[string]string{},
+			ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+			PostmanNode:    "worker",
+			PostmanSession: "work",
+		}},
+	}
+}
+
+type fakeRuntimeHerdrClient struct {
+	snapshot multiplexer.HerdrSessionSnapshot
+
+	writeTextCalls int
+	writeTextPane  string
+	sendKeyCalls   int
+	sendKeyKey     string
+
+	setPaneMetadataPane  string
+	setPaneMetadataKey   string
+	setPaneMetadataValue string
+}
+
+func (f *fakeRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeRuntimeHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{
+		Envelope:    multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
+		ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+	}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) WritePaneText(_ context.Context, paneID string, _ string) (multiplexer.HerdrWriteResult, error) {
+	f.writeTextCalls++
+	f.writeTextPane = paneID
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) SendPaneKey(_ context.Context, _ string, key string) (multiplexer.HerdrWriteResult, error) {
+	f.sendKeyCalls++
+	f.sendKeyKey = key
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) SetPaneMetadata(_ context.Context, paneID string, key string, value string) (multiplexer.HerdrWriteResult, error) {
+	f.setPaneMetadataPane = paneID
+	f.setPaneMetadataKey = key
+	f.setPaneMetadataValue = value
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
@@ -138,6 +139,126 @@ func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr pane ownership backend remained routable")
+	}
+}
+
+func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(initial) error = %v", err)
+	}
+	next := validRuntimeHerdrSnapshot()
+	next.Panes = nil
+	client.snapshot = next
+	if nodes, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(empty) error = %v", err)
+	} else if len(nodes) != 0 {
+		t.Fatalf("Discover(empty) nodes = %#v, want none", nodes)
+	}
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
+		t.Fatalf("ClearSessionOwnerMarker() after zero-pane rediscovery error = %v", err)
+	}
+	if client.clearWorkspaceMetadataWorkspace != "workspace-1" || client.clearWorkspaceMetadataKey == "" {
+		t.Fatalf("clear workspace metadata workspace=%q key=%q, want retained session ownership backend", client.clearWorkspaceMetadataWorkspace, client.clearWorkspaceMetadataKey)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("stale Herdr pane ownership backend remained routable after zero-pane rediscovery")
+	}
+}
+
+func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	client.snapshot.Panes = append(client.snapshot.Panes, multiplexer.HerdrPaneSnapshot{
+		ID:          "workspace-1:pane-2",
+		WorkspaceID: "workspace-1",
+		TabID:       "workspace-1:tab-1",
+		PostmanNode: "worker",
+		ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+	})
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, collisions, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if _, ok := nodes[sessionName+":worker"]; ok {
+		t.Fatalf("duplicate Herdr claim registered in nodes: %#v", nodes)
+	}
+	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
+		t.Fatalf("collisions = %#v, want duplicate Herdr collision", collisions)
+	}
+	for _, paneID := range []string{"workspace-1:pane-1", "workspace-1:pane-2"} {
+		target := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: paneID}}
+		if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+			t.Fatalf("duplicate Herdr pane %q remained registered", paneID)
+		}
+	}
+}
+
+func TestSocketClientHonorsContextDeadlineAfterConnect(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen(unix) error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(2 * time.Second)
+	}()
+	client, err := herdrruntime.NewSocketClient(config.HerdrConfig{SocketPath: socketPath})
+	if err != nil {
+		t.Fatalf("NewSocketClient() error = %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = client.Ping(ctx)
+	if err == nil {
+		t.Fatal("Ping() error = nil, want context deadline error")
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("Ping() took %v, want bounded by context deadline", time.Since(started))
 	}
 }
 
@@ -297,6 +418,9 @@ type fakeRuntimeHerdrClient struct {
 	setPaneMetadataPane  string
 	setPaneMetadataKey   string
 	setPaneMetadataValue string
+
+	clearWorkspaceMetadataWorkspace string
+	clearWorkspaceMetadataKey       string
 }
 
 func (f *fakeRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
@@ -334,7 +458,9 @@ func (f *fakeRuntimeHerdrClient) SetWorkspaceMetadata(context.Context, string, s
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 
-func (f *fakeRuntimeHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+func (f *fakeRuntimeHerdrClient) ClearWorkspaceMetadata(_ context.Context, workspaceID string, key string) (multiplexer.HerdrWriteResult, error) {
+	f.clearWorkspaceMetadataWorkspace = workspaceID
+	f.clearWorkspaceMetadataKey = key
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -249,7 +249,9 @@ func TestSocketClientHonorsContextDeadlineAfterConnect(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() {
+			_ = conn.Close()
+		}()
 		time.Sleep(2 * time.Second)
 	}()
 	client, err := herdrruntime.NewSocketClient(config.HerdrConfig{SocketPath: socketPath})

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -235,7 +235,7 @@ func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
 }
 
 func TestSocketClientHonorsContextDeadlineAfterConnect(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
+	socketPath := tempHerdrSocketPath(t)
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("Listen(unix) error = %v", err)
@@ -271,7 +271,7 @@ func TestSocketClientHonorsContextDeadlineAfterConnect(t *testing.T) {
 }
 
 func TestSocketClientRoundTripsSnapshotAndWriteMutations(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
+	socketPath := tempHerdrSocketPath(t)
 	methods := serveFakeHerdrSocket(t, socketPath)
 
 	client, err := herdrruntime.NewSocketClient(config.HerdrConfig{SocketPath: socketPath})
@@ -311,6 +311,18 @@ func TestSocketClientRoundTripsSnapshotAndWriteMutations(t *testing.T) {
 			t.Fatalf("method[%d] = %q, want %q (all=%#v)", i, gotMethods[i], wantMethods[i], gotMethods)
 		}
 	}
+}
+
+func tempHerdrSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "herdr-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(/tmp) error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return filepath.Join(dir, "h.sock")
 }
 
 func validRuntimeHerdrConfig() config.HerdrConfig {

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -1,11 +1,17 @@
 package herdrruntime_test
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/controlplane"
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/herdrruntime"
 	"github.com/i9wa4/tmux-a2a-postman/internal/message"
@@ -86,6 +92,98 @@ func TestRuntimeDiscoverRegistersProductionHerdrDeliveryAndOwnership(t *testing.
 	}
 }
 
+func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(initial) error = %v", err)
+	}
+	staleTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
+	if _, err := controlplane.DefaultHandAdapter(staleTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
+	}
+
+	next := validRuntimeHerdrSnapshot()
+	next.Panes[0].ID = "workspace-1:pane-2"
+	client.snapshot = next
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(second) error = %v", err)
+	}
+	if _, err := controlplane.DefaultHandAdapter(staleTarget); err == nil {
+		t.Fatal("stale Herdr pane adapter remained registered after rediscovery")
+	}
+	freshTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-2"}}
+	if _, err := controlplane.DefaultHandAdapter(freshTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(fresh) error = %v", err)
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("stale Herdr pane ownership backend remained routable")
+	}
+}
+
+func TestSocketClientRoundTripsSnapshotAndWriteMutations(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
+	methods := serveFakeHerdrSocket(t, socketPath)
+
+	client, err := herdrruntime.NewSocketClient(config.HerdrConfig{SocketPath: socketPath})
+	if err != nil {
+		t.Fatalf("NewSocketClient() error = %v", err)
+	}
+	writeClient, ok := client.(multiplexer.HerdrWriteClient)
+	if !ok {
+		t.Fatalf("NewSocketClient() does not implement HerdrWriteClient")
+	}
+
+	snapshot, err := client.SessionSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("SessionSnapshot() error = %v", err)
+	}
+	if snapshot.Envelope.ProtocolVersion != "1" || snapshot.Envelope.SchemaVersion != 1 {
+		t.Fatalf("snapshot envelope = %#v, want protocol/schema 1", snapshot.Envelope)
+	}
+	if len(snapshot.Panes) != 1 || snapshot.Panes[0].WorkspaceID != "workspace-1" || snapshot.Panes[0].TabID != "workspace-1:tab-1" {
+		t.Fatalf("snapshot panes = %#v, want snake_case IDs decoded", snapshot.Panes)
+	}
+	if got := snapshot.Panes[0].ProcessInfo.CurrentCommand(); got != "codex" {
+		t.Fatalf("CurrentCommand() = %q, want codex", got)
+	}
+
+	if _, err := writeClient.WritePaneText(context.Background(), "workspace-1:pane-1", "body"); err != nil {
+		t.Fatalf("WritePaneText() error = %v", err)
+	}
+	if _, err := writeClient.SetWorkspaceMetadata(context.Background(), "workspace-1", "postman.session_owner.work", "ctx:123"); err != nil {
+		t.Fatalf("SetWorkspaceMetadata() error = %v", err)
+	}
+
+	gotMethods := []string{<-methods, <-methods, <-methods}
+	wantMethods := []string{"session.snapshot", "pane.send_text", "workspace.report_metadata"}
+	for i := range wantMethods {
+		if gotMethods[i] != wantMethods[i] {
+			t.Fatalf("method[%d] = %q, want %q (all=%#v)", i, gotMethods[i], wantMethods[i], gotMethods)
+		}
+	}
+}
+
 func validRuntimeHerdrConfig() config.HerdrConfig {
 	return config.HerdrConfig{
 		Enabled:                 true,
@@ -127,6 +225,65 @@ func validRuntimeHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
 			PostmanSession: "work",
 		}},
 	}
+}
+
+func serveFakeHerdrSocket(t *testing.T, socketPath string) <-chan string {
+	t.Helper()
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen(unix): %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+	methods := make(chan string, 8)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				continue
+			}
+			go handleFakeHerdrSocketConn(conn, methods)
+		}
+	}()
+	return methods
+}
+
+func handleFakeHerdrSocketConn(conn net.Conn, methods chan<- string) {
+	defer func() { _ = conn.Close() }()
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil {
+		return
+	}
+	var request struct {
+		ID     int64           `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(line, &request); err != nil {
+		return
+	}
+	methods <- request.Method
+	result := map[string]interface{}{"protocol_version": "1", "schema_version": 1}
+	if request.Method == "session.snapshot" {
+		result["workspaces"] = []map[string]interface{}{{"id": "workspace-1", "metadata": map[string]string{}}}
+		result["tabs"] = []map[string]interface{}{{"id": "workspace-1:tab-1", "workspace_id": "workspace-1"}}
+		result["panes"] = []map[string]interface{}{{
+			"id":           "workspace-1:pane-1",
+			"workspace_id": "workspace-1",
+			"tab_id":       "workspace-1:tab-1",
+			"metadata":     map[string]string{"postman.node": "worker"},
+			"process_info": map[string]interface{}{"foreground_processes": []map[string]string{{"name": "codex"}}},
+		}}
+	}
+	response := map[string]interface{}{"jsonrpc": "2.0", "id": request.ID, "result": result}
+	payload, _ := json.Marshal(response)
+	payload = append(payload, '\n')
+	_, _ = conn.Write(payload)
 }
 
 type fakeRuntimeHerdrClient struct {

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -409,6 +409,16 @@ func TestRuntimeReconcileFinalNodesIgnoresOlderSuccessfulDiscoveryAfterNewerSucc
 	}
 
 	oldSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-old", "workspace-1:pane-old", "")
+	oldSnapshot.Panes = append(oldSnapshot.Panes, multiplexer.HerdrPaneSnapshot{
+		ID:             "workspace-1:pane-old-2",
+		WorkspaceID:    "workspace-1",
+		TabID:          "workspace-1:tab-old",
+		Metadata:       map[string]string{"postman.node": "worker-2"},
+		Env:            map[string]string{},
+		ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+		PostmanNode:    "worker-2",
+		PostmanSession: "work",
+	})
 	newSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-new", "workspace-1:pane-new", "")
 	oldCall := newControlledRuntimeSnapshot(oldSnapshot, nil)
 	newCall := newControlledRuntimeSnapshot(newSnapshot, nil)
@@ -447,7 +457,9 @@ func TestRuntimeReconcileFinalNodesIgnoresOlderSuccessfulDiscoveryAfterNewerSucc
 	if len(newer.collisions) != 0 {
 		t.Fatalf("newer collisions = %#v, want none", newer.collisions)
 	}
-	rt.ReconcileFinalNodesForToken(newer.token, newer.nodes)
+	if !rt.ReconcileFinalNodesForToken(newer.token, newer.nodes) {
+		t.Fatal("newer ReconcileFinalNodesForToken() accepted = false, want true")
+	}
 
 	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
 	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
@@ -459,14 +471,92 @@ func TestRuntimeReconcileFinalNodesIgnoresOlderSuccessfulDiscoveryAfterNewerSucc
 	if older.err != nil {
 		t.Fatalf("older DiscoverForReconcile() error = %v", older.err)
 	}
-	rt.ReconcileFinalNodesForToken(older.token, older.nodes)
+	if rt.ReconcileFinalNodesForToken(older.token, older.nodes) {
+		t.Fatal("older ReconcileFinalNodesForToken() accepted = true, want stale rejection")
+	}
 
-	oldTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-old"}}
-	if _, err := controlplane.DefaultHandAdapter(oldTarget); err == nil {
-		t.Fatal("older successful discovery registered stale Herdr adapter")
+	for _, paneID := range []string{"workspace-1:pane-old", "workspace-1:pane-old-2"} {
+		oldTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: paneID}}
+		if _, err := controlplane.DefaultHandAdapter(oldTarget); err == nil {
+			t.Fatalf("older successful discovery registered stale Herdr adapter for %s", paneID)
+		}
 	}
 	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
 		t.Fatalf("newer Herdr adapter was removed by stale older reconcile: %v", err)
+	}
+}
+
+func TestRuntimeStaleZeroPaneReconcileDoesNotPruneNewerRoutesOrWorkspaceOwner(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	oldSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-old", "workspace-1:pane-old", "")
+	oldSnapshot.Panes = nil
+	newSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-new", "workspace-1:pane-new", "ctx-new:1")
+	oldCall := newControlledRuntimeSnapshot(oldSnapshot, nil)
+	newCall := newControlledRuntimeSnapshot(newSnapshot, nil)
+	client := &sequencedRuntimeHerdrClient{calls: make(chan *controlledRuntimeSnapshot, 2)}
+	client.calls <- oldCall
+	client.calls <- newCall
+
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		oldResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-oldCall.started
+
+	newResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		newResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-newCall.started
+	close(newCall.release)
+	newer := <-newResult
+	if newer.err != nil {
+		t.Fatalf("newer DiscoverForReconcile() error = %v", newer.err)
+	}
+	if !rt.ReconcileFinalNodesForToken(newer.token, newer.nodes) {
+		t.Fatal("newer ReconcileFinalNodesForToken() accepted = false, want true")
+	}
+
+	close(oldCall.release)
+	older := <-oldResult
+	if older.err != nil {
+		t.Fatalf("older DiscoverForReconcile() error = %v", older.err)
+	}
+	if rt.ReconcileFinalNodesForToken(older.token, older.nodes) {
+		t.Fatal("older zero-pane ReconcileFinalNodesForToken() accepted = true, want stale rejection")
+	}
+
+	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("newer Herdr adapter was removed by stale zero-pane reconcile: %v", err)
+	}
+	verifyCall := newControlledRuntimeSnapshot(newSnapshot, nil)
+	client.calls <- verifyCall
+	close(verifyCall.release)
+	owner, err := rt.OwnershipBackend().SessionOwnerMarker(context.Background(), "work")
+	if err != nil {
+		t.Fatalf("SessionOwnerMarker(work) error = %v", err)
+	}
+	if owner != "ctx-new:1" {
+		t.Fatalf("SessionOwnerMarker(work) = %q, want newer owner", owner)
 	}
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -722,6 +722,150 @@ func TestRuntimeFinalReconcilePublishesBeforeCompetingDiscoveryCanAdvance(t *tes
 	close(releaseCompeting)
 }
 
+func TestRuntimeFinalReconcileFailureKeepsPriorGenerationAuthoritative(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldNodes, _, oldToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile(old) error = %v", err)
+	}
+	if err := rt.ReconcileFinalNodesForTokenAndCommit(oldToken, oldNodes, nil, nil); err != nil {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit(old) error = %v", err)
+	}
+	oldNode := oldNodes[sessionName+":worker"]
+	oldTarget := controlplane.TargetForNode(sessionName+":worker", oldNode)
+	if _, err := controlplane.DefaultHandAdapter(oldTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(old) error = %v", err)
+	}
+
+	next := validRuntimeHerdrSnapshot()
+	next.Panes[0].ID = "workspace-1:pane-2"
+	client.snapshot = next
+	newNodes, _, newToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile(new) error = %v", err)
+	}
+	newNode := newNodes[sessionName+":worker"]
+	newTarget := controlplane.TargetForNode(sessionName+":worker", newNode)
+	publishErr := errors.New("publish failed")
+	err = rt.ReconcileFinalNodesForTokenAndCommit(newToken, newNodes, func(*herdrruntime.FinalPublication) error {
+		if _, adapterErr := controlplane.DefaultHandAdapter(oldTarget); adapterErr != nil {
+			t.Fatalf("old adapter disappeared during failed prepare: %v", adapterErr)
+		}
+		if _, adapterErr := controlplane.DefaultHandAdapter(newTarget); adapterErr == nil {
+			t.Fatal("new adapter became visible before failed publication committed")
+		}
+		return publishErr
+	}, func() {
+		t.Fatal("commit callback ran after prepare failure")
+	})
+	if !errors.Is(err, publishErr) {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit(new) error = %v, want %v", err, publishErr)
+	}
+	if _, err := controlplane.DefaultHandAdapter(oldTarget); err != nil {
+		t.Fatalf("old adapter after failed publication error = %v", err)
+	}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err == nil {
+		t.Fatal("new adapter escaped after failed publication")
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(newNode.PaneID), contextID); err == nil {
+		t.Fatal("new ownership route escaped after failed publication")
+	}
+	client.snapshot = validRuntimeHerdrSnapshot()
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(oldNode.PaneID), contextID); err != nil {
+		t.Fatalf("old ownership route after failed publication error = %v", err)
+	}
+}
+
+func TestRuntimeFinalReconcileBlocksExternalReadersDuringPublicCommit(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldNodes, _, oldToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile(old) error = %v", err)
+	}
+	if err := rt.ReconcileFinalNodesForTokenAndCommit(oldToken, oldNodes, nil, nil); err != nil {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit(old) error = %v", err)
+	}
+
+	next := validRuntimeHerdrSnapshot()
+	next.Panes[0].ID = "workspace-1:pane-2"
+	client.snapshot = next
+	newNodes, _, newToken, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile(new) error = %v", err)
+	}
+	newNode := newNodes[sessionName+":worker"]
+	newTarget := controlplane.TargetForNode(sessionName+":worker", newNode)
+	readerDone := make(chan error, 1)
+	err = rt.ReconcileFinalNodesForTokenAndCommit(newToken, newNodes, nil, func() {
+		go func() {
+			if _, adapterErr := controlplane.DefaultHandAdapter(newTarget); adapterErr != nil {
+				readerDone <- adapterErr
+				return
+			}
+			ownershipBackend, backendErr := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+			if backendErr != nil {
+				readerDone <- backendErr
+				return
+			}
+			readerDone <- ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(newNode.PaneID), contextID)
+		}()
+		select {
+		case err := <-readerDone:
+			t.Fatalf("external Herdr reader completed inside public commit with %v; want blocked until generation commit releases", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+	})
+	if err != nil {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit(new) error = %v", err)
+	}
+	select {
+	case err := <-readerDone:
+		if err != nil {
+			t.Fatalf("external Herdr reader after commit error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("external Herdr reader remained blocked after public commit")
+	}
+}
+
 func TestRuntimeCloseWhileDiscoverBlockedDoesNotRegisterRoutes(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -327,19 +327,24 @@ func tempHerdrSocketPath(t *testing.T) string {
 
 func validRuntimeHerdrConfig() config.HerdrConfig {
 	return config.HerdrConfig{
-		Enabled:                 true,
-		SocketPath:              "/tmp/herdr.sock",
-		SessionName:             "work",
-		WorkspaceID:             "workspace-1",
-		AllowedSocketPaths:      []string{"/tmp/herdr.sock"},
-		AllowedSessions:         []string{"work"},
-		AllowedWorkspaceIDs:     []string{"workspace-1"},
-		AllowedProtocolVersions: []string{"1"},
-		AllowedSchemaVersions:   []int{1},
-		ReadEnabled:             true,
-		WriteEnabled:            true,
-		InputSanitizerReady:     true,
-		ComplianceDecision:      string(multiplexer.HerdrComplianceDecisionAGPL),
+		Enabled:                     true,
+		SocketPath:                  "/tmp/herdr.sock",
+		SessionName:                 "work",
+		WorkspaceID:                 "workspace-1",
+		AllowedSocketPaths:          []string{"/tmp/herdr.sock"},
+		AllowedSessions:             []string{"work"},
+		AllowedWorkspaceIDs:         []string{"workspace-1"},
+		AllowedProtocolVersions:     []string{"1"},
+		AllowedSchemaVersions:       []int{1},
+		ReadEnabled:                 true,
+		WriteEnabled:                true,
+		InputSanitizerReady:         true,
+		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionAGPL),
+		ComplianceAuthorizedBy:      "test-authority",
+		ComplianceDecisionID:        "test-decision",
+		ComplianceDecidedAt:         "2026-08-12T00:00:00Z",
+		ComplianceRevalidatedAt:     "2026-08-12T00:00:00Z",
+		ComplianceCurrentReferences: []string{"https://github.com/ogulcancelik/herdr/blob/master/LICENSE"},
 	}
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -142,6 +142,96 @@ func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	}
 }
 
+func TestRuntimeReconcileFinalNodesPrunesCrossBackendCollisionLoser(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(initial) error = %v", err)
+	}
+	loserTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
+	if _, err := controlplane.DefaultHandAdapter(loserTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
+	}
+
+	rt.ReconcileFinalNodes(map[string]discovery.NodeInfo{
+		sessionName + ":worker": {
+			PaneID:      "%tmux-winner",
+			SessionName: sessionName,
+			Backend:     string(multiplexer.BackendKindTmux),
+		},
+	})
+
+	if _, err := controlplane.DefaultHandAdapter(loserTarget); err == nil {
+		t.Fatal("cross-backend collision loser Herdr adapter remained registered")
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("cross-backend collision loser Herdr ownership route remained available")
+	}
+}
+
+func TestRuntimeDiscoverErrorClearsStalePaneRegistrations(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(initial) error = %v", err)
+	}
+	staleTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
+	if _, err := controlplane.DefaultHandAdapter(staleTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
+	}
+
+	client.snapshotErr = errors.New("socket snapshot failed")
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err == nil {
+		t.Fatal("Discover(error) error = nil, want discovery failure")
+	}
+	if _, err := controlplane.DefaultHandAdapter(staleTarget); err == nil {
+		t.Fatal("stale Herdr adapter remained registered after discovery error")
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("stale Herdr pane ownership route remained available after discovery error")
+	}
+}
+
 func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
@@ -433,7 +523,8 @@ func handleFakeHerdrSocketConn(conn net.Conn, methods chan<- string) {
 }
 
 type fakeRuntimeHerdrClient struct {
-	snapshot multiplexer.HerdrSessionSnapshot
+	snapshot    multiplexer.HerdrSessionSnapshot
+	snapshotErr error
 
 	writeTextCalls int
 	writeTextPane  string
@@ -455,6 +546,9 @@ func (f *fakeRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrRespons
 }
 
 func (f *fakeRuntimeHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	if f.snapshotErr != nil {
+		return multiplexer.HerdrSessionSnapshot{}, f.snapshotErr
+	}
 	return f.snapshot, nil
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -390,6 +390,11 @@ func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
 func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
+	for _, sessionName := range []string{"work", "other"} {
+		if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+			t.Fatalf("CreateSessionDirs(%q) error = %v", sessionName, err)
+		}
+	}
 
 	workClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-1", "workspace-1:pane-1", "ctx-work:1")}
 	workCfg := config.DefaultConfig()
@@ -415,8 +420,13 @@ func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 	if _, _, err := workRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
 		t.Fatalf("Discover(work) error = %v", err)
 	}
-	if _, _, err := otherRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+	otherNodes, _, err := otherRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(other) error = %v", err)
+	}
+	otherNode := otherNodes["other:worker"]
+	if otherNode.PaneID == "" {
+		t.Fatalf("Discover(other) nodes = %#v, want other:worker", otherNodes)
 	}
 
 	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
@@ -431,9 +441,30 @@ func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 	}
 
 	otherRuntime.Close()
+	otherTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-2:pane-1"}}
+	if _, err := controlplane.DefaultHandAdapter(otherTarget); err == nil {
+		t.Fatal("closed Herdr runtime pane adapter remained registered")
+	}
+	if result, err := message.DeliverSystemMessageDirectResult(
+		"20260414-120000-r5678-from-postman-to-worker.md",
+		otherNode,
+		"worker",
+		"postman",
+		contextID,
+		"body",
+		otherCfg,
+		nil,
+		map[string]discovery.NodeInfo{"other:worker": otherNode},
+		nil,
+	); err == nil || result.Delivered {
+		t.Fatalf("DeliverSystemMessageDirectResult(closed other) = %#v, %v; want closed runtime delivery unavailable", result, err)
+	}
 	ownershipBackend, err = multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
 	if err != nil {
 		t.Fatalf("OwnershipBackendForKind(herdr after other close) error = %v", err)
+	}
+	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), "other"); err == nil {
+		t.Fatal("closed Herdr runtime session owner route remained available")
 	}
 	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "ctx-work:1" {
 		t.Fatalf("SessionOwnerMarker(work after other close) = %q, %v; want ctx-work:1", got, err)
@@ -536,6 +567,8 @@ func validRuntimeHerdrConfig() config.HerdrConfig {
 }
 
 func runtimeHerdrConfigFor(sessionName, workspaceID string) config.HerdrConfig {
+	revalidatedAt := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	decidedAt := revalidatedAt.Add(-time.Hour)
 	return config.HerdrConfig{
 		Enabled:                     true,
 		SocketPath:                  "/tmp/herdr.sock",
@@ -552,8 +585,8 @@ func runtimeHerdrConfigFor(sessionName, workspaceID string) config.HerdrConfig {
 		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionRecorded),
 		ComplianceAuthorizedBy:      "test-authority",
 		ComplianceDecisionID:        "test-decision",
-		ComplianceDecidedAt:         "2026-08-12T00:00:00Z",
-		ComplianceRevalidatedAt:     "2026-08-12T00:00:00Z",
+		ComplianceDecidedAt:         decidedAt.Format(time.RFC3339),
+		ComplianceRevalidatedAt:     revalidatedAt.Format(time.RFC3339),
 		ComplianceCurrentReferences: []string{"https://github.com/ogulcancelik/herdr/blob/master/LICENSE"},
 	}
 }

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -199,6 +199,88 @@ func TestRuntimeReconcileKeepsSamePaneIDInDifferentTabsRoutable(t *testing.T) {
 	}
 }
 
+func TestRuntimeReconcileKeepsIndependentTabRuntimeAdaptersIsolated(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	paneID := "workspace-1:pane-shared"
+	tabOne := "workspace-1:tab-1"
+	tabTwo := "workspace-1:tab-2"
+	firstClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor(sessionName, "workspace-1", tabOne, paneID, "")}
+	firstCfg := config.DefaultConfig()
+	firstCfg.Herdr = validRuntimeHerdrConfig()
+	firstRuntime, err := herdrruntime.New(firstCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return firstClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(first) error = %v", err)
+	}
+	t.Cleanup(firstRuntime.Close)
+
+	secondClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor(sessionName, "workspace-1", tabTwo, paneID, "")}
+	secondCfg := config.DefaultConfig()
+	secondCfg.Herdr = validRuntimeHerdrConfig()
+	secondRuntime, err := herdrruntime.New(secondCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return secondClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(second) error = %v", err)
+	}
+	t.Cleanup(secondRuntime.Close)
+
+	firstNodes, _, err := firstRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover(first) error = %v", err)
+	}
+	firstRuntime.ReconcileFinalNodes(firstNodes)
+	firstTarget := controlplane.TargetForNode(sessionName+":worker", firstNodes[sessionName+":worker"])
+	firstAdapter, err := controlplane.DefaultHandAdapter(firstTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(first after first reconcile) error = %v", err)
+	}
+	if err := firstAdapter.Deliver(firstTarget, controlplane.PaneDelivery{Content: "first-before"}); err != nil {
+		t.Fatalf("Deliver(first before second reconcile) error = %v", err)
+	}
+
+	secondNodes, _, err := secondRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover(second) error = %v", err)
+	}
+	secondRuntime.ReconcileFinalNodes(secondNodes)
+	secondTarget := controlplane.TargetForNode(sessionName+":worker", secondNodes[sessionName+":worker"])
+	secondAdapter, err := controlplane.DefaultHandAdapter(secondTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(second after second reconcile) error = %v", err)
+	}
+	if err := secondAdapter.Deliver(secondTarget, controlplane.PaneDelivery{Content: "second"}); err != nil {
+		t.Fatalf("Deliver(second) error = %v", err)
+	}
+	firstAdapter, err = controlplane.DefaultHandAdapter(firstTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(first after second reconcile) error = %v", err)
+	}
+	if err := firstAdapter.Deliver(firstTarget, controlplane.PaneDelivery{Content: "first-after"}); err != nil {
+		t.Fatalf("Deliver(first after second reconcile) error = %v", err)
+	}
+
+	firstRuntime.ReconcileFinalNodes(firstNodes)
+	if _, err := controlplane.DefaultHandAdapter(secondTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(second after first refresh) error = %v", err)
+	}
+
+	secondRuntime.Close()
+	if _, err := controlplane.DefaultHandAdapter(secondTarget); err == nil {
+		t.Fatal("closed second tab runtime adapter remained registered")
+	}
+	if _, err := controlplane.DefaultHandAdapter(firstTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(first after second close) error = %v", err)
+	}
+}
+
 func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -1539,6 +1539,67 @@ func TestRuntimeHerdrOwnershipCompositeResolvesReducedUniquePaneIdentity(t *test
 	}
 }
 
+func TestRuntimeHerdrOwnershipSingleRuntimeResolvesReducedPaneIdentity(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs(%q) error = %v", sessionName, err)
+	}
+
+	const (
+		paneID      = "workspace-1:pane-single"
+		socketPath  = "/tmp/herdr-reduced-single.sock"
+		workspaceID = "workspace-1"
+		tabID       = "workspace-1:tab-1"
+	)
+	snapshot := runtimeHerdrSnapshotFor(sessionName, workspaceID, tabID, paneID, "")
+	snapshot.Panes[0].Metadata[multiplexer.HerdrPaneContextIDMetadataKey] = "ctx-pane-old"
+	client := &fakeRuntimeHerdrClient{snapshot: snapshot}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = runtimeHerdrConfigFor(sessionName, workspaceID)
+	cfg.Herdr.SocketPath = socketPath
+	cfg.Herdr.AllowedSocketPaths = []string{socketPath}
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	rt.ReconcileFinalNodes(nodes)
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	reducedPane := multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+		SocketPath:  socketPath,
+		SessionName: sessionName,
+		WorkspaceID: workspaceID,
+		PaneID:      paneID,
+	}, paneID)
+	if got, err := ownershipBackend.PaneOwnerMarker(context.Background(), reducedPane); err != nil || got != "ctx-pane-old" {
+		t.Fatalf("PaneOwnerMarker(reduced single runtime) = %q, %v; want ctx-pane-old", got, err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), reducedPane, "ctx-pane-new"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(reduced single runtime) error = %v", err)
+	}
+	if client.setPaneMetadataPane != paneID || client.setPaneMetadataValue != "ctx-pane-new" {
+		t.Fatalf("SetPaneMetadata pane/value = %q/%q, want %q/ctx-pane-new", client.setPaneMetadataPane, client.setPaneMetadataValue, paneID)
+	}
+	if err := ownershipBackend.ClearPaneOwnerMarker(context.Background(), reducedPane); err != nil {
+		t.Fatalf("ClearPaneOwnerMarker(reduced single runtime) error = %v", err)
+	}
+	if client.clearPaneMetadataPane != paneID || client.clearPaneMetadataKey != multiplexer.HerdrPaneContextIDMetadataKey {
+		t.Fatalf("ClearPaneMetadata pane/key = %q/%q, want %q/%q", client.clearPaneMetadataPane, client.clearPaneMetadataKey, paneID, multiplexer.HerdrPaneContextIDMetadataKey)
+	}
+}
+
 func TestRuntimeHerdrOwnershipQualifiedPaneMissesFailClosed(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -764,12 +765,23 @@ func TestRuntimeFinalReconcileFailureKeepsPriorGenerationAuthoritative(t *testin
 	newNode := newNodes[sessionName+":worker"]
 	newTarget := controlplane.TargetForNode(sessionName+":worker", newNode)
 	publishErr := errors.New("publish failed")
+	readerStarted := make(chan struct{})
+	readerDone := make(chan error, 1)
 	err = rt.ReconcileFinalNodesForTokenAndCommit(newToken, newNodes, func(*herdrruntime.FinalPublication) error {
-		if _, adapterErr := controlplane.DefaultHandAdapter(oldTarget); adapterErr != nil {
-			t.Fatalf("old adapter disappeared during failed prepare: %v", adapterErr)
-		}
-		if _, adapterErr := controlplane.DefaultHandAdapter(newTarget); adapterErr == nil {
-			t.Fatal("new adapter became visible before failed publication committed")
+		go func() {
+			close(readerStarted)
+			_, adapterErr := controlplane.DefaultHandAdapter(oldTarget)
+			if adapterErr != nil {
+				readerDone <- fmt.Errorf("old adapter lookup during failed prepare: %w", adapterErr)
+				return
+			}
+			readerDone <- nil
+		}()
+		<-readerStarted
+		select {
+		case err := <-readerDone:
+			t.Fatalf("reader completed during failed prepare with %v; want blocked until publication gate releases", err)
+		case <-time.After(20 * time.Millisecond):
 		}
 		return publishErr
 	}, func() {
@@ -778,8 +790,24 @@ func TestRuntimeFinalReconcileFailureKeepsPriorGenerationAuthoritative(t *testin
 	if !errors.Is(err, publishErr) {
 		t.Fatalf("ReconcileFinalNodesForTokenAndCommit(new) error = %v, want %v", err, publishErr)
 	}
+	select {
+	case err := <-readerDone:
+		if err != nil {
+			t.Fatalf("old reader after failed prepare error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old reader remained blocked after failed prepare rollback")
+	}
 	if _, err := controlplane.DefaultHandAdapter(oldTarget); err != nil {
 		t.Fatalf("old adapter after failed publication error = %v", err)
+	}
+	client.snapshot = validRuntimeHerdrSnapshot()
+	oldAdapter, err := controlplane.DefaultHandAdapter(oldTarget)
+	if err != nil {
+		t.Fatalf("old adapter after failed publication lookup error = %v", err)
+	}
+	if err := oldAdapter.Deliver(oldTarget, controlplane.PaneDelivery{Content: "old generation"}); err != nil {
+		t.Fatalf("old adapter after failed publication delivery error = %v", err)
 	}
 	if _, err := controlplane.DefaultHandAdapter(newTarget); err == nil {
 		t.Fatal("new adapter escaped after failed publication")
@@ -791,9 +819,65 @@ func TestRuntimeFinalReconcileFailureKeepsPriorGenerationAuthoritative(t *testin
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(newNode.PaneID), contextID); err == nil {
 		t.Fatal("new ownership route escaped after failed publication")
 	}
-	client.snapshot = validRuntimeHerdrSnapshot()
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(oldNode.PaneID), contextID); err != nil {
 		t.Fatalf("old ownership route after failed publication error = %v", err)
+	}
+}
+
+func TestRuntimeFinalReconcileRollsBackPreparedExternalMarkersOnFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	publishErr := errors.New("pane claim failed")
+	client := &fakeRuntimeHerdrClient{
+		snapshot:            validRuntimeHerdrSnapshot(),
+		setPaneMetadataErr:  publishErr,
+		setPaneMetadataPane: "",
+	}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, _, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile() error = %v", err)
+	}
+	err = rt.ReconcileFinalNodesForTokenAndCommit(token, nodes, func(publication *herdrruntime.FinalPublication) error {
+		if err := publication.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
+			return err
+		}
+		nodeInfo := nodes[sessionName+":worker"]
+		return publication.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  nodeInfo.HerdrSocketPath,
+			SessionName: nodeInfo.SessionName,
+			WorkspaceID: nodeInfo.HerdrWorkspaceID,
+			TabID:       nodeInfo.HerdrTabID,
+			PaneID:      nodeInfo.PaneID,
+		}, nodeInfo.PaneID), contextID)
+	}, func() {
+		t.Fatal("commit callback ran after failed pane claim")
+	})
+	if !errors.Is(err, publishErr) {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit() error = %v, want %v", err, publishErr)
+	}
+	if client.clearWorkspaceMetadataWorkspace != "workspace-1" {
+		t.Fatalf("rollback clear workspace = %q, want workspace-1", client.clearWorkspaceMetadataWorkspace)
+	}
+	if _, err := controlplane.DefaultHandAdapter(controlplane.TargetForNode(sessionName+":worker", nodes[sessionName+":worker"])); err == nil {
+		t.Fatal("adapter escaped after prepared marker rollback")
+	}
+	if err := rt.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("ownership route escaped after prepared marker rollback")
 	}
 }
 
@@ -1401,6 +1485,7 @@ type fakeRuntimeHerdrClient struct {
 	setPaneMetadataPane  string
 	setPaneMetadataKey   string
 	setPaneMetadataValue string
+	setPaneMetadataErr   error
 
 	setWorkspaceMetadataWorkspace   string
 	setWorkspaceMetadataValue       string
@@ -1465,6 +1550,9 @@ func (f *fakeRuntimeHerdrClient) SetPaneMetadata(_ context.Context, paneID strin
 	f.setPaneMetadataPane = paneID
 	f.setPaneMetadataKey = key
 	f.setPaneMetadataValue = value
+	if f.setPaneMetadataErr != nil {
+		return multiplexer.HerdrWriteResult{}, f.setPaneMetadataErr
+	}
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -96,6 +96,109 @@ func TestRuntimeDiscoverRegistersProductionHerdrDeliveryAndOwnership(t *testing.
 	}
 }
 
+func TestRuntimeReconcileKeepsSamePaneIDInDifferentTabsRoutable(t *testing.T) {
+	contextID := "ctx-main"
+	sessionName := "work"
+	paneID := "workspace-1:pane-shared"
+	tabOne := "workspace-1:tab-1"
+	tabTwo := "workspace-1:tab-2"
+	snapshot := runtimeHerdrSnapshotFor(sessionName, "workspace-1", tabOne, paneID, "")
+	snapshot.Tabs = append(snapshot.Tabs, multiplexer.HerdrTabSnapshot{
+		ID:          tabTwo,
+		WorkspaceID: "workspace-1",
+		Metadata:    map[string]string{},
+	})
+	snapshot.Panes[0].Metadata[multiplexer.HerdrPaneContextIDMetadataKey] = "ctx-tab-1"
+	snapshot.Panes = append(snapshot.Panes, multiplexer.HerdrPaneSnapshot{
+		ID:             paneID,
+		WorkspaceID:    "workspace-1",
+		TabID:          tabTwo,
+		Metadata:       map[string]string{"postman.node": "critic", multiplexer.HerdrPaneContextIDMetadataKey: "ctx-tab-2"},
+		Env:            map[string]string{},
+		ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+		PostmanNode:    "critic",
+		PostmanSession: sessionName,
+	})
+	client := &fakeRuntimeHerdrClient{snapshot: snapshot}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes := map[string]discovery.NodeInfo{
+		sessionName + ":worker": {
+			PaneID:           paneID,
+			SessionName:      sessionName,
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  cfg.Herdr.SocketPath,
+			HerdrWorkspaceID: "workspace-1",
+			HerdrTabID:       tabOne,
+		},
+		sessionName + ":critic": {
+			PaneID:           paneID,
+			SessionName:      sessionName,
+			Backend:          string(multiplexer.BackendKindHerdr),
+			HerdrSocketPath:  cfg.Herdr.SocketPath,
+			HerdrWorkspaceID: "workspace-1",
+			HerdrTabID:       tabTwo,
+		},
+	}
+	rt.ReconcileFinalNodes(nodes)
+
+	workerTarget := controlplane.TargetForNode(sessionName+":worker", nodes[sessionName+":worker"])
+	workerAdapter, err := controlplane.DefaultHandAdapter(workerTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(worker) error = %v", err)
+	}
+	if err := workerAdapter.Deliver(workerTarget, controlplane.PaneDelivery{Content: "worker"}); err != nil {
+		t.Fatalf("Deliver(worker) error = %v", err)
+	}
+	criticTarget := controlplane.TargetForNode(sessionName+":critic", nodes[sessionName+":critic"])
+	criticAdapter, err := controlplane.DefaultHandAdapter(criticTarget)
+	if err != nil {
+		t.Fatalf("DefaultHandAdapter(critic) error = %v", err)
+	}
+	if err := criticAdapter.Deliver(criticTarget, controlplane.PaneDelivery{Content: "critic"}); err != nil {
+		t.Fatalf("Deliver(critic) error = %v", err)
+	}
+	if client.writeTextCalls != 2 {
+		t.Fatalf("writeTextCalls = %d, want both tab-distinct adapters routable", client.writeTextCalls)
+	}
+
+	ownershipBackend := rt.OwnershipBackend()
+	workerPane := multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+		SocketPath:  cfg.Herdr.SocketPath,
+		SessionName: sessionName,
+		WorkspaceID: "workspace-1",
+		TabID:       tabOne,
+		PaneID:      paneID,
+	}, paneID)
+	if got, err := ownershipBackend.PaneOwnerMarker(context.Background(), workerPane); err != nil || got != "ctx-tab-1" {
+		t.Fatalf("PaneOwnerMarker(worker tab) = %q, %v; want ctx-tab-1", got, err)
+	}
+	criticPane := multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+		SocketPath:  cfg.Herdr.SocketPath,
+		SessionName: sessionName,
+		WorkspaceID: "workspace-1",
+		TabID:       tabTwo,
+		PaneID:      paneID,
+	}, paneID)
+	if got, err := ownershipBackend.PaneOwnerMarker(context.Background(), criticPane); err != nil || got != "ctx-tab-2" {
+		t.Fatalf("PaneOwnerMarker(critic tab) = %q, %v; want ctx-tab-2", got, err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), workerPane, contextID); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(worker tab) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), criticPane, contextID); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(critic tab) error = %v", err)
+	}
+}
+
 func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -198,6 +198,53 @@ func TestRuntimeDiscoverDoesNotPublishRoutesBeforeFinalReconcile(t *testing.T) {
 	}
 }
 
+func TestRuntimeStartupMarkerPublicationWaitsForFinalReconcile(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	nodeInfo, ok := nodes[sessionName+":worker"]
+	if !ok {
+		t.Fatalf("Discover() nodes = %#v, want work:worker candidate", nodes)
+	}
+	target := controlplane.TargetForNode(sessionName+":worker", nodeInfo)
+	if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+		t.Fatal("Herdr candidate pane route was published before final reconcile")
+	}
+	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err == nil {
+		t.Fatal("SetSessionEnabledMarker() succeeded before final reconcile")
+	}
+
+	rt.ReconcileFinalNodes(nodes)
+	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
+		t.Fatalf("SetSessionEnabledMarker(after reconcile) error = %v", err)
+	}
+	if client.setWorkspaceMetadataWorkspace != "workspace-1" || client.setWorkspaceMetadataValue == "" {
+		t.Fatalf("session marker workspace=%q value=%q, want Herdr startup marker publication", client.setWorkspaceMetadataWorkspace, client.setWorkspaceMetadataValue)
+	}
+	if _, err := controlplane.DefaultHandAdapter(target); err != nil {
+		t.Fatalf("DefaultHandAdapter(after marker publication) error = %v", err)
+	}
+}
+
 func TestRuntimeReconcileFinalNodesPrunesCrossBackendCollisionLoser(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -292,14 +292,14 @@ func TestRuntimeReconcileFinalNodesPrunesCrossBackendCollisionLoser(t *testing.T
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("cross-backend collision loser Herdr ownership route remained available")
 	}
-	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
-		t.Fatal("final-pruned Herdr session owner read remained available")
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err != nil || got != "" {
+		t.Fatalf("final-pruned Herdr session owner read = %q, %v; want empty workspace marker route", got, err)
 	}
-	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err == nil {
-		t.Fatal("final-pruned Herdr session owner set remained available")
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err != nil {
+		t.Fatalf("final-pruned Herdr session owner set error = %v, want workspace marker route", err)
 	}
 	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
-		t.Fatalf("final-pruned Herdr session owner clear error = %v, want teardown-only clear to remain available", err)
+		t.Fatalf("final-pruned Herdr session owner clear error = %v, want workspace marker route", err)
 	}
 }
 
@@ -343,6 +343,15 @@ func TestRuntimeReconcileFinalNodesPrunesFilteredHerdrPane(t *testing.T) {
 	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("activation-filtered Herdr ownership route remained available")
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err != nil || got != "" {
+		t.Fatalf("activation-filtered Herdr session owner read = %q, %v; want empty workspace marker route", got, err)
+	}
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err != nil {
+		t.Fatalf("activation-filtered Herdr session owner set error = %v, want workspace marker route", err)
+	}
+	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
+		t.Fatalf("activation-filtered Herdr session owner clear error = %v, want workspace marker route", err)
 	}
 }
 
@@ -388,6 +397,136 @@ func TestRuntimeDiscoverErrorClearsStalePaneRegistrations(t *testing.T) {
 	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr pane ownership route remained available after discovery error")
+	}
+}
+
+func TestRuntimeReconcileFinalNodesIgnoresOlderSuccessfulDiscoveryAfterNewerSuccess(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	oldSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-old", "workspace-1:pane-old", "")
+	newSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-new", "workspace-1:pane-new", "")
+	oldCall := newControlledRuntimeSnapshot(oldSnapshot, nil)
+	newCall := newControlledRuntimeSnapshot(newSnapshot, nil)
+	client := &sequencedRuntimeHerdrClient{calls: make(chan *controlledRuntimeSnapshot, 2)}
+	client.calls <- oldCall
+	client.calls <- newCall
+
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		oldResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-oldCall.started
+
+	newResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		newResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-newCall.started
+	close(newCall.release)
+	newer := <-newResult
+	if newer.err != nil {
+		t.Fatalf("newer DiscoverForReconcile() error = %v", newer.err)
+	}
+	if len(newer.collisions) != 0 {
+		t.Fatalf("newer collisions = %#v, want none", newer.collisions)
+	}
+	rt.ReconcileFinalNodesForToken(newer.token, newer.nodes)
+
+	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("newer Herdr adapter missing after final reconcile: %v", err)
+	}
+
+	close(oldCall.release)
+	older := <-oldResult
+	if older.err != nil {
+		t.Fatalf("older DiscoverForReconcile() error = %v", older.err)
+	}
+	rt.ReconcileFinalNodesForToken(older.token, older.nodes)
+
+	oldTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-old"}}
+	if _, err := controlplane.DefaultHandAdapter(oldTarget); err == nil {
+		t.Fatal("older successful discovery registered stale Herdr adapter")
+	}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("newer Herdr adapter was removed by stale older reconcile: %v", err)
+	}
+}
+
+func TestRuntimeDiscoveryErrorDoesNotClearNewerSuccessfulRoutes(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	oldErr := errors.New("old snapshot failed")
+	oldCall := newControlledRuntimeSnapshot(multiplexer.HerdrSessionSnapshot{}, oldErr)
+	newCall := newControlledRuntimeSnapshot(runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-new", "workspace-1:pane-new", ""), nil)
+	client := &sequencedRuntimeHerdrClient{calls: make(chan *controlledRuntimeSnapshot, 2)}
+	client.calls <- oldCall
+	client.calls <- newCall
+
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		oldResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-oldCall.started
+
+	newResult := make(chan runtimeDiscoverResult, 1)
+	go func() {
+		nodes, collisions, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		newResult <- runtimeDiscoverResult{nodes: nodes, collisions: collisions, token: token, err: err}
+	}()
+	<-newCall.started
+	close(newCall.release)
+	newer := <-newResult
+	if newer.err != nil {
+		t.Fatalf("newer DiscoverForReconcile() error = %v", newer.err)
+	}
+	rt.ReconcileFinalNodesForToken(newer.token, newer.nodes)
+
+	newTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-new"}}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("newer Herdr adapter missing after final reconcile: %v", err)
+	}
+
+	close(oldCall.release)
+	older := <-oldResult
+	if !errors.Is(older.err, oldErr) {
+		t.Fatalf("older DiscoverForReconcile() error = %v, want old snapshot failure", older.err)
+	}
+	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
+		t.Fatalf("newer Herdr adapter was cleared by stale older error: %v", err)
 	}
 }
 
@@ -486,11 +625,11 @@ func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T)
 	if client.clearWorkspaceMetadataWorkspace != "workspace-1" || client.clearWorkspaceMetadataKey == "" {
 		t.Fatalf("clear workspace metadata workspace=%q key=%q, want retained session ownership backend", client.clearWorkspaceMetadataWorkspace, client.clearWorkspaceMetadataKey)
 	}
-	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
-		t.Fatal("zero-pane Herdr session owner read remained available")
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err != nil || got != "" {
+		t.Fatalf("zero-pane Herdr session owner read = %q, %v; want empty workspace marker route", got, err)
 	}
-	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err == nil {
-		t.Fatal("zero-pane Herdr session owner set remained available")
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err != nil {
+		t.Fatalf("zero-pane Herdr session owner set error = %v, want workspace marker route", err)
 	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr pane ownership backend remained routable after zero-pane rediscovery")
@@ -529,18 +668,19 @@ func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
 	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
 		t.Fatalf("collisions = %#v, want duplicate Herdr collision", collisions)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
 	if err != nil {
 		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
 	}
-	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
-		t.Fatal("duplicate-only Herdr session owner read remained available")
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err != nil || got != "" {
+		t.Fatalf("duplicate-only Herdr session owner read = %q, %v; want empty workspace marker route", got, err)
 	}
-	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err == nil {
-		t.Fatal("duplicate-only Herdr session owner set remained available")
+	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
+		t.Fatalf("duplicate-only Herdr session owner set error = %v, want workspace marker route", err)
 	}
 	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
-		t.Fatalf("duplicate-only Herdr session owner clear error = %v, want teardown-only clear to remain available", err)
+		t.Fatalf("duplicate-only Herdr session owner clear error = %v, want workspace marker route", err)
 	}
 	for _, paneID := range []string{"workspace-1:pane-1", "workspace-1:pane-2"} {
 		target := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: paneID}}
@@ -993,5 +1133,81 @@ func (f *fakeRuntimeHerdrClient) SetPaneMetadata(_ context.Context, paneID strin
 }
 
 func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+type runtimeDiscoverResult struct {
+	nodes      map[string]discovery.NodeInfo
+	collisions []discovery.CollisionReport
+	token      uint64
+	err        error
+}
+
+type controlledRuntimeSnapshot struct {
+	started  chan struct{}
+	release  chan struct{}
+	snapshot multiplexer.HerdrSessionSnapshot
+	err      error
+}
+
+func newControlledRuntimeSnapshot(snapshot multiplexer.HerdrSessionSnapshot, err error) *controlledRuntimeSnapshot {
+	return &controlledRuntimeSnapshot{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		snapshot: snapshot,
+		err:      err,
+	}
+}
+
+type sequencedRuntimeHerdrClient struct {
+	calls chan *controlledRuntimeSnapshot
+}
+
+func (s *sequencedRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	call := <-s.calls
+	close(call.started)
+	<-call.release
+	if call.err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, call.err
+	}
+	return call.snapshot, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{
+		Envelope:    multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
+		ProcessInfo: multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
+	}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) WritePaneText(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) SendPaneKey(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+func (s *sequencedRuntimeHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -881,6 +881,78 @@ func TestRuntimeFinalReconcileRollsBackPreparedExternalMarkersOnFailure(t *testi
 	}
 }
 
+func TestRuntimeFinalReconcileReturnsRollbackFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	publishErr := errors.New("pane claim failed")
+	rollbackErr := errors.New("workspace clear failed")
+	client := &fakeRuntimeHerdrClient{
+		snapshot:                  validRuntimeHerdrSnapshot(),
+		setPaneMetadataErr:        publishErr,
+		clearWorkspaceMetadataErr: rollbackErr,
+	}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, _, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile() error = %v", err)
+	}
+	err = rt.ReconcileFinalNodesForTokenAndCommit(token, nodes, func(publication *herdrruntime.FinalPublication) error {
+		if err := publication.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
+			return err
+		}
+		nodeInfo := nodes[sessionName+":worker"]
+		return publication.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  nodeInfo.HerdrSocketPath,
+			SessionName: nodeInfo.SessionName,
+			WorkspaceID: nodeInfo.HerdrWorkspaceID,
+			TabID:       nodeInfo.HerdrTabID,
+			PaneID:      nodeInfo.PaneID,
+		}, nodeInfo.PaneID), contextID)
+	}, func() {
+		t.Fatal("commit callback ran after failed pane claim")
+	})
+	if !errors.Is(err, publishErr) {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit() error = %v, want publish failure", err)
+	}
+	if !errors.Is(err, rollbackErr) {
+		t.Fatalf("ReconcileFinalNodesForTokenAndCommit() error = %v, want rollback failure", err)
+	}
+}
+
+func TestFinalPublicationRestoresPaneMarkerAfterAmbiguousWriteFailure(t *testing.T) {
+	backend := &transactionOwnershipBackend{
+		kind:        multiplexer.BackendKindHerdr,
+		paneMarkers: map[string]string{"%42": "ctx-old"},
+		failSetFor:  "ctx-new",
+		failSetErr:  errors.New("remote write returned failure after mutation"),
+	}
+	unregister := multiplexer.RegisterOwnershipBackend(backend)
+	t.Cleanup(unregister)
+
+	publication := herdrruntime.NewFinalPublication()
+	err := publication.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("%42"), "ctx-new")
+	if !errors.Is(err, backend.failSetErr) {
+		t.Fatalf("SetPaneOwnerMarker() error = %v, want ambiguous write failure", err)
+	}
+	if got := backend.paneMarkers["%42"]; got != "ctx-old" {
+		t.Fatalf("pane marker after failed write = %q, want restored ctx-old", got)
+	}
+}
+
 func TestRuntimeFinalReconcileBlocksExternalReadersDuringPublicCommit(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
@@ -1491,6 +1563,7 @@ type fakeRuntimeHerdrClient struct {
 	setWorkspaceMetadataValue       string
 	clearWorkspaceMetadataWorkspace string
 	clearWorkspaceMetadataKey       string
+	clearWorkspaceMetadataErr       error
 }
 
 func (f *fakeRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
@@ -1543,6 +1616,9 @@ func (f *fakeRuntimeHerdrClient) SetWorkspaceMetadata(_ context.Context, workspa
 func (f *fakeRuntimeHerdrClient) ClearWorkspaceMetadata(_ context.Context, workspaceID string, key string) (multiplexer.HerdrWriteResult, error) {
 	f.clearWorkspaceMetadataWorkspace = workspaceID
 	f.clearWorkspaceMetadataKey = key
+	if f.clearWorkspaceMetadataErr != nil {
+		return multiplexer.HerdrWriteResult{}, f.clearWorkspaceMetadataErr
+	}
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 
@@ -1558,6 +1634,50 @@ func (f *fakeRuntimeHerdrClient) SetPaneMetadata(_ context.Context, paneID strin
 
 func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
+}
+
+type transactionOwnershipBackend struct {
+	kind           multiplexer.BackendKind
+	sessionMarkers map[string]string
+	paneMarkers    map[string]string
+	failSetFor     string
+	failSetErr     error
+}
+
+func (b *transactionOwnershipBackend) Kind() multiplexer.BackendKind {
+	return b.kind
+}
+
+func (b *transactionOwnershipBackend) SessionOwnerMarker(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (b *transactionOwnershipBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+	return nil
+}
+
+func (b *transactionOwnershipBackend) ClearSessionOwnerMarker(context.Context, string) error {
+	return nil
+}
+
+func (b *transactionOwnershipBackend) PaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) (string, error) {
+	return b.paneMarkers[pane.Native], nil
+}
+
+func (b *transactionOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID, contextID string) error {
+	if b.paneMarkers == nil {
+		b.paneMarkers = make(map[string]string)
+	}
+	b.paneMarkers[pane.Native] = contextID
+	if contextID == b.failSetFor {
+		return b.failSetErr
+	}
+	return nil
+}
+
+func (b *transactionOwnershipBackend) ClearPaneOwnerMarker(_ context.Context, pane multiplexer.ResourceID) error {
+	delete(b.paneMarkers, pane.Native)
+	return nil
 }
 
 type runtimeDiscoverResult struct {

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -339,7 +339,7 @@ func validRuntimeHerdrConfig() config.HerdrConfig {
 		ReadEnabled:                 true,
 		WriteEnabled:                true,
 		InputSanitizerReady:         true,
-		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionAGPL),
+		ComplianceDecision:          string(multiplexer.HerdrComplianceDecisionRecorded),
 		ComplianceAuthorizedBy:      "test-authority",
 		ComplianceDecisionID:        "test-decision",
 		ComplianceDecidedAt:         "2026-08-12T00:00:00Z",

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -55,6 +55,7 @@ func TestRuntimeDiscoverRegistersProductionHerdrDeliveryAndOwnership(t *testing.
 	if nodeInfo.Backend != string(multiplexer.BackendKindHerdr) || nodeInfo.Runtime != "codex" {
 		t.Fatalf("nodeInfo = %#v, want Herdr codex node", nodeInfo)
 	}
+	rt.ReconcileFinalNodes(nodes)
 
 	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
 	if err != nil {
@@ -112,9 +113,11 @@ func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	}
 	t.Cleanup(rt.Close)
 
-	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(initial) error = %v", err)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	staleTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
 	if _, err := controlplane.DefaultHandAdapter(staleTarget); err != nil {
 		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
@@ -123,9 +126,11 @@ func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	next := validRuntimeHerdrSnapshot()
 	next.Panes[0].ID = "workspace-1:pane-2"
 	client.snapshot = next
-	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+	nodes, _, err = rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(second) error = %v", err)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	if _, err := controlplane.DefaultHandAdapter(staleTarget); err == nil {
 		t.Fatal("stale Herdr pane adapter remained registered after rediscovery")
 	}
@@ -139,6 +144,57 @@ func TestRuntimeDiscoverPrunesStalePaneRegistrations(t *testing.T) {
 	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr pane ownership backend remained routable")
+	}
+}
+
+func TestRuntimeDiscoverDoesNotPublishRoutesBeforeFinalReconcile(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	nodeInfo, ok := nodes[sessionName+":worker"]
+	if !ok {
+		t.Fatalf("Discover() nodes = %#v, want work:worker candidate", nodes)
+	}
+	target := controlplane.TargetForNode(sessionName+":worker", nodeInfo)
+	if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+		t.Fatal("Herdr hand adapter was published before final reconcile")
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(nodeInfo.PaneID), contextID); err == nil {
+		t.Fatal("Herdr pane ownership route was published before final reconcile")
+	}
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err == nil {
+		t.Fatal("Herdr session ownership route was published before final reconcile")
+	}
+
+	rt.ReconcileFinalNodes(nodes)
+	if _, err := controlplane.DefaultHandAdapter(target); err != nil {
+		t.Fatalf("DefaultHandAdapter(after reconcile) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID(nodeInfo.PaneID), contextID); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(after reconcile) error = %v", err)
 	}
 }
 
@@ -161,9 +217,11 @@ func TestRuntimeReconcileFinalNodesPrunesCrossBackendCollisionLoser(t *testing.T
 	}
 	t.Cleanup(rt.Close)
 
-	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(initial) error = %v", err)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	loserTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
 	if _, err := controlplane.DefaultHandAdapter(loserTarget); err != nil {
 		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
@@ -217,9 +275,11 @@ func TestRuntimeReconcileFinalNodesPrunesFilteredHerdrPane(t *testing.T) {
 	}
 	t.Cleanup(rt.Close)
 
-	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(initial) error = %v", err)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	filteredTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
 	if _, err := controlplane.DefaultHandAdapter(filteredTarget); err != nil {
 		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
@@ -258,9 +318,11 @@ func TestRuntimeDiscoverErrorClearsStalePaneRegistrations(t *testing.T) {
 	}
 	t.Cleanup(rt.Close)
 
-	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(initial) error = %v", err)
 	}
+	rt.ReconcileFinalNodes(nodes)
 	staleTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
 	if _, err := controlplane.DefaultHandAdapter(staleTarget); err != nil {
 		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
@@ -363,6 +425,8 @@ func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T)
 		t.Fatalf("Discover(empty) error = %v", err)
 	} else if len(nodes) != 0 {
 		t.Fatalf("Discover(empty) nodes = %#v, want none", nodes)
+	} else {
+		rt.ReconcileFinalNodes(nodes)
 	}
 
 	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
@@ -469,13 +533,16 @@ func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 		t.Fatalf("New(other) error = %v", err)
 	}
 
-	if _, _, err := workRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+	workNodes, _, err := workRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(work) error = %v", err)
 	}
+	workRuntime.ReconcileFinalNodes(workNodes)
 	otherNodes, _, err := otherRuntime.Discover(context.Background(), baseDir, contextID)
 	if err != nil {
 		t.Fatalf("Discover(other) error = %v", err)
 	}
+	otherRuntime.ReconcileFinalNodes(otherNodes)
 	otherNode := otherNodes["other:worker"]
 	if otherNode.PaneID == "" {
 		t.Fatalf("Discover(other) nodes = %#v, want other:worker", otherNodes)
@@ -556,12 +623,16 @@ func TestRuntimeHerdrOwnershipRegistrySkipsEmptyDuplicateAndTeardown(t *testing.
 		t.Fatalf("New(healthy) error = %v", err)
 	}
 
-	if _, _, err := emptyRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+	emptyNodes, _, err := emptyRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(empty) error = %v", err)
 	}
-	if _, _, err := healthyRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+	emptyRuntime.ReconcileFinalNodes(emptyNodes)
+	healthyNodes, _, err := healthyRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
 		t.Fatalf("Discover(healthy) error = %v", err)
 	}
+	healthyRuntime.ReconcileFinalNodes(healthyNodes)
 
 	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
 	if err != nil {

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -187,6 +187,56 @@ func TestRuntimeReconcileFinalNodesPrunesCrossBackendCollisionLoser(t *testing.T
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("cross-backend collision loser Herdr ownership route remained available")
 	}
+	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
+		t.Fatal("final-pruned Herdr session owner read remained available")
+	}
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err == nil {
+		t.Fatal("final-pruned Herdr session owner set remained available")
+	}
+	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
+		t.Fatalf("final-pruned Herdr session owner clear error = %v, want teardown-only clear to remain available", err)
+	}
+}
+
+func TestRuntimeReconcileFinalNodesPrunesFilteredHerdrPane(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	if _, _, err := rt.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(initial) error = %v", err)
+	}
+	filteredTarget := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: "workspace-1:pane-1"}}
+	if _, err := controlplane.DefaultHandAdapter(filteredTarget); err != nil {
+		t.Fatalf("DefaultHandAdapter(initial) error = %v", err)
+	}
+
+	rt.ReconcileFinalNodes(map[string]discovery.NodeInfo{})
+
+	if _, err := controlplane.DefaultHandAdapter(filteredTarget); err == nil {
+		t.Fatal("activation-filtered Herdr hand adapter remained registered")
+	}
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("activation-filtered Herdr ownership route remained available")
+	}
 }
 
 func TestRuntimeDiscoverErrorClearsStalePaneRegistrations(t *testing.T) {
@@ -273,6 +323,12 @@ func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T)
 	if client.clearWorkspaceMetadataWorkspace != "workspace-1" || client.clearWorkspaceMetadataKey == "" {
 		t.Fatalf("clear workspace metadata workspace=%q key=%q, want retained session ownership backend", client.clearWorkspaceMetadataWorkspace, client.clearWorkspaceMetadataKey)
 	}
+	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
+		t.Fatal("zero-pane Herdr session owner read remained available")
+	}
+	if err := ownershipBackend.SetSessionOwnerMarker(context.Background(), contextID, sessionName, 0); err == nil {
+		t.Fatal("zero-pane Herdr session owner set remained available")
+	}
 	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
 		t.Fatal("stale Herdr pane ownership backend remained routable after zero-pane rediscovery")
 	}
@@ -310,17 +366,77 @@ func TestRuntimeDiscoverDoesNotRegisterDuplicateHerdrClaims(t *testing.T) {
 	if len(collisions) != 1 || collisions[0].NodeKey != sessionName+":worker" {
 		t.Fatalf("collisions = %#v, want duplicate Herdr collision", collisions)
 	}
-	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err != nil {
-		t.Fatalf("SetSessionEnabledMarker() duplicate-only Herdr cold start error = %v", err)
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
 	}
-	if client.setWorkspaceMetadataWorkspace != "workspace-1" || client.setWorkspaceMetadataValue == "" {
-		t.Fatalf("set workspace metadata workspace=%q value=%q, want duplicate-only cold start session marker", client.setWorkspaceMetadataWorkspace, client.setWorkspaceMetadataValue)
+	if _, err := ownershipBackend.SessionOwnerMarker(context.Background(), sessionName); err == nil {
+		t.Fatal("duplicate-only Herdr session owner read remained available")
+	}
+	if err := rt.SetSessionEnabledMarker(context.Background(), contextID, sessionName, true); err == nil {
+		t.Fatal("duplicate-only Herdr session owner set remained available")
+	}
+	if err := ownershipBackend.ClearSessionOwnerMarker(context.Background(), sessionName); err != nil {
+		t.Fatalf("duplicate-only Herdr session owner clear error = %v, want teardown-only clear to remain available", err)
 	}
 	for _, paneID := range []string{"workspace-1:pane-1", "workspace-1:pane-2"} {
 		target := controlplane.Target{Hand: controlplane.HandAttachment{Kind: controlplane.HandKindHerdr, Address: paneID}}
 		if _, err := controlplane.DefaultHandAdapter(target); err == nil {
 			t.Fatalf("duplicate Herdr pane %q remained registered", paneID)
 		}
+	}
+}
+
+func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+
+	workClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-1", "workspace-1:pane-1", "ctx-work:1")}
+	workCfg := config.DefaultConfig()
+	workCfg.Herdr = runtimeHerdrConfigFor("work", "workspace-1")
+	workRuntime, err := herdrruntime.New(workCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return workClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(work) error = %v", err)
+	}
+	t.Cleanup(workRuntime.Close)
+
+	otherClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("other", "workspace-2", "workspace-2:tab-1", "workspace-2:pane-1", "ctx-other:1")}
+	otherCfg := config.DefaultConfig()
+	otherCfg.Herdr = runtimeHerdrConfigFor("other", "workspace-2")
+	otherRuntime, err := herdrruntime.New(otherCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return otherClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(other) error = %v", err)
+	}
+
+	if _, _, err := workRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(work) error = %v", err)
+	}
+	if _, _, err := otherRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(other) error = %v", err)
+	}
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "ctx-work:1" {
+		t.Fatalf("SessionOwnerMarker(work) = %q, %v; want ctx-work:1", got, err)
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "other"); err != nil || got != "ctx-other:1" {
+		t.Fatalf("SessionOwnerMarker(other) = %q, %v; want ctx-other:1", got, err)
+	}
+
+	otherRuntime.Close()
+	ownershipBackend, err = multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr after other close) error = %v", err)
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "ctx-work:1" {
+		t.Fatalf("SessionOwnerMarker(work after other close) = %q, %v; want ctx-work:1", got, err)
 	}
 }
 
@@ -416,14 +532,18 @@ func tempHerdrSocketPath(t *testing.T) string {
 }
 
 func validRuntimeHerdrConfig() config.HerdrConfig {
+	return runtimeHerdrConfigFor("work", "workspace-1")
+}
+
+func runtimeHerdrConfigFor(sessionName, workspaceID string) config.HerdrConfig {
 	return config.HerdrConfig{
 		Enabled:                     true,
 		SocketPath:                  "/tmp/herdr.sock",
-		SessionName:                 "work",
-		WorkspaceID:                 "workspace-1",
+		SessionName:                 sessionName,
+		WorkspaceID:                 workspaceID,
 		AllowedSocketPaths:          []string{"/tmp/herdr.sock"},
-		AllowedSessions:             []string{"work"},
-		AllowedWorkspaceIDs:         []string{"workspace-1"},
+		AllowedSessions:             []string{sessionName},
+		AllowedWorkspaceIDs:         []string{workspaceID},
 		AllowedProtocolVersions:     []string{"1"},
 		AllowedSchemaVersions:       []int{1},
 		ReadEnabled:                 true,
@@ -439,26 +559,34 @@ func validRuntimeHerdrConfig() config.HerdrConfig {
 }
 
 func validRuntimeHerdrSnapshot() multiplexer.HerdrSessionSnapshot {
+	return runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-1", "workspace-1:pane-1", "")
+}
+
+func runtimeHerdrSnapshotFor(sessionName, workspaceID, tabID, paneID, sessionOwner string) multiplexer.HerdrSessionSnapshot {
+	workspaceMetadata := map[string]string{}
+	if sessionOwner != "" {
+		workspaceMetadata["postman.session_owner."+sessionName] = sessionOwner
+	}
 	return multiplexer.HerdrSessionSnapshot{
 		Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1},
 		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
-			ID:       "workspace-1",
-			Metadata: map[string]string{},
+			ID:       workspaceID,
+			Metadata: workspaceMetadata,
 		}},
 		Tabs: []multiplexer.HerdrTabSnapshot{{
-			ID:          "workspace-1:tab-1",
-			WorkspaceID: "workspace-1",
+			ID:          tabID,
+			WorkspaceID: workspaceID,
 			Metadata:    map[string]string{},
 		}},
 		Panes: []multiplexer.HerdrPaneSnapshot{{
-			ID:             "workspace-1:pane-1",
-			WorkspaceID:    "workspace-1",
-			TabID:          "workspace-1:tab-1",
+			ID:             paneID,
+			WorkspaceID:    workspaceID,
+			TabID:          tabID,
 			Metadata:       map[string]string{"postman.node": "worker"},
 			Env:            map[string]string{},
 			ProcessInfo:    multiplexer.HerdrPaneProcessInfo{ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}}},
 			PostmanNode:    "worker",
-			PostmanSession: "work",
+			PostmanSession: sessionName,
 		}},
 	}
 }

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -282,6 +282,58 @@ func TestRuntimeDiscoverErrorClearsStalePaneRegistrations(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseWhileDiscoverBlockedDoesNotRegisterRoutes(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	snapshotStarted := make(chan struct{})
+	releaseSnapshot := make(chan struct{})
+	client := &fakeRuntimeHerdrClient{
+		snapshot:        validRuntimeHerdrSnapshot(),
+		snapshotStarted: snapshotStarted,
+		releaseSnapshot: releaseSnapshot,
+	}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	discoverDone := make(chan error, 1)
+	go func() {
+		_, _, err := rt.Discover(context.Background(), baseDir, contextID)
+		discoverDone <- err
+	}()
+	<-snapshotStarted
+	rt.Close()
+	close(releaseSnapshot)
+	if err := <-discoverDone; err == nil {
+		t.Fatal("Discover() error = nil after Close, want terminal closed error")
+	}
+
+	target := controlplane.TargetForNode("work:worker", discovery.NodeInfo{
+		PaneID:           "workspace-1:pane-1",
+		SessionName:      "work",
+		Backend:          string(multiplexer.BackendKindHerdr),
+		HerdrSocketPath:  "/tmp/herdr.sock",
+		HerdrWorkspaceID: "workspace-1",
+		HerdrTabID:       "workspace-1:tab-1",
+	})
+	if _, err := controlplane.DefaultHandAdapter(target); err == nil {
+		t.Fatal("Herdr adapter registered after runtime Close")
+	}
+	if err := rt.OwnershipBackend().SetPaneOwnerMarker(context.Background(), multiplexer.HerdrPaneID("workspace-1:pane-1"), contextID); err == nil {
+		t.Fatal("Herdr ownership route registered after runtime Close")
+	}
+}
+
 func TestRuntimeClearSessionOwnerMarkerSurvivesZeroPaneRediscovery(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
@@ -468,6 +520,64 @@ func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 	}
 	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "ctx-work:1" {
 		t.Fatalf("SessionOwnerMarker(work after other close) = %q, %v; want ctx-work:1", got, err)
+	}
+}
+
+func TestRuntimeHerdrOwnershipRegistrySkipsEmptyDuplicateAndTeardown(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs(%q) error = %v", sessionName, err)
+	}
+
+	emptyClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-1", "workspace-1:pane-empty", "")}
+	emptyCfg := config.DefaultConfig()
+	emptyCfg.Herdr = runtimeHerdrConfigFor("work", "workspace-1")
+	emptyCfg.Herdr.SocketPath = "/tmp/herdr-empty.sock"
+	emptyCfg.Herdr.AllowedSocketPaths = []string{"/tmp/herdr-empty.sock"}
+	emptyRuntime, err := herdrruntime.New(emptyCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return emptyClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(empty) error = %v", err)
+	}
+	t.Cleanup(emptyRuntime.Close)
+
+	healthyClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("work", "workspace-1", "workspace-1:tab-2", "workspace-1:pane-healthy", "ctx-work:1")}
+	healthyCfg := config.DefaultConfig()
+	healthyCfg.Herdr = runtimeHerdrConfigFor("work", "workspace-1")
+	healthyCfg.Herdr.SocketPath = "/tmp/herdr-healthy.sock"
+	healthyCfg.Herdr.AllowedSocketPaths = []string{"/tmp/herdr-healthy.sock"}
+	healthyRuntime, err := herdrruntime.New(healthyCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return healthyClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(healthy) error = %v", err)
+	}
+
+	if _, _, err := emptyRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(empty) error = %v", err)
+	}
+	if _, _, err := healthyRuntime.Discover(context.Background(), baseDir, contextID); err != nil {
+		t.Fatalf("Discover(healthy) error = %v", err)
+	}
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "ctx-work:1" {
+		t.Fatalf("SessionOwnerMarker(work) = %q, %v; want ctx-work:1", got, err)
+	}
+
+	healthyRuntime.Close()
+	ownershipBackend, err = multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr after healthy close) error = %v", err)
+	}
+	if got, err := ownershipBackend.SessionOwnerMarker(context.Background(), "work"); err != nil || got != "" {
+		t.Fatalf("SessionOwnerMarker(work after healthy close) = %q, %v; want empty surviving duplicate marker", got, err)
 	}
 }
 
@@ -684,8 +794,10 @@ func handleFakeHerdrSocketConn(conn net.Conn, methods chan<- string) {
 }
 
 type fakeRuntimeHerdrClient struct {
-	snapshot    multiplexer.HerdrSessionSnapshot
-	snapshotErr error
+	snapshot        multiplexer.HerdrSessionSnapshot
+	snapshotErr     error
+	snapshotStarted chan struct{}
+	releaseSnapshot chan struct{}
 
 	writeTextCalls int
 	writeTextPane  string
@@ -707,6 +819,13 @@ func (f *fakeRuntimeHerdrClient) Ping(context.Context) (multiplexer.HerdrRespons
 }
 
 func (f *fakeRuntimeHerdrClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	if f.snapshotStarted != nil {
+		close(f.snapshotStarted)
+		f.snapshotStarted = nil
+	}
+	if f.releaseSnapshot != nil {
+		<-f.releaseSnapshot
+	}
 	if f.snapshotErr != nil {
 		return multiplexer.HerdrSessionSnapshot{}, f.snapshotErr
 	}

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -1454,6 +1454,187 @@ func TestRuntimeHerdrOwnershipRegistryIsolatesMultipleSessions(t *testing.T) {
 	}
 }
 
+func TestRuntimeHerdrOwnershipCompositeResolvesReducedUniquePaneIdentity(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	for _, sessionName := range []string{"work", "other"} {
+		if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+			t.Fatalf("CreateSessionDirs(%q) error = %v", sessionName, err)
+		}
+	}
+
+	const (
+		workPaneID = "workspace-1:pane-reduced"
+		workTabID  = "workspace-1:tab-1"
+	)
+	workSnapshot := runtimeHerdrSnapshotFor("work", "workspace-1", workTabID, workPaneID, "ctx-work:1")
+	workSnapshot.Panes[0].Metadata[multiplexer.HerdrPaneContextIDMetadataKey] = "ctx-pane-old"
+	workClient := &fakeRuntimeHerdrClient{snapshot: workSnapshot}
+	workCfg := config.DefaultConfig()
+	workCfg.Herdr = runtimeHerdrConfigFor("work", "workspace-1")
+	workCfg.Herdr.SocketPath = "/tmp/herdr-reduced-work.sock"
+	workCfg.Herdr.AllowedSocketPaths = []string{workCfg.Herdr.SocketPath}
+	workRuntime, err := herdrruntime.New(workCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return workClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(work) error = %v", err)
+	}
+	t.Cleanup(workRuntime.Close)
+
+	otherClient := &fakeRuntimeHerdrClient{snapshot: runtimeHerdrSnapshotFor("other", "workspace-2", "workspace-2:tab-1", "workspace-2:pane-1", "ctx-other:1")}
+	otherCfg := config.DefaultConfig()
+	otherCfg.Herdr = runtimeHerdrConfigFor("other", "workspace-2")
+	otherCfg.Herdr.SocketPath = "/tmp/herdr-reduced-other.sock"
+	otherCfg.Herdr.AllowedSocketPaths = []string{otherCfg.Herdr.SocketPath}
+	otherRuntime, err := herdrruntime.New(otherCfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return otherClient, nil
+	})
+	if err != nil {
+		t.Fatalf("New(other) error = %v", err)
+	}
+	t.Cleanup(otherRuntime.Close)
+
+	workNodes, _, err := workRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover(work) error = %v", err)
+	}
+	workRuntime.ReconcileFinalNodes(workNodes)
+	otherNodes, _, err := otherRuntime.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover(other) error = %v", err)
+	}
+	otherRuntime.ReconcileFinalNodes(otherNodes)
+
+	ownershipBackend, err := multiplexer.OwnershipBackendForKind(multiplexer.BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	reducedPane := multiplexer.HerdrPaneIDForRuntime(multiplexer.HerdrRuntimeIdentity{
+		SocketPath:  workCfg.Herdr.SocketPath,
+		SessionName: "work",
+		WorkspaceID: "workspace-1",
+		PaneID:      workPaneID,
+	}, workPaneID)
+	if got, err := ownershipBackend.PaneOwnerMarker(context.Background(), reducedPane); err != nil || got != "ctx-pane-old" {
+		t.Fatalf("PaneOwnerMarker(reduced unique) = %q, %v; want ctx-pane-old", got, err)
+	}
+	if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), reducedPane, "ctx-pane-new"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(reduced unique) error = %v", err)
+	}
+	if workClient.setPaneMetadataPane != workPaneID || workClient.setPaneMetadataValue != "ctx-pane-new" {
+		t.Fatalf("work SetPaneMetadata pane/value = %q/%q, want %q/ctx-pane-new", workClient.setPaneMetadataPane, workClient.setPaneMetadataValue, workPaneID)
+	}
+	if otherClient.setPaneMetadataPane != "" {
+		t.Fatalf("other SetPaneMetadata pane = %q, want no reduced unique mutation", otherClient.setPaneMetadataPane)
+	}
+	if err := ownershipBackend.ClearPaneOwnerMarker(context.Background(), reducedPane); err != nil {
+		t.Fatalf("ClearPaneOwnerMarker(reduced unique) error = %v", err)
+	}
+	if workClient.clearPaneMetadataPane != workPaneID || workClient.clearPaneMetadataKey != multiplexer.HerdrPaneContextIDMetadataKey {
+		t.Fatalf("work ClearPaneMetadata pane/key = %q/%q, want %q/%q", workClient.clearPaneMetadataPane, workClient.clearPaneMetadataKey, workPaneID, multiplexer.HerdrPaneContextIDMetadataKey)
+	}
+	if otherClient.clearPaneMetadataPane != "" {
+		t.Fatalf("other ClearPaneMetadata pane = %q, want no reduced unique clear", otherClient.clearPaneMetadataPane)
+	}
+}
+
+func TestRuntimeHerdrOwnershipQualifiedPaneMissesFailClosed(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs(%q) error = %v", sessionName, err)
+	}
+
+	const (
+		paneID      = "workspace-1:pane-qualified"
+		socketPath  = "/tmp/herdr-qualified-runtime.sock"
+		workspaceID = "workspace-1"
+		tabID       = "workspace-1:tab-1"
+	)
+	snapshot := runtimeHerdrSnapshotFor(sessionName, workspaceID, tabID, paneID, "")
+	snapshot.Panes[0].Metadata[multiplexer.HerdrPaneContextIDMetadataKey] = "ctx-pane-old"
+	client := &fakeRuntimeHerdrClient{snapshot: snapshot}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = runtimeHerdrConfigFor(sessionName, workspaceID)
+	cfg.Herdr.SocketPath = socketPath
+	cfg.Herdr.AllowedSocketPaths = []string{socketPath}
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+	nodes, _, err := rt.Discover(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	rt.ReconcileFinalNodes(nodes)
+	ownershipBackend := rt.OwnershipBackend()
+
+	for _, tt := range []struct {
+		name    string
+		runtime multiplexer.HerdrRuntimeIdentity
+	}{
+		{
+			name: "socket",
+			runtime: multiplexer.HerdrRuntimeIdentity{
+				SocketPath:  "/tmp/herdr-missing.sock",
+				SessionName: sessionName,
+				WorkspaceID: workspaceID,
+				TabID:       tabID,
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "session",
+			runtime: multiplexer.HerdrRuntimeIdentity{
+				SessionName: "missing",
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "workspace",
+			runtime: multiplexer.HerdrRuntimeIdentity{
+				SocketPath:  socketPath,
+				SessionName: sessionName,
+				WorkspaceID: "missing",
+				TabID:       tabID,
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "tab",
+			runtime: multiplexer.HerdrRuntimeIdentity{
+				TabID:  "missing-tab",
+				PaneID: paneID,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client.setPaneMetadataPane = ""
+			client.setPaneMetadataValue = ""
+			client.clearPaneMetadataPane = ""
+			client.clearPaneMetadataKey = ""
+			pane := multiplexer.HerdrPaneIDForRuntime(tt.runtime, paneID)
+			if _, err := ownershipBackend.PaneOwnerMarker(context.Background(), pane); err == nil {
+				t.Fatal("PaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if err := ownershipBackend.SetPaneOwnerMarker(context.Background(), pane, "ctx-new"); err == nil {
+				t.Fatal("SetPaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if err := ownershipBackend.ClearPaneOwnerMarker(context.Background(), pane); err == nil {
+				t.Fatal("ClearPaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if client.setPaneMetadataPane != "" || client.clearPaneMetadataPane != "" {
+				t.Fatalf("qualified miss mutated pane metadata set/clear=%q/%q", client.setPaneMetadataPane, client.clearPaneMetadataPane)
+			}
+		})
+	}
+}
+
 func TestRuntimeHerdrOwnershipRegistrySkipsEmptyDuplicateAndTeardown(t *testing.T) {
 	baseDir := t.TempDir()
 	contextID := "ctx-main"
@@ -1739,10 +1920,12 @@ type fakeRuntimeHerdrClient struct {
 	sendKeyCalls   int
 	sendKeyKey     string
 
-	setPaneMetadataPane  string
-	setPaneMetadataKey   string
-	setPaneMetadataValue string
-	setPaneMetadataErr   error
+	setPaneMetadataPane   string
+	setPaneMetadataKey    string
+	setPaneMetadataValue  string
+	setPaneMetadataErr    error
+	clearPaneMetadataPane string
+	clearPaneMetadataKey  string
 
 	setWorkspaceMetadataWorkspace   string
 	setWorkspaceMetadataValue       string
@@ -1817,7 +2000,9 @@ func (f *fakeRuntimeHerdrClient) SetPaneMetadata(_ context.Context, paneID strin
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 
-func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(_ context.Context, paneID string, key string) (multiplexer.HerdrWriteResult, error) {
+	f.clearPaneMetadataPane = paneID
+	f.clearPaneMetadataKey = key
 	return multiplexer.HerdrWriteResult{Envelope: multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}}, nil
 }
 

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -618,6 +619,107 @@ func TestRuntimeDiscoveryErrorDoesNotClearNewerSuccessfulRoutes(t *testing.T) {
 	if _, err := controlplane.DefaultHandAdapter(newTarget); err != nil {
 		t.Fatalf("newer Herdr adapter was cleared by stale older error: %v", err)
 	}
+}
+
+func TestRuntimeTokenlessDiscoverFailsClosedWhenGenerationIsLost(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	oldCall := newControlledRuntimeSnapshot(runtimeHerdrSnapshotFor(sessionName, "workspace-1", "workspace-1:tab-1", "workspace-1:pane-old", ""), nil)
+	newCall := newControlledRuntimeSnapshot(runtimeHerdrSnapshotFor(sessionName, "workspace-1", "workspace-1:tab-1", "workspace-1:pane-new", ""), nil)
+	client := &sequencedRuntimeHerdrClient{calls: make(chan *controlledRuntimeSnapshot, 2)}
+	client.calls <- oldCall
+	client.calls <- newCall
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	oldDone := make(chan error, 1)
+	go func() {
+		_, _, err := rt.Discover(context.Background(), baseDir, contextID)
+		oldDone <- err
+	}()
+	<-oldCall.started
+
+	newDone := make(chan error, 1)
+	go func() {
+		_, _, err := rt.Discover(context.Background(), baseDir, contextID)
+		newDone <- err
+	}()
+	<-newCall.started
+	close(newCall.release)
+	if err := <-newDone; err != nil {
+		t.Fatalf("new Discover() error = %v", err)
+	}
+
+	close(oldCall.release)
+	if err := <-oldDone; err == nil || !strings.Contains(err.Error(), "stale Herdr discovery token") {
+		t.Fatalf("old Discover() error = %v, want stale token", err)
+	}
+}
+
+func TestRuntimeFinalReconcilePublishesBeforeCompetingDiscoveryCanAdvance(t *testing.T) {
+	baseDir := t.TempDir()
+	contextID := "ctx-main"
+	sessionName := "work"
+	if err := config.CreateSessionDirs(filepath.Join(baseDir, contextID, sessionName)); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+
+	client := &fakeRuntimeHerdrClient{snapshot: validRuntimeHerdrSnapshot()}
+	cfg := config.DefaultConfig()
+	cfg.Herdr = validRuntimeHerdrConfig()
+	rt, err := herdrruntime.New(cfg, func(config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(rt.Close)
+
+	nodes, _, token, err := rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+	if err != nil {
+		t.Fatalf("DiscoverForReconcile() error = %v", err)
+	}
+	competingStarted := make(chan struct{})
+	releaseCompeting := make(chan struct{})
+	published := false
+	err = rt.ReconcileFinalNodesForTokenAndPublish(token, nodes, func() error {
+		client.snapshotStarted = competingStarted
+		client.releaseSnapshot = releaseCompeting
+		go func() {
+			_, _, _, _ = rt.DiscoverForReconcile(context.Background(), baseDir, contextID)
+		}()
+		select {
+		case <-competingStarted:
+			t.Fatal("competing discovery advanced before final snapshot publication")
+		case <-time.After(20 * time.Millisecond):
+		}
+		published = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ReconcileFinalNodesForTokenAndPublish() error = %v", err)
+	}
+	if !published {
+		t.Fatal("publish callback was not called")
+	}
+	select {
+	case <-competingStarted:
+	case <-time.After(time.Second):
+		t.Fatal("competing discovery did not advance after final publication")
+	}
+	close(releaseCompeting)
 }
 
 func TestRuntimeCloseWhileDiscoverBlockedDoesNotRegisterRoutes(t *testing.T) {

--- a/internal/herdrruntime/runtime_test.go
+++ b/internal/herdrruntime/runtime_test.go
@@ -2068,11 +2068,10 @@ func (f *fakeRuntimeHerdrClient) ClearPaneMetadata(_ context.Context, paneID str
 }
 
 type transactionOwnershipBackend struct {
-	kind           multiplexer.BackendKind
-	sessionMarkers map[string]string
-	paneMarkers    map[string]string
-	failSetFor     string
-	failSetErr     error
+	kind        multiplexer.BackendKind
+	paneMarkers map[string]string
+	failSetFor  string
+	failSetErr  error
 }
 
 func (b *transactionOwnershipBackend) Kind() multiplexer.BackendKind {

--- a/internal/herdrruntime/socket_client.go
+++ b/internal/herdrruntime/socket_client.go
@@ -1,0 +1,404 @@
+package herdrruntime
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+
+	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+)
+
+type socketClient struct {
+	socketPath string
+	nextID     atomic.Int64
+}
+
+type socketRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int64       `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type socketResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *socketError    `json:"error,omitempty"`
+}
+
+type socketError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func NewSocketClient(cfg config.HerdrConfig) (multiplexer.HerdrReadClient, error) {
+	socketPath := strings.TrimSpace(cfg.SocketPath)
+	if socketPath == "" {
+		return nil, fmt.Errorf("%w: herdr socket_path is empty", multiplexer.ErrHerdrBackendUnavailable)
+	}
+	return &socketClient{socketPath: socketPath}, nil
+}
+
+func (c *socketClient) Ping(ctx context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	result, err := c.call(ctx, "ping", nil)
+	if err != nil {
+		return multiplexer.HerdrResponseEnvelope{}, err
+	}
+	return decodeHerdrEnvelope(result)
+}
+
+func (c *socketClient) SessionSnapshot(ctx context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	result, err := c.call(ctx, "session.snapshot", nil)
+	if err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, err
+	}
+	return decodeHerdrSessionSnapshot(result)
+}
+
+func (c *socketClient) ReadPane(ctx context.Context, paneID string, opts multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	result, err := c.call(ctx, "pane.read", map[string]interface{}{
+		"pane_id":    paneID,
+		"paneId":     paneID,
+		"source":     opts.Source,
+		"tail_lines": opts.TailLines,
+		"tailLines":  opts.TailLines,
+	})
+	if err != nil {
+		return multiplexer.HerdrPaneReadResult{}, err
+	}
+	var raw struct {
+		Envelope multiplexer.HerdrResponseEnvelope `json:"envelope"`
+		Text     string                            `json:"text"`
+		Content  string                            `json:"content"`
+		Output   string                            `json:"output"`
+	}
+	_ = json.Unmarshal(result, &raw)
+	envelope, err := decodeHerdrEnvelope(result)
+	if err != nil {
+		return multiplexer.HerdrPaneReadResult{}, err
+	}
+	text := raw.Text
+	if text == "" {
+		text = raw.Content
+	}
+	if text == "" {
+		text = raw.Output
+	}
+	return multiplexer.HerdrPaneReadResult{Envelope: envelope, Text: text}, nil
+}
+
+func (c *socketClient) PaneProcessInfo(ctx context.Context, paneID string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	result, err := c.call(ctx, "pane.process_info", map[string]interface{}{"pane_id": paneID, "paneId": paneID})
+	if err != nil {
+		return multiplexer.HerdrPaneProcessInfoResult{}, err
+	}
+	var raw struct {
+		ProcessInfo      rawHerdrProcessInfo              `json:"process_info"`
+		ProcessInfoCamel multiplexer.HerdrPaneProcessInfo `json:"processInfo"`
+	}
+	_ = json.Unmarshal(result, &raw)
+	envelope, err := decodeHerdrEnvelope(result)
+	if err != nil {
+		return multiplexer.HerdrPaneProcessInfoResult{}, err
+	}
+	info := raw.ProcessInfo.toSnapshot()
+	if len(info.ForegroundProcesses) == 0 {
+		info = raw.ProcessInfoCamel
+	}
+	return multiplexer.HerdrPaneProcessInfoResult{Envelope: envelope, ProcessInfo: info}, nil
+}
+
+func (c *socketClient) WritePaneText(ctx context.Context, paneID string, text string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "pane.send_text", map[string]interface{}{"pane_id": paneID, "text": text})
+}
+
+func (c *socketClient) SendPaneKey(ctx context.Context, paneID string, key string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "pane.send_keys", map[string]interface{}{"pane_id": paneID, "keys": []string{key}})
+}
+
+func (c *socketClient) SetWorkspaceMetadata(ctx context.Context, workspaceID string, key string, value string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "workspace.report_metadata", map[string]interface{}{"workspace_id": workspaceID, "source": "tmux-a2a-postman", "tokens": map[string]interface{}{key: value}})
+}
+
+func (c *socketClient) ClearWorkspaceMetadata(ctx context.Context, workspaceID string, key string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "workspace.report_metadata", map[string]interface{}{"workspace_id": workspaceID, "source": "tmux-a2a-postman", "tokens": map[string]interface{}{key: nil}})
+}
+
+func (c *socketClient) SetPaneMetadata(ctx context.Context, paneID string, key string, value string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "pane.report_metadata", map[string]interface{}{"pane_id": paneID, "source": "tmux-a2a-postman", "tokens": map[string]interface{}{key: value}})
+}
+
+func (c *socketClient) ClearPaneMetadata(ctx context.Context, paneID string, key string) (multiplexer.HerdrWriteResult, error) {
+	return c.write(ctx, "pane.report_metadata", map[string]interface{}{"pane_id": paneID, "source": "tmux-a2a-postman", "tokens": map[string]interface{}{key: nil}})
+}
+
+func (c *socketClient) write(ctx context.Context, method string, params interface{}) (multiplexer.HerdrWriteResult, error) {
+	result, err := c.call(ctx, method, params)
+	if err != nil {
+		return multiplexer.HerdrWriteResult{}, err
+	}
+	envelope, err := decodeHerdrEnvelope(result)
+	if err != nil {
+		return multiplexer.HerdrWriteResult{}, err
+	}
+	return multiplexer.HerdrWriteResult{Envelope: envelope}, nil
+}
+
+func (c *socketClient) call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", c.socketPath)
+	if err != nil {
+		return nil, multiplexer.NormalizeHerdrBackendError(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	id := c.nextID.Add(1)
+	request := socketRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	payload = append(payload, '\n')
+	if _, err := conn.Write(payload); err != nil {
+		return nil, multiplexer.NormalizeHerdrBackendError(err)
+	}
+
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil {
+		return nil, multiplexer.NormalizeHerdrBackendError(err)
+	}
+	var response socketResponse
+	if err := json.Unmarshal(bytes.TrimSpace(line), &response); err != nil {
+		return nil, fmt.Errorf("%w: invalid herdr socket response: %v", multiplexer.ErrHerdrBackendUnavailable, err)
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("herdr socket method %s failed: %s", method, response.Error.Message)
+	}
+	return response.Result, nil
+}
+
+func decodeHerdrEnvelope(raw json.RawMessage) (multiplexer.HerdrResponseEnvelope, error) {
+	var decoded struct {
+		Envelope        multiplexer.HerdrResponseEnvelope `json:"envelope"`
+		ProtocolVersion string                            `json:"protocol_version"`
+		ProtocolCamel   string                            `json:"protocolVersion"`
+		SchemaVersion   int                               `json:"schema_version"`
+		SchemaCamel     int                               `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return multiplexer.HerdrResponseEnvelope{}, err
+	}
+	envelope := decoded.Envelope
+	if envelope.ProtocolVersion == "" {
+		envelope.ProtocolVersion = decoded.ProtocolVersion
+	}
+	if envelope.ProtocolVersion == "" {
+		envelope.ProtocolVersion = decoded.ProtocolCamel
+	}
+	if envelope.SchemaVersion == 0 {
+		envelope.SchemaVersion = decoded.SchemaVersion
+	}
+	if envelope.SchemaVersion == 0 {
+		envelope.SchemaVersion = decoded.SchemaCamel
+	}
+	return envelope, nil
+}
+
+func decodeHerdrSessionSnapshot(raw json.RawMessage) (multiplexer.HerdrSessionSnapshot, error) {
+	var wrapper struct {
+		Snapshot json.RawMessage `json:"snapshot"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, err
+	}
+	source := raw
+	if len(wrapper.Snapshot) > 0 && string(wrapper.Snapshot) != "null" {
+		source = wrapper.Snapshot
+	}
+	snapshot, err := decodeHerdrSessionSnapshotObject(source)
+	if err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, err
+	}
+	if snapshot.Envelope.ProtocolVersion == "" && snapshot.Envelope.SchemaVersion == 0 {
+		envelope, err := decodeHerdrEnvelope(raw)
+		if err != nil {
+			return multiplexer.HerdrSessionSnapshot{}, err
+		}
+		snapshot.Envelope = envelope
+	}
+	return snapshot, nil
+}
+
+func decodeHerdrSessionSnapshotObject(raw json.RawMessage) (multiplexer.HerdrSessionSnapshot, error) {
+	var decoded struct {
+		Envelope           multiplexer.HerdrResponseEnvelope `json:"envelope"`
+		FocusedWorkspaceID string                            `json:"focused_workspace_id"`
+		FocusedWorkspace   string                            `json:"focusedWorkspaceID"`
+		FocusedTabID       string                            `json:"focused_tab_id"`
+		FocusedTab         string                            `json:"focusedTabID"`
+		FocusedPaneID      string                            `json:"focused_pane_id"`
+		FocusedPane        string                            `json:"focusedPaneID"`
+		Workspaces         []rawHerdrWorkspace               `json:"workspaces"`
+		Tabs               []rawHerdrTab                     `json:"tabs"`
+		Panes              []rawHerdrPane                    `json:"panes"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return multiplexer.HerdrSessionSnapshot{}, err
+	}
+	snapshot := multiplexer.HerdrSessionSnapshot{
+		Envelope:           decoded.Envelope,
+		FocusedWorkspaceID: firstNonEmpty(decoded.FocusedWorkspaceID, decoded.FocusedWorkspace),
+		FocusedTabID:       firstNonEmpty(decoded.FocusedTabID, decoded.FocusedTab),
+		FocusedPaneID:      firstNonEmpty(decoded.FocusedPaneID, decoded.FocusedPane),
+	}
+	for _, workspace := range decoded.Workspaces {
+		snapshot.Workspaces = append(snapshot.Workspaces, workspace.toSnapshot())
+	}
+	for _, tab := range decoded.Tabs {
+		snapshot.Tabs = append(snapshot.Tabs, tab.toSnapshot())
+	}
+	for _, pane := range decoded.Panes {
+		snapshot.Panes = append(snapshot.Panes, pane.toSnapshot())
+	}
+	return snapshot, nil
+}
+
+type rawHerdrWorkspace struct {
+	ID       string            `json:"id"`
+	Label    string            `json:"label"`
+	Metadata map[string]string `json:"metadata"`
+	Tokens   map[string]string `json:"tokens"`
+}
+
+func (w rawHerdrWorkspace) toSnapshot() multiplexer.HerdrWorkspaceSnapshot {
+	return multiplexer.HerdrWorkspaceSnapshot{ID: w.ID, Label: w.Label, Metadata: mergeMetadataTokens(w.Metadata, w.Tokens)}
+}
+
+type rawHerdrTab struct {
+	ID          string            `json:"id"`
+	WorkspaceID string            `json:"workspace_id"`
+	Workspace   string            `json:"workspaceId"`
+	Label       string            `json:"label"`
+	Order       int               `json:"order"`
+	Metadata    map[string]string `json:"metadata"`
+	Tokens      map[string]string `json:"tokens"`
+}
+
+func (t rawHerdrTab) toSnapshot() multiplexer.HerdrTabSnapshot {
+	return multiplexer.HerdrTabSnapshot{
+		ID:          t.ID,
+		WorkspaceID: firstNonEmpty(t.WorkspaceID, t.Workspace),
+		Label:       t.Label,
+		Order:       t.Order,
+		Metadata:    mergeMetadataTokens(t.Metadata, t.Tokens),
+	}
+}
+
+type rawHerdrPane struct {
+	ID             string                           `json:"id"`
+	WorkspaceID    string                           `json:"workspace_id"`
+	Workspace      string                           `json:"workspaceId"`
+	TabID          string                           `json:"tab_id"`
+	Tab            string                           `json:"tabId"`
+	Label          string                           `json:"label"`
+	Order          int                              `json:"order"`
+	Metadata       map[string]string                `json:"metadata"`
+	Tokens         map[string]string                `json:"tokens"`
+	Env            map[string]string                `json:"env"`
+	ProcessInfo    rawHerdrProcessInfo              `json:"process_info"`
+	ProcessInfoAlt multiplexer.HerdrPaneProcessInfo `json:"processInfo"`
+	AgentStatus    string                           `json:"agent_status"`
+	AgentStatusAlt string                           `json:"agentStatus"`
+	TerminalTitle  string                           `json:"terminal_title"`
+	TerminalAlt    string                           `json:"terminalTitle"`
+	ForegroundCWD  string                           `json:"foreground_cwd"`
+	ForegroundAlt  string                           `json:"foregroundCWD"`
+	Stale          bool                             `json:"stale"`
+	StaleReason    string                           `json:"stale_reason"`
+	StaleAlt       string                           `json:"staleReason"`
+	PostmanNode    string                           `json:"postman_node"`
+	PostmanNodeAlt string                           `json:"postmanNode"`
+	PostmanSession string                           `json:"postman_session"`
+	PostmanSessAlt string                           `json:"postmanSession"`
+}
+
+func (p rawHerdrPane) toSnapshot() multiplexer.HerdrPaneSnapshot {
+	processInfo := p.ProcessInfo.toSnapshot()
+	if len(processInfo.ForegroundProcesses) == 0 {
+		processInfo = p.ProcessInfoAlt
+	}
+	return multiplexer.HerdrPaneSnapshot{
+		ID:             p.ID,
+		WorkspaceID:    firstNonEmpty(p.WorkspaceID, p.Workspace),
+		TabID:          firstNonEmpty(p.TabID, p.Tab),
+		Label:          p.Label,
+		Order:          p.Order,
+		Metadata:       mergeMetadataTokens(p.Metadata, p.Tokens),
+		Env:            p.Env,
+		ProcessInfo:    processInfo,
+		AgentStatus:    firstNonEmpty(p.AgentStatus, p.AgentStatusAlt),
+		TerminalTitle:  firstNonEmpty(p.TerminalTitle, p.TerminalAlt),
+		ForegroundCWD:  firstNonEmpty(p.ForegroundCWD, p.ForegroundAlt),
+		Stale:          p.Stale,
+		StaleReason:    firstNonEmpty(p.StaleReason, p.StaleAlt),
+		PostmanNode:    firstNonEmpty(p.PostmanNode, p.PostmanNodeAlt),
+		PostmanSession: firstNonEmpty(p.PostmanSession, p.PostmanSessAlt),
+	}
+}
+
+func mergeMetadataTokens(metadata, tokens map[string]string) map[string]string {
+	if len(tokens) == 0 {
+		return metadata
+	}
+	merged := make(map[string]string, len(metadata)+len(tokens))
+	for key, value := range metadata {
+		merged[key] = value
+	}
+	for key, value := range tokens {
+		merged[key] = value
+	}
+	return merged
+}
+
+type rawHerdrProcessInfo struct {
+	ShellPID               int                            `json:"shell_pid"`
+	ShellPIDAlt            int                            `json:"shellPID"`
+	ForegroundProcessID    int                            `json:"foreground_process_id"`
+	ForegroundProcessIDAlt int                            `json:"foregroundProcessID"`
+	ForegroundProcesses    []multiplexer.HerdrProcessInfo `json:"foreground_processes"`
+	ForegroundProcessesAlt []multiplexer.HerdrProcessInfo `json:"foregroundProcesses"`
+}
+
+func (p rawHerdrProcessInfo) toSnapshot() multiplexer.HerdrPaneProcessInfo {
+	info := multiplexer.HerdrPaneProcessInfo{
+		ShellPID:            p.ShellPID,
+		ForegroundProcessID: p.ForegroundProcessID,
+		ForegroundProcesses: p.ForegroundProcesses,
+	}
+	if info.ShellPID == 0 {
+		info.ShellPID = p.ShellPIDAlt
+	}
+	if info.ForegroundProcessID == 0 {
+		info.ForegroundProcessID = p.ForegroundProcessIDAlt
+	}
+	if len(info.ForegroundProcesses) == 0 {
+		info.ForegroundProcesses = p.ForegroundProcessesAlt
+	}
+	return info
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/herdrruntime/socket_client.go
+++ b/internal/herdrruntime/socket_client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
 	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
@@ -18,6 +19,8 @@ type socketClient struct {
 	socketPath string
 	nextID     atomic.Int64
 }
+
+const defaultSocketCallTimeout = 5 * time.Second
 
 type socketRequest struct {
 	JSONRPC string      `json:"jsonrpc"`
@@ -153,11 +156,33 @@ func (c *socketClient) write(ctx context.Context, method string, params interfac
 }
 
 func (c *socketClient) call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
-	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", c.socketPath)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	callCtx := ctx
+	cancel := func() {}
+	if _, hasDeadline := callCtx.Deadline(); !hasDeadline {
+		callCtx, cancel = context.WithTimeout(callCtx, defaultSocketCallTimeout)
+	}
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(callCtx, "unix", c.socketPath)
 	if err != nil {
-		return nil, multiplexer.NormalizeHerdrBackendError(err)
+		return nil, normalizeSocketCallError(callCtx, err)
 	}
 	defer func() { _ = conn.Close() }()
+	if deadline, ok := callCtx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-callCtx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
 
 	id := c.nextID.Add(1)
 	request := socketRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}
@@ -167,12 +192,12 @@ func (c *socketClient) call(ctx context.Context, method string, params interface
 	}
 	payload = append(payload, '\n')
 	if _, err := conn.Write(payload); err != nil {
-		return nil, multiplexer.NormalizeHerdrBackendError(err)
+		return nil, normalizeSocketCallError(callCtx, err)
 	}
 
 	line, err := bufio.NewReader(conn).ReadBytes('\n')
 	if err != nil {
-		return nil, multiplexer.NormalizeHerdrBackendError(err)
+		return nil, normalizeSocketCallError(callCtx, err)
 	}
 	var response socketResponse
 	if err := json.Unmarshal(bytes.TrimSpace(line), &response); err != nil {
@@ -182,6 +207,13 @@ func (c *socketClient) call(ctx context.Context, method string, params interface
 		return nil, fmt.Errorf("herdr socket method %s failed: %s", method, response.Error.Message)
 	}
 	return response.Result, nil
+}
+
+func normalizeSocketCallError(ctx context.Context, err error) error {
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return multiplexer.NormalizeHerdrBackendError(err)
 }
 
 func decodeHerdrEnvelope(raw json.RawMessage) (multiplexer.HerdrResponseEnvelope, error) {

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -16,6 +17,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/idle"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
+	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 )
 
@@ -1816,6 +1818,51 @@ func TestDeliverNotificationWithRetry_RetryUsesRefreshedPaneID(t *testing.T) {
 	}
 }
 
+func TestDeliverSystemMessageDirectResultUsesRegisteredHerdrDelivery(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "session")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs() error = %v", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.NotificationTemplate = "notice {node}"
+	cfg.EnterDelay = 0
+	cfg.TmuxTimeout = 0
+	cfg.Nodes = map[string]config.NodeConfig{"worker": {}}
+	nodeInfo := discovery.NodeInfo{
+		PaneID:      "workspace-1:pane-1",
+		SessionName: "work",
+		SessionDir:  sessionDir,
+		Backend:     string(multiplexer.BackendKindHerdr),
+		Runtime:     "codex",
+	}
+	client := &fakeHerdrMessageWriteClient{snapshot: validHerdrMessageSnapshot()}
+	unregister := controlplane.RegisterHerdrHandAdapter("workspace-1:pane-1", controlplane.HerdrHandAdapter{
+		HerdrInteractiveDeliveryAdapter: controlplane.HerdrInteractiveDeliveryAdapter{
+			Backend: multiplexer.HerdrBackend{
+				Config: validHerdrMessageConfig(),
+				Client: client,
+			},
+		},
+	})
+	t.Cleanup(unregister)
+
+	result, err := DeliverSystemMessageDirectResult("20260414-120000-r1234-from-postman-to-worker.md", nodeInfo, "worker", "postman", "ctx-1", "body", cfg, nil, map[string]discovery.NodeInfo{
+		"work:worker": nodeInfo,
+	}, nil)
+	if err != nil {
+		t.Fatalf("DeliverSystemMessageDirectResult() error = %v", err)
+	}
+	if !result.Delivered {
+		t.Fatal("DeliverSystemMessageDirectResult() delivered = false, want true")
+	}
+	if client.writeTextCalls != 1 || client.writeTextPane != "workspace-1:pane-1" {
+		t.Fatalf("Herdr write calls = %d pane=%q, want notification delivered through registered Herdr adapter", client.writeTextCalls, client.writeTextPane)
+	}
+	if client.sendKeyCalls != 2 || client.sendKeyKey != multiplexer.HerdrKeySubmit {
+		t.Fatalf("Herdr key calls = %d key=%q, want Codex default submit count", client.sendKeyCalls, client.sendKeyKey)
+	}
+}
+
 // TestDeliverNotificationWithRetry_BothAttemptsFail_LogsWarning verifies that
 // when both delivery attempts fail, a WARNING is logged with node, pane, and session.
 func TestDeliverNotificationWithRetry_BothAttemptsFail_LogsWarning(t *testing.T) {
@@ -1857,4 +1904,112 @@ func TestDeliverNotificationWithRetry_BothAttemptsFail_LogsWarning(t *testing.T)
 	if !strings.Contains(logOut, "msg=test-fail.md") {
 		t.Errorf("expected msg= in WARNING, got: %s", logOut)
 	}
+}
+
+type fakeHerdrMessageWriteClient struct {
+	snapshot multiplexer.HerdrSessionSnapshot
+
+	writeTextCalls int
+	writeTextPane  string
+	writeTextText  string
+	sendKeyCalls   int
+	sendKeyPane    string
+	sendKeyKey     string
+}
+
+func (f *fakeHerdrMessageWriteClient) Ping(context.Context) (multiplexer.HerdrResponseEnvelope, error) {
+	return validHerdrMessageEnvelope(), nil
+}
+
+func (f *fakeHerdrMessageWriteClient) SessionSnapshot(context.Context) (multiplexer.HerdrSessionSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) ReadPane(context.Context, string, multiplexer.HerdrPaneReadOptions) (multiplexer.HerdrPaneReadResult, error) {
+	return multiplexer.HerdrPaneReadResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) PaneProcessInfo(context.Context, string) (multiplexer.HerdrPaneProcessInfoResult, error) {
+	return multiplexer.HerdrPaneProcessInfoResult{
+		Envelope: validHerdrMessageEnvelope(),
+		ProcessInfo: multiplexer.HerdrPaneProcessInfo{
+			ForegroundProcesses: []multiplexer.HerdrProcessInfo{{Name: "codex"}},
+		},
+	}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) WritePaneText(_ context.Context, paneID string, text string) (multiplexer.HerdrWriteResult, error) {
+	f.writeTextCalls++
+	f.writeTextPane = paneID
+	f.writeTextText = text
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) SendPaneKey(_ context.Context, paneID string, key string) (multiplexer.HerdrWriteResult, error) {
+	f.sendKeyCalls++
+	f.sendKeyPane = paneID
+	f.sendKeyKey = key
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) SetWorkspaceMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) ClearWorkspaceMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) SetPaneMetadata(context.Context, string, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func (f *fakeHerdrMessageWriteClient) ClearPaneMetadata(context.Context, string, string) (multiplexer.HerdrWriteResult, error) {
+	return multiplexer.HerdrWriteResult{Envelope: validHerdrMessageEnvelope()}, nil
+}
+
+func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
+	return multiplexer.HerdrReadConfig{
+		Enabled: true,
+		Runtime: multiplexer.HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-1",
+			TabID:       "workspace-1:tab-1",
+			PaneID:      "workspace-1:pane-1",
+		},
+		Policy: multiplexer.HerdrGatePolicy{
+			ReadEnabled:             true,
+			WriteEnabled:            true,
+			AllowedSocketPaths:      []string{"/tmp/herdr.sock"},
+			AllowedSessions:         []string{"work"},
+			AllowedWorkspaceIDs:     []string{"workspace-1"},
+			AllowedProtocolVersions: []string{"1"},
+			AllowedSchemaVersions:   []int{1},
+			InputSanitizerReady:     true,
+			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
+		},
+	}
+}
+
+func validHerdrMessageSnapshot() multiplexer.HerdrSessionSnapshot {
+	return multiplexer.HerdrSessionSnapshot{
+		Envelope: validHerdrMessageEnvelope(),
+		Workspaces: []multiplexer.HerdrWorkspaceSnapshot{{
+			ID: "workspace-1",
+		}},
+		Tabs: []multiplexer.HerdrTabSnapshot{{
+			ID:          "workspace-1:tab-1",
+			WorkspaceID: "workspace-1",
+		}},
+		Panes: []multiplexer.HerdrPaneSnapshot{{
+			ID:          "workspace-1:pane-1",
+			WorkspaceID: "workspace-1",
+			TabID:       "workspace-1:tab-1",
+		}},
+	}
+}
+
+func validHerdrMessageEnvelope() multiplexer.HerdrResponseEnvelope {
+	return multiplexer.HerdrResponseEnvelope{ProtocolVersion: "1", SchemaVersion: 1}
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1988,6 +1988,7 @@ func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionCommercial, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
 		},
 	}
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1969,6 +1969,7 @@ func (f *fakeHerdrMessageWriteClient) ClearPaneMetadata(context.Context, string,
 }
 
 func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
+	now := time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC)
 	return multiplexer.HerdrReadConfig{
 		Enabled: true,
 		Runtime: multiplexer.HerdrRuntimeIdentity{
@@ -1988,8 +1989,8 @@ func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionRecorded,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), RevalidatedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), CurrentReferences: []string{"test"}},
-			ComplianceNow:           func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: now.Add(-time.Hour), RevalidatedAt: now, CurrentReferences: []string{"test"}},
+			ComplianceNow:           func() time.Time { return now },
 		},
 	}
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1987,8 +1987,9 @@ func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
 			AllowedProtocolVersions: []string{"1"},
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
-			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"test"}},
+			ComplianceDecision:      multiplexer.HerdrComplianceDecisionRecorded,
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), RevalidatedAt: time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC), CurrentReferences: []string{"test"}},
+			ComplianceNow:           func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
 		},
 	}
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1988,7 +1988,7 @@ func validHerdrMessageConfig() multiplexer.HerdrReadConfig {
 			AllowedSchemaVersions:   []int{1},
 			InputSanitizerReady:     true,
 			ComplianceDecision:      multiplexer.HerdrComplianceDecisionCommercial,
-			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionCommercial, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now()},
+			ComplianceRecord:        multiplexer.HerdrComplianceRecord{Decision: multiplexer.HerdrComplianceDecisionRecorded, AuthorizedBy: "test", DecisionID: "test", DecidedAt: time.Now(), RevalidatedAt: time.Now(), CurrentReferences: []string{"test"}},
 		},
 	}
 }

--- a/internal/multiplexer/backend.go
+++ b/internal/multiplexer/backend.go
@@ -27,9 +27,10 @@ const (
 )
 
 type ResourceID struct {
-	Backend BackendKind
-	Kind    ResourceKind
-	Native  string
+	Backend      BackendKind
+	Kind         ResourceKind
+	Native       string
+	HerdrRuntime HerdrRuntimeIdentity
 }
 
 func TmuxPaneID(paneID string) ResourceID {

--- a/internal/multiplexer/herdr_gate.go
+++ b/internal/multiplexer/herdr_gate.go
@@ -278,6 +278,13 @@ func HerdrPaneID(paneID string) ResourceID {
 	return ResourceID{Backend: BackendKindHerdr, Kind: ResourceKindPane, Native: paneID}
 }
 
+func HerdrPaneIDForRuntime(runtime HerdrRuntimeIdentity, paneID string) ResourceID {
+	if runtime.PaneID == "" {
+		runtime.PaneID = paneID
+	}
+	return ResourceID{Backend: BackendKindHerdr, Kind: ResourceKindPane, Native: paneID, HerdrRuntime: runtime}
+}
+
 func HerdrWorkspaceID(workspaceID string) ResourceID {
 	return ResourceID{Backend: BackendKindHerdr, Kind: ResourceKindWorkspace, Native: workspaceID}
 }

--- a/internal/multiplexer/herdr_gate.go
+++ b/internal/multiplexer/herdr_gate.go
@@ -140,6 +140,27 @@ func ValidateHerdrWriteGate(policy HerdrGatePolicy, runtime HerdrRuntimeIdentity
 	return nil
 }
 
+func validateHerdrWorkspaceWriteGate(policy HerdrGatePolicy, runtime HerdrRuntimeIdentity, envelope HerdrResponseEnvelope) error {
+	if !policy.WriteEnabled {
+		return herdrGateError(HerdrAccessPhaseWrite, "", HerdrGateFailureClosed)
+	}
+	writePolicy := policy
+	writePolicy.ReadScope = HerdrReadScopeDiscovery
+	if err := validateHerdrReadGateForPhase(HerdrAccessPhaseWrite, writePolicy, runtime, envelope); err != nil {
+		return err
+	}
+	if !policy.InputSanitizerReady {
+		return herdrGateError(HerdrAccessPhaseWrite, "input_sanitizer", HerdrGateFailureSanitizerMissing)
+	}
+	if policy.ComplianceDecision != HerdrComplianceDecisionUnset && policy.ComplianceDecision != policy.ComplianceRecord.Decision {
+		return herdrGateError(HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
+	}
+	if !isCurrentHerdrComplianceRecord(policy.ComplianceRecord, policy.ComplianceNow) {
+		return herdrGateError(HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
+	}
+	return nil
+}
+
 func validateHerdrReadGateForPhase(phase HerdrAccessPhase, policy HerdrGatePolicy, runtime HerdrRuntimeIdentity, envelope HerdrResponseEnvelope) error {
 	if !policy.ReadEnabled {
 		return herdrGateError(phase, "read_enabled", HerdrGateFailureClosed)

--- a/internal/multiplexer/herdr_gate.go
+++ b/internal/multiplexer/herdr_gate.go
@@ -131,6 +131,9 @@ func ValidateHerdrWriteGate(policy HerdrGatePolicy, runtime HerdrRuntimeIdentity
 	if !policy.InputSanitizerReady {
 		return herdrGateError(HerdrAccessPhaseWrite, "input_sanitizer", HerdrGateFailureSanitizerMissing)
 	}
+	if policy.ComplianceDecision != HerdrComplianceDecisionUnset && policy.ComplianceDecision != policy.ComplianceRecord.Decision {
+		return herdrGateError(HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
+	}
 	if !isCurrentHerdrComplianceRecord(policy.ComplianceRecord, policy.ComplianceNow) {
 		return herdrGateError(HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
 	}

--- a/internal/multiplexer/herdr_gate_test.go
+++ b/internal/multiplexer/herdr_gate_test.go
@@ -311,6 +311,7 @@ func TestHerdrProtocolVersion(t *testing.T) {
 }
 
 func validHerdrGatePolicy() HerdrGatePolicy {
+	now := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
 	return HerdrGatePolicy{
 		ReadEnabled:             true,
 		WriteEnabled:            true,
@@ -325,11 +326,11 @@ func validHerdrGatePolicy() HerdrGatePolicy {
 			Decision:          HerdrComplianceDecisionRecorded,
 			AuthorizedBy:      "compliance-authority",
 			DecisionID:        "decision-001",
-			DecidedAt:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-			RevalidatedAt:     time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+			DecidedAt:         now.Add(-time.Hour),
+			RevalidatedAt:     now,
 			CurrentReferences: []string{"https://github.com/ogulcancelik/herdr/blob/master/LICENSE"},
 		},
-		ComplianceNow: func() time.Time { return time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC) },
+		ComplianceNow: func() time.Time { return now },
 	}
 }
 

--- a/internal/multiplexer/herdr_gate_test.go
+++ b/internal/multiplexer/herdr_gate_test.go
@@ -142,10 +142,20 @@ func TestValidateHerdrWriteGateRequiresWriteSpecificGates(t *testing.T) {
 	t.Run("legacy labels never authorize writes", func(t *testing.T) {
 		for _, decision := range []HerdrComplianceDecision{HerdrComplianceDecisionAGPL, HerdrComplianceDecisionCommercial} {
 			policy := validHerdrGatePolicy()
+			policy.ComplianceDecision = decision
 			policy.ComplianceRecord.Decision = decision
 			err := ValidateHerdrWriteGate(policy, validHerdrRuntime(), validHerdrEnvelope())
 			assertHerdrGateError(t, err, HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
 		}
+	})
+
+	t.Run("top-level decision mismatch never authorizes writes", func(t *testing.T) {
+		policy := validHerdrGatePolicy()
+		policy.ComplianceDecision = HerdrComplianceDecisionCommercial
+		policy.ComplianceRecord.Decision = HerdrComplianceDecisionRecorded
+
+		err := ValidateHerdrWriteGate(policy, validHerdrRuntime(), validHerdrEnvelope())
+		assertHerdrGateError(t, err, HerdrAccessPhaseWrite, "compliance_decision", HerdrGateFailureComplianceUnresolved)
 	})
 
 	t.Run("blank provenance fields never authorize writes", func(t *testing.T) {
@@ -310,6 +320,7 @@ func validHerdrGatePolicy() HerdrGatePolicy {
 		AllowedProtocolVersions: []string{"1"},
 		AllowedSchemaVersions:   []int{1},
 		InputSanitizerReady:     true,
+		ComplianceDecision:      HerdrComplianceDecisionRecorded,
 		ComplianceRecord: HerdrComplianceRecord{
 			Decision:          HerdrComplianceDecisionRecorded,
 			AuthorizedBy:      "compliance-authority",

--- a/internal/multiplexer/herdr_publication.go
+++ b/internal/multiplexer/herdr_publication.go
@@ -1,0 +1,21 @@
+package multiplexer
+
+import "sync"
+
+var herdrPublicationMu sync.RWMutex
+
+func LockHerdrPublicationRead() {
+	herdrPublicationMu.RLock()
+}
+
+func UnlockHerdrPublicationRead() {
+	herdrPublicationMu.RUnlock()
+}
+
+func LockHerdrPublicationWrite() {
+	herdrPublicationMu.Lock()
+}
+
+func UnlockHerdrPublicationWrite() {
+	herdrPublicationMu.Unlock()
+}

--- a/internal/multiplexer/herdr_publication.go
+++ b/internal/multiplexer/herdr_publication.go
@@ -2,7 +2,10 @@ package multiplexer
 
 import "sync"
 
-var herdrPublicationMu sync.RWMutex
+var (
+	herdrPublicationMu         sync.RWMutex
+	herdrPublicationGeneration uint64
+)
 
 func LockHerdrPublicationRead() {
 	herdrPublicationMu.RLock()
@@ -18,4 +21,13 @@ func LockHerdrPublicationWrite() {
 
 func UnlockHerdrPublicationWrite() {
 	herdrPublicationMu.Unlock()
+}
+
+func HerdrPublicationGenerationLocked() uint64 {
+	return herdrPublicationGeneration
+}
+
+func AdvanceHerdrPublicationGenerationLocked() uint64 {
+	herdrPublicationGeneration++
+	return herdrPublicationGeneration
 }

--- a/internal/multiplexer/herdr_read.go
+++ b/internal/multiplexer/herdr_read.go
@@ -121,8 +121,9 @@ type HerdrDiscoveryResult struct {
 }
 
 type HerdrBackend struct {
-	Config HerdrReadConfig
-	Client HerdrReadClient
+	Config         HerdrReadConfig
+	Client         HerdrReadClient
+	InputSanitizer HerdrInputSanitizer
 }
 
 func NewHerdrBackend(config HerdrReadConfig, client HerdrReadClient) (HerdrBackend, error) {

--- a/internal/multiplexer/herdr_read.go
+++ b/internal/multiplexer/herdr_read.go
@@ -277,17 +277,17 @@ func (b HerdrBackend) validatePaneContainment(snapshot HerdrSessionSnapshot, tab
 			continue
 		}
 		if pane.WorkspaceID != b.Config.Runtime.WorkspaceID {
-			return fmt.Errorf("%w: pane %q is in workspace %q, want %q", ErrHerdrSnapshotInvalid, pane.ID, pane.WorkspaceID, b.Config.Runtime.WorkspaceID)
+			continue
 		}
 		if pane.TabID != tabID {
-			return fmt.Errorf("%w: pane %q is in tab %q, want %q", ErrHerdrSnapshotInvalid, pane.ID, pane.TabID, tabID)
+			continue
 		}
 		if pane.Stale {
 			return fmt.Errorf("%w: pane %q is stale: %s", ErrHerdrSnapshotInvalid, pane.ID, pane.StaleReason)
 		}
 		return nil
 	}
-	return fmt.Errorf("%w: pane %q is not in latest snapshot", ErrHerdrSnapshotInvalid, paneID)
+	return fmt.Errorf("%w: pane %q is not in configured workspace %q tab %q", ErrHerdrSnapshotInvalid, paneID, b.Config.Runtime.WorkspaceID, tabID)
 }
 
 func (b HerdrBackend) discoveryFromSnapshot(sessionName string, snapshot HerdrSessionSnapshot) (HerdrDiscoveryResult, error) {

--- a/internal/multiplexer/herdr_write.go
+++ b/internal/multiplexer/herdr_write.go
@@ -1,0 +1,287 @@
+package multiplexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	HerdrKeyEnter                 = "Enter"
+	HerdrSessionOwnerMetadataKey  = "postman.session_owner"
+	HerdrPaneContextIDMetadataKey = "postman.context_id"
+)
+
+var (
+	ErrHerdrWriteClientMissing    = errors.New("herdr write client missing")
+	ErrHerdrInputSanitizerMissing = errors.New("herdr input sanitizer missing")
+)
+
+type HerdrInputSanitizer func(string) (string, error)
+
+type HerdrWriteClient interface {
+	HerdrReadClient
+	WritePaneText(ctx context.Context, paneID string, text string) (HerdrWriteResult, error)
+	SendPaneKey(ctx context.Context, paneID string, key string) (HerdrWriteResult, error)
+	SetWorkspaceMetadata(ctx context.Context, workspaceID string, key string, value string) (HerdrWriteResult, error)
+	ClearWorkspaceMetadata(ctx context.Context, workspaceID string, key string) (HerdrWriteResult, error)
+	SetPaneMetadata(ctx context.Context, paneID string, key string, value string) (HerdrWriteResult, error)
+	ClearPaneMetadata(ctx context.Context, paneID string, key string) (HerdrWriteResult, error)
+}
+
+type HerdrPaneInput struct {
+	Text       string
+	EnterCount int
+}
+
+type HerdrWriteResult struct {
+	Envelope HerdrResponseEnvelope
+}
+
+func (b HerdrBackend) SendPaneInput(ctx context.Context, pane ResourceID, input HerdrPaneInput) error {
+	if err := b.authorizeWritePath(); err != nil {
+		return err
+	}
+	if pane.Backend != BackendKindHerdr || pane.Kind != ResourceKindPane {
+		return fmt.Errorf("herdr input requires herdr pane resource: %#v", pane)
+	}
+	if pane.Native != b.Config.Runtime.PaneID {
+		return ErrHerdrPaneTargetMismatch
+	}
+	client, err := b.writeClient()
+	if err != nil {
+		return err
+	}
+	sanitized, err := b.sanitizePaneInput(input.Text)
+	if err != nil {
+		return err
+	}
+	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+		return err
+	}
+	result, err := client.WritePaneText(ctx, pane.Native, sanitized)
+	if err != nil {
+		return NormalizeHerdrBackendError(err)
+	}
+	if err := b.validateWriteEnvelope(result.Envelope); err != nil {
+		return err
+	}
+	for range herdrSubmitEnterCount(input.EnterCount) {
+		result, err := client.SendPaneKey(ctx, pane.Native, HerdrKeyEnter)
+		if err != nil {
+			return NormalizeHerdrBackendError(err)
+		}
+		if err := b.validateWriteEnvelope(result.Envelope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b HerdrBackend) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	if err := b.authorizeReadPath(HerdrReadScopeDiscovery); err != nil {
+		return "", err
+	}
+	if sessionName != b.Config.Runtime.SessionName {
+		return "", ErrHerdrSessionNameMismatch
+	}
+	snapshot, err := b.readValidatedSnapshot(ctx, HerdrReadScopeDiscovery)
+	if err != nil {
+		return "", err
+	}
+	for _, workspace := range snapshot.Workspaces {
+		if workspace.ID == b.Config.Runtime.WorkspaceID {
+			return workspace.Metadata[HerdrSessionOwnerMetadataKey], nil
+		}
+	}
+	return "", nil
+}
+
+func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	if err := b.authorizeWritePath(); err != nil {
+		return err
+	}
+	if contextID == "" {
+		return fmt.Errorf("context ID is empty")
+	}
+	if sessionName != b.Config.Runtime.SessionName {
+		return ErrHerdrSessionNameMismatch
+	}
+	if pid <= 0 {
+		pid = os.Getpid()
+	}
+	markerValue, err := sanitizeHerdrMetadataValue(contextID + ":" + strconv.Itoa(pid))
+	if err != nil {
+		return err
+	}
+	client, err := b.writeClient()
+	if err != nil {
+		return err
+	}
+	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+		return err
+	}
+	result, err := client.SetWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, HerdrSessionOwnerMetadataKey, markerValue)
+	if err != nil {
+		return NormalizeHerdrBackendError(err)
+	}
+	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	if err := b.authorizeWritePath(); err != nil {
+		return err
+	}
+	if sessionName != b.Config.Runtime.SessionName {
+		return ErrHerdrSessionNameMismatch
+	}
+	client, err := b.writeClient()
+	if err != nil {
+		return err
+	}
+	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+		return err
+	}
+	result, err := client.ClearWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, HerdrSessionOwnerMetadataKey)
+	if err != nil {
+		return NormalizeHerdrBackendError(err)
+	}
+	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func (b HerdrBackend) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {
+	if err := b.authorizeReadPath(HerdrReadScopePane); err != nil {
+		return "", err
+	}
+	if pane.Backend != BackendKindHerdr || pane.Kind != ResourceKindPane {
+		return "", fmt.Errorf("herdr pane owner marker requires herdr pane resource: %#v", pane)
+	}
+	if pane.Native != b.Config.Runtime.PaneID {
+		return "", ErrHerdrPaneTargetMismatch
+	}
+	snapshot, err := b.readValidatedSnapshot(ctx, HerdrReadScopePane)
+	if err != nil {
+		return "", err
+	}
+	if err := b.validatePaneContainment(snapshot, b.Config.Runtime.TabID, pane.Native); err != nil {
+		return "", err
+	}
+	for _, snapshotPane := range snapshot.Panes {
+		if snapshotPane.ID == pane.Native {
+			return snapshotPane.Metadata[HerdrPaneContextIDMetadataKey], nil
+		}
+	}
+	return "", nil
+}
+
+func (b HerdrBackend) SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error {
+	if err := b.authorizeWritePath(); err != nil {
+		return err
+	}
+	if contextID == "" {
+		return fmt.Errorf("context ID is empty")
+	}
+	markerValue, err := sanitizeHerdrMetadataValue(contextID)
+	if err != nil {
+		return err
+	}
+	if pane.Backend != BackendKindHerdr || pane.Kind != ResourceKindPane {
+		return fmt.Errorf("herdr pane owner marker requires herdr pane resource: %#v", pane)
+	}
+	if pane.Native != b.Config.Runtime.PaneID {
+		return ErrHerdrPaneTargetMismatch
+	}
+	client, err := b.writeClient()
+	if err != nil {
+		return err
+	}
+	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+		return err
+	}
+	result, err := client.SetPaneMetadata(ctx, pane.Native, HerdrPaneContextIDMetadataKey, markerValue)
+	if err != nil {
+		return NormalizeHerdrBackendError(err)
+	}
+	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func (b HerdrBackend) ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error {
+	if err := b.authorizeWritePath(); err != nil {
+		return err
+	}
+	if pane.Backend != BackendKindHerdr || pane.Kind != ResourceKindPane {
+		return fmt.Errorf("herdr pane owner marker requires herdr pane resource: %#v", pane)
+	}
+	if pane.Native != b.Config.Runtime.PaneID {
+		return ErrHerdrPaneTargetMismatch
+	}
+	client, err := b.writeClient()
+	if err != nil {
+		return err
+	}
+	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+		return err
+	}
+	result, err := client.ClearPaneMetadata(ctx, pane.Native, HerdrPaneContextIDMetadataKey)
+	if err != nil {
+		return NormalizeHerdrBackendError(err)
+	}
+	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func (b HerdrBackend) authorizeWritePath() error {
+	if !b.Config.Enabled {
+		return ErrHerdrReadDisabled
+	}
+	if b.Client == nil {
+		return ErrHerdrReadClientMissing
+	}
+	envelope := b.localReadGateEnvelope()
+	return ValidateHerdrWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
+}
+
+func (b HerdrBackend) validateWriteEnvelope(envelope HerdrResponseEnvelope) error {
+	return ValidateHerdrWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
+}
+
+func (b HerdrBackend) writeClient() (HerdrWriteClient, error) {
+	client, ok := b.Client.(HerdrWriteClient)
+	if !ok {
+		return nil, ErrHerdrWriteClientMissing
+	}
+	return client, nil
+}
+
+func (b HerdrBackend) sanitizePaneInput(text string) (string, error) {
+	if b.InputSanitizer == nil {
+		return "", ErrHerdrInputSanitizerMissing
+	}
+	return b.InputSanitizer(text)
+}
+
+func herdrSubmitEnterCount(configured int) int {
+	if configured <= 0 {
+		return 1
+	}
+	return configured
+}
+
+func sanitizeHerdrMetadataValue(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("herdr metadata value is empty")
+	}
+	if !utf8.ValidString(value) {
+		return "", fmt.Errorf("herdr metadata value is invalid UTF-8")
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return "", fmt.Errorf("herdr metadata value contains control character")
+		}
+	}
+	return value, nil
+}

--- a/internal/multiplexer/herdr_write.go
+++ b/internal/multiplexer/herdr_write.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	HerdrKeyEnter                 = "Enter"
+	// Match tmux delivery's Codex submit key; literal Enter may insert a newline.
+	HerdrKeySubmit                = "C-m"
 	HerdrSessionOwnerMetadataKey  = "postman.session_owner"
 	HerdrPaneContextIDMetadataKey = "postman.context_id"
 )
@@ -71,7 +72,7 @@ func (b HerdrBackend) SendPaneInput(ctx context.Context, pane ResourceID, input 
 		return err
 	}
 	for range herdrSubmitEnterCount(input.EnterCount) {
-		result, err := client.SendPaneKey(ctx, pane.Native, HerdrKeyEnter)
+		result, err := client.SendPaneKey(ctx, pane.Native, HerdrKeySubmit)
 		if err != nil {
 			return NormalizeHerdrBackendError(err)
 		}
@@ -89,13 +90,17 @@ func (b HerdrBackend) SessionOwnerMarker(ctx context.Context, sessionName string
 	if sessionName != b.Config.Runtime.SessionName {
 		return "", ErrHerdrSessionNameMismatch
 	}
+	metadataKey, err := herdrSessionOwnerMetadataKey(sessionName)
+	if err != nil {
+		return "", err
+	}
 	snapshot, err := b.readValidatedSnapshot(ctx, HerdrReadScopeDiscovery)
 	if err != nil {
 		return "", err
 	}
 	for _, workspace := range snapshot.Workspaces {
 		if workspace.ID == b.Config.Runtime.WorkspaceID {
-			return workspace.Metadata[HerdrSessionOwnerMetadataKey], nil
+			return workspace.Metadata[metadataKey], nil
 		}
 	}
 	return "", nil
@@ -105,14 +110,19 @@ func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sess
 	if err := b.authorizeWritePath(); err != nil {
 		return err
 	}
-	if contextID == "" {
-		return fmt.Errorf("context ID is empty")
-	}
 	if sessionName != b.Config.Runtime.SessionName {
 		return ErrHerdrSessionNameMismatch
 	}
 	if pid <= 0 {
 		pid = os.Getpid()
+	}
+	contextID, err := sanitizeHerdrMetadataValue(contextID)
+	if err != nil {
+		return err
+	}
+	metadataKey, err := herdrSessionOwnerMetadataKey(sessionName)
+	if err != nil {
+		return err
 	}
 	markerValue, err := sanitizeHerdrMetadataValue(contextID + ":" + strconv.Itoa(pid))
 	if err != nil {
@@ -125,7 +135,7 @@ func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sess
 	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
 		return err
 	}
-	result, err := client.SetWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, HerdrSessionOwnerMetadataKey, markerValue)
+	result, err := client.SetWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, metadataKey, markerValue)
 	if err != nil {
 		return NormalizeHerdrBackendError(err)
 	}
@@ -139,6 +149,10 @@ func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName s
 	if sessionName != b.Config.Runtime.SessionName {
 		return ErrHerdrSessionNameMismatch
 	}
+	metadataKey, err := herdrSessionOwnerMetadataKey(sessionName)
+	if err != nil {
+		return err
+	}
 	client, err := b.writeClient()
 	if err != nil {
 		return err
@@ -146,11 +160,19 @@ func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName s
 	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
 		return err
 	}
-	result, err := client.ClearWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, HerdrSessionOwnerMetadataKey)
+	result, err := client.ClearWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, metadataKey)
 	if err != nil {
 		return NormalizeHerdrBackendError(err)
 	}
 	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func herdrSessionOwnerMetadataKey(sessionName string) (string, error) {
+	sessionName, err := sanitizeHerdrMetadataValue(sessionName)
+	if err != nil {
+		return "", fmt.Errorf("invalid herdr session owner metadata key: %w", err)
+	}
+	return HerdrSessionOwnerMetadataKey + "." + sessionName, nil
 }
 
 func (b HerdrBackend) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {

--- a/internal/multiplexer/herdr_write.go
+++ b/internal/multiplexer/herdr_write.go
@@ -132,7 +132,7 @@ func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sess
 	if err != nil {
 		return err
 	}
-	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+	if err := b.validateConfiguredWorkspaceInSnapshot(ctx); err != nil {
 		return err
 	}
 	result, err := client.SetWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, metadataKey, markerValue)
@@ -157,7 +157,7 @@ func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName s
 	if err != nil {
 		return err
 	}
-	if err := b.validateConfiguredPaneInSnapshot(ctx); err != nil {
+	if err := b.validateConfiguredWorkspaceInSnapshot(ctx); err != nil {
 		return err
 	}
 	result, err := client.ClearWorkspaceMetadata(ctx, b.Config.Runtime.WorkspaceID, metadataKey)
@@ -165,6 +165,11 @@ func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName s
 		return NormalizeHerdrBackendError(err)
 	}
 	return b.validateWriteEnvelope(result.Envelope)
+}
+
+func (b HerdrBackend) validateConfiguredWorkspaceInSnapshot(ctx context.Context) error {
+	_, err := b.readValidatedSnapshot(ctx, HerdrReadScopeDiscovery)
+	return err
 }
 
 func herdrSessionOwnerMetadataKey(sessionName string) (string, error) {

--- a/internal/multiplexer/herdr_write.go
+++ b/internal/multiplexer/herdr_write.go
@@ -107,7 +107,7 @@ func (b HerdrBackend) SessionOwnerMarker(ctx context.Context, sessionName string
 }
 
 func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
-	if err := b.authorizeWritePath(); err != nil {
+	if err := b.authorizeWorkspaceWritePath(); err != nil {
 		return err
 	}
 	if sessionName != b.Config.Runtime.SessionName {
@@ -139,11 +139,11 @@ func (b HerdrBackend) SetSessionOwnerMarker(ctx context.Context, contextID, sess
 	if err != nil {
 		return NormalizeHerdrBackendError(err)
 	}
-	return b.validateWriteEnvelope(result.Envelope)
+	return b.validateWorkspaceWriteEnvelope(result.Envelope)
 }
 
 func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
-	if err := b.authorizeWritePath(); err != nil {
+	if err := b.authorizeWorkspaceWritePath(); err != nil {
 		return err
 	}
 	if sessionName != b.Config.Runtime.SessionName {
@@ -164,7 +164,7 @@ func (b HerdrBackend) ClearSessionOwnerMarker(ctx context.Context, sessionName s
 	if err != nil {
 		return NormalizeHerdrBackendError(err)
 	}
-	return b.validateWriteEnvelope(result.Envelope)
+	return b.validateWorkspaceWriteEnvelope(result.Envelope)
 }
 
 func (b HerdrBackend) validateConfiguredWorkspaceInSnapshot(ctx context.Context) error {
@@ -271,8 +271,23 @@ func (b HerdrBackend) authorizeWritePath() error {
 	return ValidateHerdrWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
 }
 
+func (b HerdrBackend) authorizeWorkspaceWritePath() error {
+	if !b.Config.Enabled {
+		return ErrHerdrReadDisabled
+	}
+	if b.Client == nil {
+		return ErrHerdrReadClientMissing
+	}
+	envelope := b.localReadGateEnvelope()
+	return validateHerdrWorkspaceWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
+}
+
 func (b HerdrBackend) validateWriteEnvelope(envelope HerdrResponseEnvelope) error {
 	return ValidateHerdrWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
+}
+
+func (b HerdrBackend) validateWorkspaceWriteEnvelope(envelope HerdrResponseEnvelope) error {
+	return validateHerdrWorkspaceWriteGate(b.Config.Policy, b.Config.Runtime, envelope)
 }
 
 func (b HerdrBackend) writeClient() (HerdrWriteClient, error) {

--- a/internal/multiplexer/herdr_write.go
+++ b/internal/multiplexer/herdr_write.go
@@ -198,7 +198,7 @@ func (b HerdrBackend) PaneOwnerMarker(ctx context.Context, pane ResourceID) (str
 		return "", err
 	}
 	for _, snapshotPane := range snapshot.Panes {
-		if snapshotPane.ID == pane.Native {
+		if snapshotPane.ID == pane.Native && snapshotPane.WorkspaceID == b.Config.Runtime.WorkspaceID && snapshotPane.TabID == b.Config.Runtime.TabID {
 			return snapshotPane.Metadata[HerdrPaneContextIDMetadataKey], nil
 		}
 	}

--- a/internal/multiplexer/herdr_write_test.go
+++ b/internal/multiplexer/herdr_write_test.go
@@ -1,0 +1,379 @@
+package multiplexer
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestHerdrBackendSendPaneInputRequiresWriteGateBeforeClientCall(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	config := validHerdrReadConfig()
+	config.Policy.WriteEnabled = false
+	backend := HerdrBackend{
+		Config:         config,
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello"})
+	assertHerdrGateError(t, err, HerdrAccessPhaseWrite, "", HerdrGateFailureClosed)
+	if client.snapshotCalls != 0 || client.writeTextCalls != 0 || client.sendKeyCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d write:%d key:%d, want none", client.snapshotCalls, client.writeTextCalls, client.sendKeyCalls)
+	}
+}
+
+func TestHerdrBackendSendPaneInputRequiresWriteClientBeforeSnapshot(t *testing.T) {
+	client := &fakeHerdrReadClient{snapshot: validHerdrSessionSnapshot()}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello"})
+	if !errors.Is(err, ErrHerdrWriteClientMissing) {
+		t.Fatalf("SendPaneInput() error = %v, want ErrHerdrWriteClientMissing", err)
+	}
+	if client.snapshotCalls != 0 {
+		t.Fatalf("snapshotCalls = %d, want 0 before write client is present", client.snapshotCalls)
+	}
+}
+
+func TestHerdrBackendSendPaneInputSanitizesBeforeWrite(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config: validHerdrReadConfig(),
+		Client: client,
+		InputSanitizer: func(text string) (string, error) {
+			if text != "hello" {
+				t.Fatalf("sanitizer input = %q, want hello", text)
+			}
+			return "sanitized:" + text, nil
+		},
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello", EnterCount: 2})
+	if err != nil {
+		t.Fatalf("SendPaneInput() error = %v", err)
+	}
+	if client.snapshotCalls != 1 {
+		t.Fatalf("snapshotCalls = %d, want 1", client.snapshotCalls)
+	}
+	if client.writeTextCalls != 1 || client.writeTextPane != "workspace-1:pane-1" || client.writeTextText != "sanitized:hello" {
+		t.Fatalf("write text call = calls:%d pane:%q text:%q, want sanitized write", client.writeTextCalls, client.writeTextPane, client.writeTextText)
+	}
+	if client.sendKeyCalls != 2 || client.sendKeyPane != "workspace-1:pane-1" || client.sendKeyKey != HerdrKeyEnter {
+		t.Fatalf("send key call = calls:%d pane:%q key:%q, want two Enter keys", client.sendKeyCalls, client.sendKeyPane, client.sendKeyKey)
+	}
+}
+
+func TestHerdrBackendSendPaneInputRequiresSanitizerBeforeSnapshot(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config: validHerdrReadConfig(),
+		Client: client,
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello"})
+	if !errors.Is(err, ErrHerdrInputSanitizerMissing) {
+		t.Fatalf("SendPaneInput() error = %v, want ErrHerdrInputSanitizerMissing", err)
+	}
+	if client.snapshotCalls != 0 || client.writeTextCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d write:%d, want none before sanitizer passes", client.snapshotCalls, client.writeTextCalls)
+	}
+}
+
+func TestHerdrBackendSendPaneInputRequiresSnapshotContainmentBeforeWrite(t *testing.T) {
+	snapshot := validHerdrSessionSnapshot()
+	snapshot.Panes[0].TabID = "workspace-1:other-tab"
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: snapshot,
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello"})
+	if !errors.Is(err, ErrHerdrSnapshotInvalid) {
+		t.Fatalf("SendPaneInput() error = %v, want ErrHerdrSnapshotInvalid", err)
+	}
+	if client.writeTextCalls != 0 || client.sendKeyCalls != 0 {
+		t.Fatalf("mutation calls = write:%d key:%d, want none before snapshot containment passes", client.writeTextCalls, client.sendKeyCalls)
+	}
+}
+
+func TestHerdrBackendSessionOwnerMarkerUsesWorkspaceMetadata(t *testing.T) {
+	snapshot := validHerdrSessionSnapshot()
+	snapshot.Workspaces[0].Metadata = map[string]string{HerdrSessionOwnerMetadataKey: "ctx-1:123"}
+	client := &fakeHerdrReadClient{snapshot: snapshot}
+	backend := HerdrBackend{Config: validHerdrReadConfig(), Client: client}
+
+	got, err := backend.SessionOwnerMarker(context.Background(), "work")
+	if err != nil {
+		t.Fatalf("SessionOwnerMarker() error = %v", err)
+	}
+	if got != "ctx-1:123" {
+		t.Fatalf("SessionOwnerMarker() = %q, want marker", got)
+	}
+}
+
+func TestHerdrBackendSetAndClearSessionOwnerMarkerUseWorkspaceMetadata(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	if err := backend.SetSessionOwnerMarker(context.Background(), "ctx-1", "work", 123); err != nil {
+		t.Fatalf("SetSessionOwnerMarker() error = %v", err)
+	}
+	if client.setWorkspaceMetadataCalls != 1 ||
+		client.setWorkspaceMetadataID != "workspace-1" ||
+		client.setWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey ||
+		client.setWorkspaceMetadataValue != "ctx-1:123" {
+		t.Fatalf("set workspace metadata = calls:%d id:%q key:%q value:%q, want session marker",
+			client.setWorkspaceMetadataCalls,
+			client.setWorkspaceMetadataID,
+			client.setWorkspaceMetadataKey,
+			client.setWorkspaceMetadataValue)
+	}
+
+	if err := backend.ClearSessionOwnerMarker(context.Background(), "work"); err != nil {
+		t.Fatalf("ClearSessionOwnerMarker() error = %v", err)
+	}
+	if client.clearWorkspaceMetadataCalls != 1 ||
+		client.clearWorkspaceMetadataID != "workspace-1" ||
+		client.clearWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey {
+		t.Fatalf("clear workspace metadata = calls:%d id:%q key:%q, want session marker clear",
+			client.clearWorkspaceMetadataCalls,
+			client.clearWorkspaceMetadataID,
+			client.clearWorkspaceMetadataKey)
+	}
+}
+
+func TestHerdrBackendSetSessionOwnerMarkerRejectsUnsafeMarkerBeforeSnapshot(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SetSessionOwnerMarker(context.Background(), "ctx-\x1b[31m1", "work", 123)
+	if err == nil {
+		t.Fatal("SetSessionOwnerMarker() error = nil, want unsafe metadata error")
+	}
+	if client.snapshotCalls != 0 || client.setWorkspaceMetadataCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d setWorkspace:%d, want none before marker sanitization passes", client.snapshotCalls, client.setWorkspaceMetadataCalls)
+	}
+}
+
+func TestHerdrBackendSetPaneOwnerMarkerRequiresWriteGateBeforeMetadata(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	config := validHerdrReadConfig()
+	config.Policy.WriteEnabled = false
+	backend := HerdrBackend{
+		Config:         config,
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SetPaneOwnerMarker(context.Background(), HerdrPaneID("workspace-1:pane-1"), "ctx-1")
+	assertHerdrGateError(t, err, HerdrAccessPhaseWrite, "", HerdrGateFailureClosed)
+	if client.snapshotCalls != 0 || client.setPaneMetadataCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d setPane:%d, want none before write gate", client.snapshotCalls, client.setPaneMetadataCalls)
+	}
+}
+
+func TestHerdrBackendSetPaneOwnerMarkerRejectsUnsafeMarkerBeforeSnapshot(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SetPaneOwnerMarker(context.Background(), HerdrPaneID("workspace-1:pane-1"), "ctx-\x1b[31m1")
+	if err == nil {
+		t.Fatal("SetPaneOwnerMarker() error = nil, want unsafe metadata error")
+	}
+	if client.snapshotCalls != 0 || client.setPaneMetadataCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d setPane:%d, want none before marker sanitization passes", client.snapshotCalls, client.setPaneMetadataCalls)
+	}
+}
+
+func TestHerdrBackendPaneOwnerMarkerUsesPaneMetadata(t *testing.T) {
+	snapshot := validHerdrSessionSnapshot()
+	snapshot.Panes[0].Metadata[HerdrPaneContextIDMetadataKey] = "ctx-1"
+	client := &fakeHerdrReadClient{snapshot: snapshot}
+	backend := HerdrBackend{Config: validHerdrReadConfig(), Client: client}
+
+	got, err := backend.PaneOwnerMarker(context.Background(), HerdrPaneID("workspace-1:pane-1"))
+	if err != nil {
+		t.Fatalf("PaneOwnerMarker() error = %v", err)
+	}
+	if got != "ctx-1" {
+		t.Fatalf("PaneOwnerMarker() = %q, want marker", got)
+	}
+}
+
+func TestHerdrBackendSetAndClearPaneOwnerMarkerUsePaneMetadata(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	if err := backend.SetPaneOwnerMarker(context.Background(), HerdrPaneID("workspace-1:pane-1"), "ctx-1"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker() error = %v", err)
+	}
+	if client.setPaneMetadataCalls != 1 ||
+		client.setPaneMetadataID != "workspace-1:pane-1" ||
+		client.setPaneMetadataKey != HerdrPaneContextIDMetadataKey ||
+		client.setPaneMetadataValue != "ctx-1" {
+		t.Fatalf("set pane metadata = calls:%d id:%q key:%q value:%q, want pane marker",
+			client.setPaneMetadataCalls,
+			client.setPaneMetadataID,
+			client.setPaneMetadataKey,
+			client.setPaneMetadataValue)
+	}
+
+	if err := backend.ClearPaneOwnerMarker(context.Background(), HerdrPaneID("workspace-1:pane-1")); err != nil {
+		t.Fatalf("ClearPaneOwnerMarker() error = %v", err)
+	}
+	if client.clearPaneMetadataCalls != 1 ||
+		client.clearPaneMetadataID != "workspace-1:pane-1" ||
+		client.clearPaneMetadataKey != HerdrPaneContextIDMetadataKey {
+		t.Fatalf("clear pane metadata = calls:%d id:%q key:%q, want pane marker clear",
+			client.clearPaneMetadataCalls,
+			client.clearPaneMetadataID,
+			client.clearPaneMetadataKey)
+	}
+}
+
+func passThroughHerdrInput(text string) (string, error) {
+	return text, nil
+}
+
+type fakeHerdrWriteClient struct {
+	fakeHerdrReadClient
+
+	writeTextResult HerdrWriteResult
+	writeTextErr    error
+	sendKeyResult   HerdrWriteResult
+	sendKeyErr      error
+	metadataResult  HerdrWriteResult
+	metadataErr     error
+
+	writeTextCalls int
+	writeTextPane  string
+	writeTextText  string
+	sendKeyCalls   int
+	sendKeyPane    string
+	sendKeyKey     string
+
+	setWorkspaceMetadataCalls int
+	setWorkspaceMetadataID    string
+	setWorkspaceMetadataKey   string
+	setWorkspaceMetadataValue string
+
+	clearWorkspaceMetadataCalls int
+	clearWorkspaceMetadataID    string
+	clearWorkspaceMetadataKey   string
+
+	setPaneMetadataCalls int
+	setPaneMetadataID    string
+	setPaneMetadataKey   string
+	setPaneMetadataValue string
+
+	clearPaneMetadataCalls int
+	clearPaneMetadataID    string
+	clearPaneMetadataKey   string
+}
+
+func (f *fakeHerdrWriteClient) WritePaneText(_ context.Context, paneID string, text string) (HerdrWriteResult, error) {
+	f.writeTextCalls++
+	f.writeTextPane = paneID
+	f.writeTextText = text
+	if f.writeTextErr != nil {
+		return HerdrWriteResult{}, f.writeTextErr
+	}
+	if f.writeTextResult.Envelope.ProtocolVersion != "" {
+		return f.writeTextResult, nil
+	}
+	return HerdrWriteResult{Envelope: validHerdrEnvelope()}, nil
+}
+
+func (f *fakeHerdrWriteClient) SendPaneKey(_ context.Context, paneID string, key string) (HerdrWriteResult, error) {
+	f.sendKeyCalls++
+	f.sendKeyPane = paneID
+	f.sendKeyKey = key
+	if f.sendKeyErr != nil {
+		return HerdrWriteResult{}, f.sendKeyErr
+	}
+	if f.sendKeyResult.Envelope.ProtocolVersion != "" {
+		return f.sendKeyResult, nil
+	}
+	return HerdrWriteResult{Envelope: validHerdrEnvelope()}, nil
+}
+
+func (f *fakeHerdrWriteClient) SetWorkspaceMetadata(_ context.Context, workspaceID string, key string, value string) (HerdrWriteResult, error) {
+	f.setWorkspaceMetadataCalls++
+	f.setWorkspaceMetadataID = workspaceID
+	f.setWorkspaceMetadataKey = key
+	f.setWorkspaceMetadataValue = value
+	return f.metadataWriteResult()
+}
+
+func (f *fakeHerdrWriteClient) ClearWorkspaceMetadata(_ context.Context, workspaceID string, key string) (HerdrWriteResult, error) {
+	f.clearWorkspaceMetadataCalls++
+	f.clearWorkspaceMetadataID = workspaceID
+	f.clearWorkspaceMetadataKey = key
+	return f.metadataWriteResult()
+}
+
+func (f *fakeHerdrWriteClient) SetPaneMetadata(_ context.Context, paneID string, key string, value string) (HerdrWriteResult, error) {
+	f.setPaneMetadataCalls++
+	f.setPaneMetadataID = paneID
+	f.setPaneMetadataKey = key
+	f.setPaneMetadataValue = value
+	return f.metadataWriteResult()
+}
+
+func (f *fakeHerdrWriteClient) ClearPaneMetadata(_ context.Context, paneID string, key string) (HerdrWriteResult, error) {
+	f.clearPaneMetadataCalls++
+	f.clearPaneMetadataID = paneID
+	f.clearPaneMetadataKey = key
+	return f.metadataWriteResult()
+}
+
+func (f *fakeHerdrWriteClient) metadataWriteResult() (HerdrWriteResult, error) {
+	if f.metadataErr != nil {
+		return HerdrWriteResult{}, f.metadataErr
+	}
+	if f.metadataResult.Envelope.ProtocolVersion != "" {
+		return f.metadataResult, nil
+	}
+	return HerdrWriteResult{Envelope: validHerdrEnvelope()}, nil
+}

--- a/internal/multiplexer/herdr_write_test.go
+++ b/internal/multiplexer/herdr_write_test.go
@@ -3,6 +3,7 @@ package multiplexer
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 )
 
@@ -67,8 +68,25 @@ func TestHerdrBackendSendPaneInputSanitizesBeforeWrite(t *testing.T) {
 	if client.writeTextCalls != 1 || client.writeTextPane != "workspace-1:pane-1" || client.writeTextText != "sanitized:hello" {
 		t.Fatalf("write text call = calls:%d pane:%q text:%q, want sanitized write", client.writeTextCalls, client.writeTextPane, client.writeTextText)
 	}
-	if client.sendKeyCalls != 2 || client.sendKeyPane != "workspace-1:pane-1" || client.sendKeyKey != HerdrKeyEnter {
+	if client.sendKeyCalls != 2 || client.sendKeyPane != "workspace-1:pane-1" || client.sendKeyKey != HerdrKeySubmit {
 		t.Fatalf("send key call = calls:%d pane:%q key:%q, want two Enter keys", client.sendKeyCalls, client.sendKeyPane, client.sendKeyKey)
+	}
+}
+
+func TestHerdrBackendSendPaneInputNormalizesUnavailableWriteError(t *testing.T) {
+	client := &fakeHerdrWriteClient{
+		fakeHerdrReadClient: fakeHerdrReadClient{snapshot: validHerdrSessionSnapshot()},
+		writeTextErr:        net.ErrClosed,
+	}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SendPaneInput(context.Background(), HerdrPaneID("workspace-1:pane-1"), HerdrPaneInput{Text: "hello"})
+	if !errors.Is(err, ErrHerdrBackendUnavailable) {
+		t.Fatalf("SendPaneInput() error = %v, want ErrHerdrBackendUnavailable", err)
 	}
 }
 
@@ -113,7 +131,7 @@ func TestHerdrBackendSendPaneInputRequiresSnapshotContainmentBeforeWrite(t *test
 
 func TestHerdrBackendSessionOwnerMarkerUsesWorkspaceMetadata(t *testing.T) {
 	snapshot := validHerdrSessionSnapshot()
-	snapshot.Workspaces[0].Metadata = map[string]string{HerdrSessionOwnerMetadataKey: "ctx-1:123"}
+	snapshot.Workspaces[0].Metadata = map[string]string{HerdrSessionOwnerMetadataKey + ".work": "ctx-1:123"}
 	client := &fakeHerdrReadClient{snapshot: snapshot}
 	backend := HerdrBackend{Config: validHerdrReadConfig(), Client: client}
 
@@ -141,7 +159,7 @@ func TestHerdrBackendSetAndClearSessionOwnerMarkerUseWorkspaceMetadata(t *testin
 	}
 	if client.setWorkspaceMetadataCalls != 1 ||
 		client.setWorkspaceMetadataID != "workspace-1" ||
-		client.setWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey ||
+		client.setWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey+".work" ||
 		client.setWorkspaceMetadataValue != "ctx-1:123" {
 		t.Fatalf("set workspace metadata = calls:%d id:%q key:%q value:%q, want session marker",
 			client.setWorkspaceMetadataCalls,
@@ -155,7 +173,7 @@ func TestHerdrBackendSetAndClearSessionOwnerMarkerUseWorkspaceMetadata(t *testin
 	}
 	if client.clearWorkspaceMetadataCalls != 1 ||
 		client.clearWorkspaceMetadataID != "workspace-1" ||
-		client.clearWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey {
+		client.clearWorkspaceMetadataKey != HerdrSessionOwnerMetadataKey+".work" {
 		t.Fatalf("clear workspace metadata = calls:%d id:%q key:%q, want session marker clear",
 			client.clearWorkspaceMetadataCalls,
 			client.clearWorkspaceMetadataID,
@@ -179,6 +197,25 @@ func TestHerdrBackendSetSessionOwnerMarkerRejectsUnsafeMarkerBeforeSnapshot(t *t
 	}
 	if client.snapshotCalls != 0 || client.setWorkspaceMetadataCalls != 0 {
 		t.Fatalf("client calls = snapshot:%d setWorkspace:%d, want none before marker sanitization passes", client.snapshotCalls, client.setWorkspaceMetadataCalls)
+	}
+}
+
+func TestHerdrBackendSetSessionOwnerMarkerRejectsWhitespaceContextBeforeConcat(t *testing.T) {
+	client := &fakeHerdrWriteClient{fakeHerdrReadClient: fakeHerdrReadClient{
+		snapshot: validHerdrSessionSnapshot(),
+	}}
+	backend := HerdrBackend{
+		Config:         validHerdrReadConfig(),
+		Client:         client,
+		InputSanitizer: passThroughHerdrInput,
+	}
+
+	err := backend.SetSessionOwnerMarker(context.Background(), "   ", "work", 123)
+	if err == nil {
+		t.Fatal("SetSessionOwnerMarker() error = nil, want empty context error")
+	}
+	if client.snapshotCalls != 0 || client.setWorkspaceMetadataCalls != 0 {
+		t.Fatalf("client calls = snapshot:%d setWorkspace:%d, want none before context sanitization passes", client.snapshotCalls, client.setWorkspaceMetadataCalls)
 	}
 }
 

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -21,6 +22,53 @@ type OwnershipBackend interface {
 	PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error)
 	SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error
 	ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error
+}
+
+var registeredOwnershipBackends sync.Map
+
+func BackendKindFromString(backend string) BackendKind {
+	switch BackendKind(strings.TrimSpace(backend)) {
+	case BackendKindHerdr:
+		return BackendKindHerdr
+	default:
+		return BackendKindTmux
+	}
+}
+
+func PaneIDForBackend(backend BackendKind, paneID string) ResourceID {
+	switch backend {
+	case BackendKindHerdr:
+		return HerdrPaneID(paneID)
+	default:
+		return TmuxPaneID(paneID)
+	}
+}
+
+func RegisterOwnershipBackend(backend OwnershipBackend) func() {
+	if backend == nil {
+		return func() {}
+	}
+	key := backend.Kind()
+	registeredOwnershipBackends.Store(key, backend)
+	return func() {
+		registeredOwnershipBackends.Delete(key)
+	}
+}
+
+func OwnershipBackendForKind(backend BackendKind) (OwnershipBackend, error) {
+	switch backend {
+	case BackendKindTmux, "":
+		return TmuxBackend{}, nil
+	case BackendKindHerdr:
+		if registered, ok := registeredOwnershipBackends.Load(BackendKindHerdr); ok {
+			if ownershipBackend, ok := registered.(OwnershipBackend); ok {
+				return ownershipBackend, nil
+			}
+		}
+		return nil, fmt.Errorf("herdr ownership backend not registered")
+	default:
+		return nil, fmt.Errorf("unsupported ownership backend %q", backend)
+	}
 }
 
 func (b TmuxBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -125,12 +125,20 @@ func (h herdrOwnershipBackends) Kind() BackendKind {
 
 func (h herdrOwnershipBackends) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
 	var lastErr error
+	foundEmpty := false
 	for _, backend := range h {
 		value, err := backend.SessionOwnerMarker(ctx, sessionName)
 		if err == nil {
-			return value, nil
+			if value != "" {
+				return value, nil
+			}
+			foundEmpty = true
+			continue
 		}
 		lastErr = err
+	}
+	if foundEmpty {
+		return "", nil
 	}
 	if lastErr != nil {
 		return "", lastErr

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -147,8 +147,12 @@ func (h herdrOwnershipBackends) SessionOwnerMarker(ctx context.Context, sessionN
 }
 
 func (h herdrOwnershipBackends) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	backends, err := h.sessionMutationBackends(ctx, sessionName)
+	if err != nil {
+		return err
+	}
 	var lastErr error
-	for _, backend := range h {
+	for _, backend := range backends {
 		if err := backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err == nil {
 			return nil
 		} else {
@@ -162,8 +166,12 @@ func (h herdrOwnershipBackends) SetSessionOwnerMarker(ctx context.Context, conte
 }
 
 func (h herdrOwnershipBackends) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	backends, err := h.sessionMutationBackends(ctx, sessionName)
+	if err != nil {
+		return err
+	}
 	var lastErr error
-	for _, backend := range h {
+	for _, backend := range backends {
 		if err := backend.ClearSessionOwnerMarker(ctx, sessionName); err == nil {
 			return nil
 		} else {
@@ -174,6 +182,36 @@ func (h herdrOwnershipBackends) ClearSessionOwnerMarker(ctx context.Context, ses
 		return lastErr
 	}
 	return fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) sessionMutationBackends(ctx context.Context, sessionName string) ([]OwnershipBackend, error) {
+	var (
+		nonEmpty []OwnershipBackend
+		empty    []OwnershipBackend
+		lastErr  error
+	)
+	for _, backend := range h {
+		value, err := backend.SessionOwnerMarker(ctx, sessionName)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if value != "" {
+			nonEmpty = append(nonEmpty, backend)
+			continue
+		}
+		empty = append(empty, backend)
+	}
+	switch {
+	case len(nonEmpty) > 0:
+		return nonEmpty, nil
+	case len(empty) > 0:
+		return empty, nil
+	case lastErr != nil:
+		return nil, lastErr
+	default:
+		return nil, fmt.Errorf("herdr ownership backend not registered")
+	}
 }
 
 func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -24,7 +24,10 @@ type OwnershipBackend interface {
 	ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error
 }
 
-var registeredOwnershipBackends sync.Map
+var (
+	registeredOwnershipBackends   sync.Map
+	registeredOwnershipBackendsMu sync.Mutex
+)
 
 func BackendKindFromString(backend string) BackendKind {
 	switch BackendKind(strings.TrimSpace(backend)) {
@@ -50,7 +53,9 @@ func RegisterOwnershipBackend(backend OwnershipBackend) func() {
 	}
 	key := backend.Kind()
 	if key == BackendKindHerdr {
+		registeredOwnershipBackendsMu.Lock()
 		registeredOwnershipBackends.Store(key, append(registeredHerdrOwnershipBackends(), backend))
+		registeredOwnershipBackendsMu.Unlock()
 	} else {
 		registeredOwnershipBackends.Store(key, backend)
 	}
@@ -59,6 +64,8 @@ func RegisterOwnershipBackend(backend OwnershipBackend) func() {
 			registeredOwnershipBackends.Delete(key)
 			return
 		}
+		registeredOwnershipBackendsMu.Lock()
+		defer registeredOwnershipBackendsMu.Unlock()
 		registered := registeredHerdrOwnershipBackends()
 		next := registered[:0]
 		for _, registeredBackend := range registered {
@@ -79,7 +86,9 @@ func OwnershipBackendForKind(backend BackendKind) (OwnershipBackend, error) {
 	case BackendKindTmux, "":
 		return TmuxBackend{}, nil
 	case BackendKindHerdr:
+		registeredOwnershipBackendsMu.Lock()
 		backends := registeredHerdrOwnershipBackends()
+		registeredOwnershipBackendsMu.Unlock()
 		switch len(backends) {
 		case 0:
 			return nil, fmt.Errorf("herdr ownership backend not registered")

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -24,6 +24,11 @@ type OwnershipBackend interface {
 	ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error
 }
 
+type HerdrRuntimeOwnershipBackend interface {
+	OwnershipBackend
+	HerdrRuntimeIdentity() HerdrRuntimeIdentity
+}
+
 var (
 	registeredOwnershipBackends   sync.Map
 	registeredOwnershipBackendsMu sync.Mutex
@@ -175,6 +180,9 @@ func (h herdrOwnershipBackends) authoritativeSessionBackend(ctx context.Context,
 }
 
 func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {
+	if backend, ok := h.backendForPaneRuntime(pane); ok {
+		return backend.PaneOwnerMarker(ctx, pane)
+	}
 	var lastErr error
 	for _, backend := range h {
 		value, err := backend.PaneOwnerMarker(ctx, pane)
@@ -190,6 +198,9 @@ func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane Resour
 }
 
 func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error {
+	if backend, ok := h.backendForPaneRuntime(pane); ok {
+		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+	}
 	var lastErr error
 	for _, backend := range h {
 		if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err == nil {
@@ -205,6 +216,9 @@ func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane Res
 }
 
 func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error {
+	if backend, ok := h.backendForPaneRuntime(pane); ok {
+		return backend.ClearPaneOwnerMarker(ctx, pane)
+	}
 	var lastErr error
 	for _, backend := range h {
 		if err := backend.ClearPaneOwnerMarker(ctx, pane); err == nil {
@@ -217,6 +231,32 @@ func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane R
 		return lastErr
 	}
 	return fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (OwnershipBackend, bool) {
+	runtime := pane.HerdrRuntime
+	if strings.TrimSpace(runtime.SocketPath) == "" || strings.TrimSpace(runtime.SessionName) == "" || strings.TrimSpace(runtime.WorkspaceID) == "" {
+		return nil, false
+	}
+	if runtime.PaneID == "" {
+		runtime.PaneID = pane.Native
+	}
+	for _, backend := range h {
+		runtimeBackend, ok := backend.(HerdrRuntimeOwnershipBackend)
+		if !ok {
+			continue
+		}
+		if sameHerdrRuntimeIdentity(runtimeBackend.HerdrRuntimeIdentity(), runtime) {
+			return backend, true
+		}
+	}
+	return nil, false
+}
+
+func sameHerdrRuntimeIdentity(a, b HerdrRuntimeIdentity) bool {
+	return strings.TrimSpace(a.SocketPath) == strings.TrimSpace(b.SocketPath) &&
+		strings.TrimSpace(a.SessionName) == strings.TrimSpace(b.SessionName) &&
+		strings.TrimSpace(a.WorkspaceID) == strings.TrimSpace(b.WorkspaceID)
 }
 
 func (b TmuxBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -181,10 +181,10 @@ func (h herdrOwnershipBackends) authoritativeSessionBackend(ctx context.Context,
 }
 
 func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {
-	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+	if backend, selectedPane, ok, err := h.backendForPaneRuntime(pane); err != nil {
 		return "", err
 	} else if ok {
-		return backend.PaneOwnerMarker(ctx, pane)
+		return backend.PaneOwnerMarker(ctx, selectedPane)
 	}
 	var lastErr error
 	for _, backend := range h {
@@ -201,10 +201,10 @@ func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane Resour
 }
 
 func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error {
-	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+	if backend, selectedPane, ok, err := h.backendForPaneRuntime(pane); err != nil {
 		return err
 	} else if ok {
-		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
+		return backend.SetPaneOwnerMarker(ctx, selectedPane, contextID)
 	}
 	var lastErr error
 	for _, backend := range h {
@@ -221,10 +221,10 @@ func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane Res
 }
 
 func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error {
-	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+	if backend, selectedPane, ok, err := h.backendForPaneRuntime(pane); err != nil {
 		return err
 	} else if ok {
-		return backend.ClearPaneOwnerMarker(ctx, pane)
+		return backend.ClearPaneOwnerMarker(ctx, selectedPane)
 	}
 	var lastErr error
 	for _, backend := range h {
@@ -240,14 +240,16 @@ func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane R
 	return fmt.Errorf("herdr ownership backend not registered")
 }
 
-func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (OwnershipBackend, bool, error) {
+func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (OwnershipBackend, ResourceID, bool, error) {
 	runtime := pane.HerdrRuntime
+	qualified := hasHerdrRuntimeQualifier(runtime)
 	if runtime.PaneID == "" {
 		runtime.PaneID = pane.Native
 	}
 	var (
-		selected OwnershipBackend
-		found    bool
+		selected     OwnershipBackend
+		selectedPane ResourceID
+		found        bool
 	)
 	for _, backend := range h {
 		runtimeBackend, ok := backend.(HerdrRuntimeOwnershipBackend)
@@ -266,13 +268,18 @@ func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (Ownershi
 				continue
 			}
 			if found {
-				return nil, false, fmt.Errorf("ambiguous herdr ownership backend for pane %q", pane.Native)
+				return nil, ResourceID{}, false, fmt.Errorf("ambiguous herdr ownership backend for pane %q", pane.Native)
 			}
 			selected = backend
+			selectedPane = pane
+			selectedPane.HerdrRuntime = identity
 			found = true
 		}
 	}
-	return selected, found, nil
+	if !found && qualified {
+		return nil, ResourceID{}, false, fmt.Errorf("herdr ownership backend not registered for qualified pane %q", pane.Native)
+	}
+	return selected, selectedPane, found, nil
 }
 
 func matchesHerdrRuntimeIdentity(candidate, target HerdrRuntimeIdentity) bool {
@@ -290,6 +297,14 @@ func matchesHerdrRuntimeIdentity(candidate, target HerdrRuntimeIdentity) bool {
 func herdrRuntimeFieldMatches(candidate, target string) bool {
 	target = strings.TrimSpace(target)
 	return target == "" || strings.TrimSpace(candidate) == target
+}
+
+func hasHerdrRuntimeQualifier(runtime HerdrRuntimeIdentity) bool {
+	return strings.TrimSpace(runtime.SocketPath) != "" ||
+		strings.TrimSpace(runtime.SessionName) != "" ||
+		strings.TrimSpace(runtime.WorkspaceID) != "" ||
+		strings.TrimSpace(runtime.TabID) != "" ||
+		strings.TrimSpace(runtime.PaneID) != ""
 }
 
 func (b TmuxBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -49,9 +49,28 @@ func RegisterOwnershipBackend(backend OwnershipBackend) func() {
 		return func() {}
 	}
 	key := backend.Kind()
-	registeredOwnershipBackends.Store(key, backend)
+	if key == BackendKindHerdr {
+		registeredOwnershipBackends.Store(key, append(registeredHerdrOwnershipBackends(), backend))
+	} else {
+		registeredOwnershipBackends.Store(key, backend)
+	}
 	return func() {
-		registeredOwnershipBackends.Delete(key)
+		if key != BackendKindHerdr {
+			registeredOwnershipBackends.Delete(key)
+			return
+		}
+		registered := registeredHerdrOwnershipBackends()
+		next := registered[:0]
+		for _, registeredBackend := range registered {
+			if registeredBackend != backend {
+				next = append(next, registeredBackend)
+			}
+		}
+		if len(next) == 0 {
+			registeredOwnershipBackends.Delete(key)
+			return
+		}
+		registeredOwnershipBackends.Store(key, append([]OwnershipBackend(nil), next...))
 	}
 }
 
@@ -60,15 +79,129 @@ func OwnershipBackendForKind(backend BackendKind) (OwnershipBackend, error) {
 	case BackendKindTmux, "":
 		return TmuxBackend{}, nil
 	case BackendKindHerdr:
-		if registered, ok := registeredOwnershipBackends.Load(BackendKindHerdr); ok {
-			if ownershipBackend, ok := registered.(OwnershipBackend); ok {
-				return ownershipBackend, nil
-			}
+		backends := registeredHerdrOwnershipBackends()
+		switch len(backends) {
+		case 0:
+			return nil, fmt.Errorf("herdr ownership backend not registered")
+		case 1:
+			return backends[0], nil
+		default:
+			return herdrOwnershipBackends(backends), nil
 		}
-		return nil, fmt.Errorf("herdr ownership backend not registered")
 	default:
 		return nil, fmt.Errorf("unsupported ownership backend %q", backend)
 	}
+}
+
+func registeredHerdrOwnershipBackends() []OwnershipBackend {
+	registered, ok := registeredOwnershipBackends.Load(BackendKindHerdr)
+	if !ok {
+		return nil
+	}
+	switch backends := registered.(type) {
+	case []OwnershipBackend:
+		return append([]OwnershipBackend(nil), backends...)
+	case OwnershipBackend:
+		return []OwnershipBackend{backends}
+	default:
+		return nil
+	}
+}
+
+type herdrOwnershipBackends []OwnershipBackend
+
+func (h herdrOwnershipBackends) Kind() BackendKind {
+	return BackendKindHerdr
+}
+
+func (h herdrOwnershipBackends) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
+	var lastErr error
+	for _, backend := range h {
+		value, err := backend.SessionOwnerMarker(ctx, sessionName)
+		if err == nil {
+			return value, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
+	var lastErr error
+	for _, backend := range h {
+		if err := backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
+	var lastErr error
+	for _, backend := range h {
+		if err := backend.ClearSessionOwnerMarker(ctx, sessionName); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {
+	var lastErr error
+	for _, backend := range h {
+		value, err := backend.PaneOwnerMarker(ctx, pane)
+		if err == nil {
+			return value, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error {
+	var lastErr error
+	for _, backend := range h {
+		if err := backend.SetPaneOwnerMarker(ctx, pane, contextID); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("herdr ownership backend not registered")
+}
+
+func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error {
+	var lastErr error
+	for _, backend := range h {
+		if err := backend.ClearPaneOwnerMarker(ctx, pane); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("herdr ownership backend not registered")
 }
 
 func (b TmuxBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -99,6 +99,12 @@ func OwnershipBackendForKind(backend BackendKind) (OwnershipBackend, error) {
 		case 0:
 			return nil, fmt.Errorf("herdr ownership backend not registered")
 		case 1:
+			if _, ok := backends[0].(HerdrRuntimeOwnershipBackend); ok {
+				return herdrOwnershipBackends(backends), nil
+			}
+			if _, ok := backends[0].(HerdrRuntimeOwnershipIdentitySet); ok {
+				return herdrOwnershipBackends(backends), nil
+			}
 			return backends[0], nil
 		default:
 			return herdrOwnershipBackends(backends), nil

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -28,6 +28,7 @@ type HerdrRuntimeOwnershipBackend interface {
 	OwnershipBackend
 	HerdrRuntimeIdentity() HerdrRuntimeIdentity
 }
+type HerdrRuntimeOwnershipIdentitySet interface{ HerdrRuntimeOwnershipIdentities() []HerdrRuntimeIdentity }
 
 var (
 	registeredOwnershipBackends   sync.Map
@@ -253,14 +254,23 @@ func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (Ownershi
 		if !ok {
 			continue
 		}
-		if !matchesHerdrRuntimeIdentity(runtimeBackend.HerdrRuntimeIdentity(), runtime) {
-			continue
+		identities := []HerdrRuntimeIdentity{runtimeBackend.HerdrRuntimeIdentity()}
+		if set, ok := backend.(HerdrRuntimeOwnershipIdentitySet); ok {
+			identities = set.HerdrRuntimeOwnershipIdentities()
 		}
-		if found {
-			return nil, false, fmt.Errorf("ambiguous herdr ownership backend for pane %q", pane.Native)
+		if len(identities) == 0 {
+			identities = []HerdrRuntimeIdentity{runtimeBackend.HerdrRuntimeIdentity()}
 		}
-		selected = backend
-		found = true
+		for _, identity := range identities {
+			if !matchesHerdrRuntimeIdentity(identity, runtime) {
+				continue
+			}
+			if found {
+				return nil, false, fmt.Errorf("ambiguous herdr ownership backend for pane %q", pane.Native)
+			}
+			selected = backend
+			found = true
+		}
 	}
 	return selected, found, nil
 }

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -124,71 +124,33 @@ func (h herdrOwnershipBackends) Kind() BackendKind {
 }
 
 func (h herdrOwnershipBackends) SessionOwnerMarker(ctx context.Context, sessionName string) (string, error) {
-	var lastErr error
-	foundEmpty := false
-	for _, backend := range h {
-		value, err := backend.SessionOwnerMarker(ctx, sessionName)
-		if err == nil {
-			if value != "" {
-				return value, nil
-			}
-			foundEmpty = true
-			continue
-		}
-		lastErr = err
+	_, value, err := h.authoritativeSessionBackend(ctx, sessionName)
+	if err != nil {
+		return "", err
 	}
-	if foundEmpty {
-		return "", nil
-	}
-	if lastErr != nil {
-		return "", lastErr
-	}
-	return "", fmt.Errorf("herdr ownership backend not registered")
+	return value, nil
 }
 
 func (h herdrOwnershipBackends) SetSessionOwnerMarker(ctx context.Context, contextID, sessionName string, pid int) error {
-	backends, err := h.sessionMutationBackends(ctx, sessionName)
+	backend, _, err := h.authoritativeSessionBackend(ctx, sessionName)
 	if err != nil {
 		return err
 	}
-	var lastErr error
-	for _, backend := range backends {
-		if err := backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid); err == nil {
-			return nil
-		} else {
-			lastErr = err
-		}
-	}
-	if lastErr != nil {
-		return lastErr
-	}
-	return fmt.Errorf("herdr ownership backend not registered")
+	return backend.SetSessionOwnerMarker(ctx, contextID, sessionName, pid)
 }
 
 func (h herdrOwnershipBackends) ClearSessionOwnerMarker(ctx context.Context, sessionName string) error {
-	backends, err := h.sessionMutationBackends(ctx, sessionName)
+	backend, _, err := h.authoritativeSessionBackend(ctx, sessionName)
 	if err != nil {
 		return err
 	}
-	var lastErr error
-	for _, backend := range backends {
-		if err := backend.ClearSessionOwnerMarker(ctx, sessionName); err == nil {
-			return nil
-		} else {
-			lastErr = err
-		}
-	}
-	if lastErr != nil {
-		return lastErr
-	}
-	return fmt.Errorf("herdr ownership backend not registered")
+	return backend.ClearSessionOwnerMarker(ctx, sessionName)
 }
 
-func (h herdrOwnershipBackends) sessionMutationBackends(ctx context.Context, sessionName string) ([]OwnershipBackend, error) {
+func (h herdrOwnershipBackends) authoritativeSessionBackend(ctx context.Context, sessionName string) (OwnershipBackend, string, error) {
 	var (
-		nonEmpty []OwnershipBackend
-		empty    []OwnershipBackend
-		lastErr  error
+		emptyBackend OwnershipBackend
+		lastErr      error
 	)
 	for _, backend := range h {
 		value, err := backend.SessionOwnerMarker(ctx, sessionName)
@@ -197,21 +159,19 @@ func (h herdrOwnershipBackends) sessionMutationBackends(ctx context.Context, ses
 			continue
 		}
 		if value != "" {
-			nonEmpty = append(nonEmpty, backend)
-			continue
+			return backend, value, nil
 		}
-		empty = append(empty, backend)
+		if emptyBackend == nil {
+			emptyBackend = backend
+		}
 	}
-	switch {
-	case len(nonEmpty) > 0:
-		return nonEmpty, nil
-	case len(empty) > 0:
-		return empty, nil
-	case lastErr != nil:
-		return nil, lastErr
-	default:
-		return nil, fmt.Errorf("herdr ownership backend not registered")
+	if emptyBackend != nil {
+		return emptyBackend, "", nil
 	}
+	if lastErr != nil {
+		return nil, "", lastErr
+	}
+	return nil, "", fmt.Errorf("herdr ownership backend not registered")
 }
 
 func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {

--- a/internal/multiplexer/ownership.go
+++ b/internal/multiplexer/ownership.go
@@ -180,7 +180,9 @@ func (h herdrOwnershipBackends) authoritativeSessionBackend(ctx context.Context,
 }
 
 func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane ResourceID) (string, error) {
-	if backend, ok := h.backendForPaneRuntime(pane); ok {
+	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+		return "", err
+	} else if ok {
 		return backend.PaneOwnerMarker(ctx, pane)
 	}
 	var lastErr error
@@ -198,7 +200,9 @@ func (h herdrOwnershipBackends) PaneOwnerMarker(ctx context.Context, pane Resour
 }
 
 func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane ResourceID, contextID string) error {
-	if backend, ok := h.backendForPaneRuntime(pane); ok {
+	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+		return err
+	} else if ok {
 		return backend.SetPaneOwnerMarker(ctx, pane, contextID)
 	}
 	var lastErr error
@@ -216,7 +220,9 @@ func (h herdrOwnershipBackends) SetPaneOwnerMarker(ctx context.Context, pane Res
 }
 
 func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane ResourceID) error {
-	if backend, ok := h.backendForPaneRuntime(pane); ok {
+	if backend, ok, err := h.backendForPaneRuntime(pane); err != nil {
+		return err
+	} else if ok {
 		return backend.ClearPaneOwnerMarker(ctx, pane)
 	}
 	var lastErr error
@@ -233,30 +239,47 @@ func (h herdrOwnershipBackends) ClearPaneOwnerMarker(ctx context.Context, pane R
 	return fmt.Errorf("herdr ownership backend not registered")
 }
 
-func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (OwnershipBackend, bool) {
+func (h herdrOwnershipBackends) backendForPaneRuntime(pane ResourceID) (OwnershipBackend, bool, error) {
 	runtime := pane.HerdrRuntime
-	if strings.TrimSpace(runtime.SocketPath) == "" || strings.TrimSpace(runtime.SessionName) == "" || strings.TrimSpace(runtime.WorkspaceID) == "" {
-		return nil, false
-	}
 	if runtime.PaneID == "" {
 		runtime.PaneID = pane.Native
 	}
+	var (
+		selected OwnershipBackend
+		found    bool
+	)
 	for _, backend := range h {
 		runtimeBackend, ok := backend.(HerdrRuntimeOwnershipBackend)
 		if !ok {
 			continue
 		}
-		if sameHerdrRuntimeIdentity(runtimeBackend.HerdrRuntimeIdentity(), runtime) {
-			return backend, true
+		if !matchesHerdrRuntimeIdentity(runtimeBackend.HerdrRuntimeIdentity(), runtime) {
+			continue
 		}
+		if found {
+			return nil, false, fmt.Errorf("ambiguous herdr ownership backend for pane %q", pane.Native)
+		}
+		selected = backend
+		found = true
 	}
-	return nil, false
+	return selected, found, nil
 }
 
-func sameHerdrRuntimeIdentity(a, b HerdrRuntimeIdentity) bool {
-	return strings.TrimSpace(a.SocketPath) == strings.TrimSpace(b.SocketPath) &&
-		strings.TrimSpace(a.SessionName) == strings.TrimSpace(b.SessionName) &&
-		strings.TrimSpace(a.WorkspaceID) == strings.TrimSpace(b.WorkspaceID)
+func matchesHerdrRuntimeIdentity(candidate, target HerdrRuntimeIdentity) bool {
+	candidatePaneID := strings.TrimSpace(candidate.PaneID)
+	targetPaneID := strings.TrimSpace(target.PaneID)
+	if targetPaneID == "" || candidatePaneID != targetPaneID {
+		return false
+	}
+	return herdrRuntimeFieldMatches(candidate.SocketPath, target.SocketPath) &&
+		herdrRuntimeFieldMatches(candidate.SessionName, target.SessionName) &&
+		herdrRuntimeFieldMatches(candidate.WorkspaceID, target.WorkspaceID) &&
+		herdrRuntimeFieldMatches(candidate.TabID, target.TabID)
+}
+
+func herdrRuntimeFieldMatches(candidate, target string) bool {
+	target = strings.TrimSpace(target)
+	return target == "" || strings.TrimSpace(candidate) == target
 }
 
 func (b TmuxBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -2,6 +2,7 @@ package multiplexer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -268,10 +269,78 @@ func TestHerdrOwnershipCompositeClearFallsBackToEmptySurvivor(t *testing.T) {
 	}
 }
 
+func TestHerdrOwnershipCompositeSetDoesNotFallThroughWhenAuthoritativeNonEmptyFails(t *testing.T) {
+	mutationErr := errors.New("authoritative set rejected")
+	authoritative := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-authoritative:1",
+		setErr:      mutationErr,
+	}
+	authoritativeCleanup := RegisterOwnershipBackend(authoritative)
+	t.Cleanup(authoritativeCleanup)
+	fallback := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-fallback:1",
+	}
+	fallbackCleanup := RegisterOwnershipBackend(fallback)
+	t.Cleanup(fallbackCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := backend.SetSessionOwnerMarker(context.Background(), "ctx-new", "work", 1234); !errors.Is(err, mutationErr) {
+		t.Fatalf("SetSessionOwnerMarker(work) error = %v, want authoritative mutation error", err)
+	}
+	if authoritative.setCalls != 1 || authoritative.owner != "ctx-authoritative:1" {
+		t.Fatalf("authoritative set calls=%d owner=%q, want failed mutation only on read winner", authoritative.setCalls, authoritative.owner)
+	}
+	if fallback.setCalls != 0 || fallback.owner != "ctx-fallback:1" {
+		t.Fatalf("fallback set calls=%d owner=%q, want no fallthrough mutation", fallback.setCalls, fallback.owner)
+	}
+}
+
+func TestHerdrOwnershipCompositeClearDoesNotFallThroughWhenAuthoritativeNonEmptyFails(t *testing.T) {
+	mutationErr := errors.New("authoritative clear rejected")
+	authoritative := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-authoritative:1",
+		clearErr:    mutationErr,
+	}
+	authoritativeCleanup := RegisterOwnershipBackend(authoritative)
+	t.Cleanup(authoritativeCleanup)
+	fallback := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-fallback:1",
+	}
+	fallbackCleanup := RegisterOwnershipBackend(fallback)
+	t.Cleanup(fallbackCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := backend.ClearSessionOwnerMarker(context.Background(), "work"); !errors.Is(err, mutationErr) {
+		t.Fatalf("ClearSessionOwnerMarker(work) error = %v, want authoritative mutation error", err)
+	}
+	if authoritative.clearCalls != 1 || authoritative.owner != "ctx-authoritative:1" {
+		t.Fatalf("authoritative clear calls=%d owner=%q, want failed mutation only on read winner", authoritative.clearCalls, authoritative.owner)
+	}
+	if fallback.clearCalls != 0 || fallback.owner != "ctx-fallback:1" {
+		t.Fatalf("fallback clear calls=%d owner=%q, want no fallthrough mutation", fallback.clearCalls, fallback.owner)
+	}
+}
+
 type testOwnershipBackend struct {
 	kind        BackendKind
 	sessionName string
 	owner       string
+	setErr      error
+	clearErr    error
 	setCalls    int
 	clearCalls  int
 }
@@ -292,6 +361,9 @@ func (t *testOwnershipBackend) SetSessionOwnerMarker(_ context.Context, contextI
 		return fmt.Errorf("session %q not owned", sessionName)
 	}
 	t.setCalls++
+	if t.setErr != nil {
+		return t.setErr
+	}
 	t.owner = contextID + ":" + strconv.Itoa(pid)
 	return nil
 }
@@ -301,6 +373,9 @@ func (t *testOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, sessio
 		return fmt.Errorf("session %q not owned", sessionName)
 	}
 	t.clearCalls++
+	if t.clearErr != nil {
+		return t.clearErr
+	}
 	t.owner = ""
 	return nil
 }

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -137,6 +137,46 @@ func TestRegisterOwnershipBackendKeepsConcurrentHerdrBackendsAddressable(t *test
 	}
 }
 
+func TestHerdrOwnershipCompositeSkipsEmptySessionMarker(t *testing.T) {
+	emptyCleanup := RegisterOwnershipBackend(&testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "",
+	})
+	t.Cleanup(emptyCleanup)
+	healthyCleanup := RegisterOwnershipBackend(&testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-work:1",
+	})
+	t.Cleanup(healthyCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	got, err := backend.SessionOwnerMarker(context.Background(), "work")
+	if err != nil {
+		t.Fatalf("SessionOwnerMarker(work) error = %v", err)
+	}
+	if got != "ctx-work:1" {
+		t.Fatalf("SessionOwnerMarker(work) = %q, want later healthy backend marker", got)
+	}
+
+	healthyCleanup()
+	backend, err = OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr after healthy cleanup) error = %v", err)
+	}
+	got, err = backend.SessionOwnerMarker(context.Background(), "work")
+	if err != nil {
+		t.Fatalf("SessionOwnerMarker(work after healthy cleanup) error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("SessionOwnerMarker(work after healthy cleanup) = %q, want empty marker", got)
+	}
+}
+
 type testOwnershipBackend struct {
 	kind        BackendKind
 	sessionName string

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -505,6 +505,93 @@ func TestHerdrOwnershipCompositeRejectsAmbiguousReducedPaneRuntime(t *testing.T)
 	}
 }
 
+func TestHerdrOwnershipCompositeDoesNotProbeAfterQualifiedPaneMiss(t *testing.T) {
+	paneID := "pane-qualified-miss"
+	first := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime: HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr-qualified-a.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-a",
+			PaneID:      paneID,
+		},
+		paneOwner: "ctx-a",
+	}
+	firstCleanup := RegisterOwnershipBackend(first)
+	t.Cleanup(firstCleanup)
+	second := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime: HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr-qualified-b.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-b",
+			PaneID:      "other-pane",
+		},
+	}
+	secondCleanup := RegisterOwnershipBackend(second)
+	t.Cleanup(secondCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	for _, tt := range []struct {
+		name    string
+		runtime HerdrRuntimeIdentity
+	}{
+		{
+			name: "socket",
+			runtime: HerdrRuntimeIdentity{
+				SocketPath:  "/tmp/herdr-missing.sock",
+				SessionName: "work",
+				WorkspaceID: "workspace-a",
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "session",
+			runtime: HerdrRuntimeIdentity{
+				SessionName: "missing",
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "workspace",
+			runtime: HerdrRuntimeIdentity{
+				SocketPath:  "/tmp/herdr-qualified-a.sock",
+				SessionName: "work",
+				WorkspaceID: "missing",
+				PaneID:      paneID,
+			},
+		},
+		{
+			name: "tab",
+			runtime: HerdrRuntimeIdentity{
+				TabID:  "missing-tab",
+				PaneID: paneID,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pane := HerdrPaneIDForRuntime(tt.runtime, paneID)
+			if _, err := backend.PaneOwnerMarker(context.Background(), pane); err == nil {
+				t.Fatal("PaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if err := backend.SetPaneOwnerMarker(context.Background(), pane, "ctx-new"); err == nil {
+				t.Fatal("SetPaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if err := backend.ClearPaneOwnerMarker(context.Background(), pane); err == nil {
+				t.Fatal("ClearPaneOwnerMarker(qualified miss) error = nil, want fail-closed miss")
+			}
+			if first.paneSetCalls != 0 || first.paneClearCalls != 0 || first.paneOwner != "ctx-a" {
+				t.Fatalf("qualified miss mutated fallback backend set/clear/owner=%d/%d/%q", first.paneSetCalls, first.paneClearCalls, first.paneOwner)
+			}
+		})
+	}
+}
+
 type testOwnershipBackend struct {
 	kind           BackendKind
 	sessionName    string

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -335,18 +335,72 @@ func TestHerdrOwnershipCompositeClearDoesNotFallThroughWhenAuthoritativeNonEmpty
 	}
 }
 
+func TestHerdrOwnershipCompositeSelectsPaneBackendByRuntimeIdentity(t *testing.T) {
+	first := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime: HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr-a.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-a",
+			PaneID:      "pane-1",
+		},
+	}
+	firstCleanup := RegisterOwnershipBackend(first)
+	t.Cleanup(firstCleanup)
+	second := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime: HerdrRuntimeIdentity{
+			SocketPath:  "/tmp/herdr-b.sock",
+			SessionName: "work",
+			WorkspaceID: "workspace-b",
+			PaneID:      "pane-1",
+		},
+	}
+	secondCleanup := RegisterOwnershipBackend(second)
+	t.Cleanup(secondCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	pane := HerdrPaneIDForRuntime(HerdrRuntimeIdentity{
+		SocketPath:  "/tmp/herdr-b.sock",
+		SessionName: "work",
+		WorkspaceID: "workspace-b",
+		PaneID:      "pane-1",
+	}, "pane-1")
+	if err := backend.SetPaneOwnerMarker(context.Background(), pane, "ctx-b"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(runtime b) error = %v", err)
+	}
+	if first.paneSetCalls != 0 {
+		t.Fatalf("first runtime pane set calls = %d, want 0", first.paneSetCalls)
+	}
+	if second.paneSetCalls != 1 || second.paneOwner != "ctx-b" {
+		t.Fatalf("second runtime pane set calls=%d owner=%q, want selected runtime", second.paneSetCalls, second.paneOwner)
+	}
+}
+
 type testOwnershipBackend struct {
-	kind        BackendKind
-	sessionName string
-	owner       string
-	setErr      error
-	clearErr    error
-	setCalls    int
-	clearCalls  int
+	kind         BackendKind
+	sessionName  string
+	owner        string
+	runtime      HerdrRuntimeIdentity
+	paneOwner    string
+	setErr       error
+	clearErr     error
+	setCalls     int
+	clearCalls   int
+	paneSetCalls int
 }
 
 func (t *testOwnershipBackend) Kind() BackendKind {
 	return t.kind
+}
+
+func (t *testOwnershipBackend) HerdrRuntimeIdentity() HerdrRuntimeIdentity {
+	return t.runtime
 }
 
 func (t *testOwnershipBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {
@@ -380,12 +434,20 @@ func (t *testOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, sessio
 	return nil
 }
 
-func (t *testOwnershipBackend) PaneOwnerMarker(context.Context, ResourceID) (string, error) {
-	return "", fmt.Errorf("pane not owned")
+func (t *testOwnershipBackend) PaneOwnerMarker(_ context.Context, pane ResourceID) (string, error) {
+	if t.runtime.PaneID == "" || pane.Native != t.runtime.PaneID {
+		return "", fmt.Errorf("pane not owned")
+	}
+	return t.paneOwner, nil
 }
 
-func (t *testOwnershipBackend) SetPaneOwnerMarker(context.Context, ResourceID, string) error {
-	return fmt.Errorf("pane not owned")
+func (t *testOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane ResourceID, contextID string) error {
+	if t.runtime.PaneID == "" || pane.Native != t.runtime.PaneID {
+		return fmt.Errorf("pane not owned")
+	}
+	t.paneSetCalls++
+	t.paneOwner = contextID
+	return nil
 }
 
 func (t *testOwnershipBackend) ClearPaneOwnerMarker(context.Context, ResourceID) error {

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -382,17 +382,141 @@ func TestHerdrOwnershipCompositeSelectsPaneBackendByRuntimeIdentity(t *testing.T
 	}
 }
 
+func TestHerdrOwnershipCompositeKeepsTabDistinctPaneBackendsIsolated(t *testing.T) {
+	paneID := "pane-shared"
+	firstRuntime := HerdrRuntimeIdentity{
+		SocketPath:  "/tmp/herdr-tab.sock",
+		SessionName: "work",
+		WorkspaceID: "workspace-1",
+		TabID:       "workspace-1:tab-1",
+		PaneID:      paneID,
+	}
+	secondRuntime := firstRuntime
+	secondRuntime.TabID = "workspace-1:tab-2"
+	first := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime:     firstRuntime,
+		paneOwner:   "ctx-tab-1",
+	}
+	firstCleanup := RegisterOwnershipBackend(first)
+	t.Cleanup(firstCleanup)
+	second := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime:     secondRuntime,
+		paneOwner:   "ctx-tab-2",
+	}
+	secondCleanup := RegisterOwnershipBackend(second)
+	t.Cleanup(secondCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	secondPane := HerdrPaneIDForRuntime(secondRuntime, paneID)
+	if got, err := backend.PaneOwnerMarker(context.Background(), secondPane); err != nil || got != "ctx-tab-2" {
+		t.Fatalf("PaneOwnerMarker(second exact) = %q, %v; want ctx-tab-2", got, err)
+	}
+	if err := backend.SetPaneOwnerMarker(context.Background(), secondPane, "ctx-updated"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(second exact) error = %v", err)
+	}
+	if second.paneSetCalls != 1 || second.paneOwner != "ctx-updated" || first.paneSetCalls != 0 || first.paneOwner != "ctx-tab-1" {
+		t.Fatalf("set calls/owners first=%d/%q second=%d/%q, want second only", first.paneSetCalls, first.paneOwner, second.paneSetCalls, second.paneOwner)
+	}
+	if err := backend.ClearPaneOwnerMarker(context.Background(), secondPane); err != nil {
+		t.Fatalf("ClearPaneOwnerMarker(second exact) error = %v", err)
+	}
+	if second.paneClearCalls != 1 || second.paneOwner != "" || first.paneClearCalls != 0 || first.paneOwner != "ctx-tab-1" {
+		t.Fatalf("clear calls/owners first=%d/%q second=%d/%q, want second only", first.paneClearCalls, first.paneOwner, second.paneClearCalls, second.paneOwner)
+	}
+}
+
+func TestHerdrOwnershipCompositeRejectsAmbiguousReducedPaneRuntime(t *testing.T) {
+	paneID := "pane-shared-reduced"
+	firstRuntime := HerdrRuntimeIdentity{
+		SocketPath:  "/tmp/herdr-reduced.sock",
+		SessionName: "work",
+		WorkspaceID: "workspace-1",
+		TabID:       "workspace-1:tab-1",
+		PaneID:      paneID,
+	}
+	secondRuntime := firstRuntime
+	secondRuntime.TabID = "workspace-1:tab-2"
+	first := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime:     firstRuntime,
+		paneOwner:   "ctx-tab-1",
+	}
+	firstCleanup := RegisterOwnershipBackend(first)
+	t.Cleanup(firstCleanup)
+	second := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		runtime:     secondRuntime,
+		paneOwner:   "ctx-tab-2",
+	}
+	secondCleanup := RegisterOwnershipBackend(second)
+	t.Cleanup(secondCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	reducedPane := HerdrPaneIDForRuntime(HerdrRuntimeIdentity{
+		SocketPath:  firstRuntime.SocketPath,
+		SessionName: firstRuntime.SessionName,
+		WorkspaceID: firstRuntime.WorkspaceID,
+		PaneID:      paneID,
+	}, paneID)
+	if _, err := backend.PaneOwnerMarker(context.Background(), reducedPane); err == nil {
+		t.Fatal("PaneOwnerMarker(reduced ambiguous) error = nil, want fail-closed ambiguity")
+	}
+	if err := backend.SetPaneOwnerMarker(context.Background(), reducedPane, "ctx-new"); err == nil {
+		t.Fatal("SetPaneOwnerMarker(reduced ambiguous) error = nil, want fail-closed ambiguity")
+	}
+	if err := backend.ClearPaneOwnerMarker(context.Background(), reducedPane); err == nil {
+		t.Fatal("ClearPaneOwnerMarker(reduced ambiguous) error = nil, want fail-closed ambiguity")
+	}
+	if first.paneSetCalls != 0 || second.paneSetCalls != 0 || first.paneClearCalls != 0 || second.paneClearCalls != 0 {
+		t.Fatalf("ambiguous reduced mutation reached candidates: first set/clear=%d/%d second set/clear=%d/%d", first.paneSetCalls, first.paneClearCalls, second.paneSetCalls, second.paneClearCalls)
+	}
+
+	secondCleanup()
+	backend, err = OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr after unregister) error = %v", err)
+	}
+	if got, err := backend.PaneOwnerMarker(context.Background(), reducedPane); err != nil || got != "ctx-tab-1" {
+		t.Fatalf("PaneOwnerMarker(reduced unique) = %q, %v; want ctx-tab-1", got, err)
+	}
+	if err := backend.SetPaneOwnerMarker(context.Background(), reducedPane, "ctx-unique"); err != nil {
+		t.Fatalf("SetPaneOwnerMarker(reduced unique) error = %v", err)
+	}
+	if first.paneSetCalls != 1 || first.paneOwner != "ctx-unique" {
+		t.Fatalf("unique reduced set calls=%d owner=%q, want first selected", first.paneSetCalls, first.paneOwner)
+	}
+	if err := backend.ClearPaneOwnerMarker(context.Background(), reducedPane); err != nil {
+		t.Fatalf("ClearPaneOwnerMarker(reduced unique) error = %v", err)
+	}
+	if first.paneClearCalls != 1 || first.paneOwner != "" {
+		t.Fatalf("unique reduced clear calls=%d owner=%q, want first cleared", first.paneClearCalls, first.paneOwner)
+	}
+}
+
 type testOwnershipBackend struct {
-	kind         BackendKind
-	sessionName  string
-	owner        string
-	runtime      HerdrRuntimeIdentity
-	paneOwner    string
-	setErr       error
-	clearErr     error
-	setCalls     int
-	clearCalls   int
-	paneSetCalls int
+	kind           BackendKind
+	sessionName    string
+	owner          string
+	runtime        HerdrRuntimeIdentity
+	paneOwner      string
+	setErr         error
+	clearErr       error
+	setCalls       int
+	clearCalls     int
+	paneSetCalls   int
+	paneClearCalls int
 }
 
 func (t *testOwnershipBackend) Kind() BackendKind {
@@ -438,6 +562,9 @@ func (t *testOwnershipBackend) PaneOwnerMarker(_ context.Context, pane ResourceI
 	if t.runtime.PaneID == "" || pane.Native != t.runtime.PaneID {
 		return "", fmt.Errorf("pane not owned")
 	}
+	if pane.HerdrRuntime.TabID != "" && pane.HerdrRuntime.TabID != t.runtime.TabID {
+		return "", fmt.Errorf("pane not owned")
+	}
 	return t.paneOwner, nil
 }
 
@@ -445,11 +572,22 @@ func (t *testOwnershipBackend) SetPaneOwnerMarker(_ context.Context, pane Resour
 	if t.runtime.PaneID == "" || pane.Native != t.runtime.PaneID {
 		return fmt.Errorf("pane not owned")
 	}
+	if pane.HerdrRuntime.TabID != "" && pane.HerdrRuntime.TabID != t.runtime.TabID {
+		return fmt.Errorf("pane not owned")
+	}
 	t.paneSetCalls++
 	t.paneOwner = contextID
 	return nil
 }
 
-func (t *testOwnershipBackend) ClearPaneOwnerMarker(context.Context, ResourceID) error {
-	return fmt.Errorf("pane not owned")
+func (t *testOwnershipBackend) ClearPaneOwnerMarker(_ context.Context, pane ResourceID) error {
+	if t.runtime.PaneID == "" || pane.Native != t.runtime.PaneID {
+		return fmt.Errorf("pane not owned")
+	}
+	if pane.HerdrRuntime.TabID != "" && pane.HerdrRuntime.TabID != t.runtime.TabID {
+		return fmt.Errorf("pane not owned")
+	}
+	t.paneClearCalls++
+	t.paneOwner = ""
+	return nil
 }

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -177,10 +177,103 @@ func TestHerdrOwnershipCompositeSkipsEmptySessionMarker(t *testing.T) {
 	}
 }
 
+func TestHerdrOwnershipCompositeSetUsesNonEmptySessionBackend(t *testing.T) {
+	empty := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "",
+	}
+	emptyCleanup := RegisterOwnershipBackend(empty)
+	t.Cleanup(emptyCleanup)
+	healthy := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-old:1",
+	}
+	healthyCleanup := RegisterOwnershipBackend(healthy)
+	t.Cleanup(healthyCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := backend.SetSessionOwnerMarker(context.Background(), "ctx-new", "work", 1234); err != nil {
+		t.Fatalf("SetSessionOwnerMarker(work) error = %v", err)
+	}
+	if empty.setCalls != 0 {
+		t.Fatalf("empty backend set calls = %d, want 0", empty.setCalls)
+	}
+	if healthy.setCalls != 1 || healthy.owner != "ctx-new:1234" {
+		t.Fatalf("healthy set calls=%d owner=%q, want one mutation to selected backend", healthy.setCalls, healthy.owner)
+	}
+}
+
+func TestHerdrOwnershipCompositeClearUsesNonEmptySessionBackend(t *testing.T) {
+	empty := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "",
+	}
+	emptyCleanup := RegisterOwnershipBackend(empty)
+	t.Cleanup(emptyCleanup)
+	healthy := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-old:1",
+	}
+	healthyCleanup := RegisterOwnershipBackend(healthy)
+	t.Cleanup(healthyCleanup)
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := backend.ClearSessionOwnerMarker(context.Background(), "work"); err != nil {
+		t.Fatalf("ClearSessionOwnerMarker(work) error = %v", err)
+	}
+	if empty.clearCalls != 0 {
+		t.Fatalf("empty backend clear calls = %d, want 0", empty.clearCalls)
+	}
+	if healthy.clearCalls != 1 || healthy.owner != "" {
+		t.Fatalf("healthy clear calls=%d owner=%q, want one clear on selected backend", healthy.clearCalls, healthy.owner)
+	}
+}
+
+func TestHerdrOwnershipCompositeClearFallsBackToEmptySurvivor(t *testing.T) {
+	empty := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "",
+	}
+	emptyCleanup := RegisterOwnershipBackend(empty)
+	t.Cleanup(emptyCleanup)
+	healthy := &testOwnershipBackend{
+		kind:        BackendKindHerdr,
+		sessionName: "work",
+		owner:       "ctx-old:1",
+	}
+	healthyCleanup := RegisterOwnershipBackend(healthy)
+	t.Cleanup(healthyCleanup)
+	healthyCleanup()
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	if err := backend.ClearSessionOwnerMarker(context.Background(), "work"); err != nil {
+		t.Fatalf("ClearSessionOwnerMarker(work) with empty survivor error = %v", err)
+	}
+	if empty.clearCalls != 1 {
+		t.Fatalf("empty survivor clear calls = %d, want 1", empty.clearCalls)
+	}
+}
+
 type testOwnershipBackend struct {
 	kind        BackendKind
 	sessionName string
 	owner       string
+	setCalls    int
+	clearCalls  int
 }
 
 func (t *testOwnershipBackend) Kind() BackendKind {
@@ -194,11 +287,21 @@ func (t *testOwnershipBackend) SessionOwnerMarker(_ context.Context, sessionName
 	return t.owner, nil
 }
 
-func (t *testOwnershipBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+func (t *testOwnershipBackend) SetSessionOwnerMarker(_ context.Context, contextID string, sessionName string, pid int) error {
+	if sessionName != t.sessionName {
+		return fmt.Errorf("session %q not owned", sessionName)
+	}
+	t.setCalls++
+	t.owner = contextID + ":" + strconv.Itoa(pid)
 	return nil
 }
 
-func (t *testOwnershipBackend) ClearSessionOwnerMarker(context.Context, string) error {
+func (t *testOwnershipBackend) ClearSessionOwnerMarker(_ context.Context, sessionName string) error {
+	if sessionName != t.sessionName {
+		return fmt.Errorf("session %q not owned", sessionName)
+	}
+	t.clearCalls++
+	t.owner = ""
 	return nil
 }
 

--- a/internal/multiplexer/ownership_test.go
+++ b/internal/multiplexer/ownership_test.go
@@ -2,7 +2,10 @@ package multiplexer
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/tmuxtest"
@@ -90,4 +93,83 @@ func TestTmuxBackendSetAndClearPaneOwnerMarker(t *testing.T) {
 	if got := fake.Invocations(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("invocations = %#v, want %#v", got, want)
 	}
+}
+
+func TestRegisterOwnershipBackendKeepsConcurrentHerdrBackendsAddressable(t *testing.T) {
+	const backendCount = 1000
+	cleanups := make([]func(), backendCount)
+	var wg sync.WaitGroup
+	for i := 0; i < backendCount; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cleanups[i] = RegisterOwnershipBackend(&testOwnershipBackend{
+				kind:        BackendKindHerdr,
+				sessionName: "session-" + strconv.Itoa(i),
+				owner:       "ctx-" + strconv.Itoa(i) + ":1",
+			})
+		}()
+	}
+	wg.Wait()
+	t.Cleanup(func() {
+		for _, cleanup := range cleanups {
+			if cleanup != nil {
+				cleanup()
+			}
+		}
+	})
+
+	backend, err := OwnershipBackendForKind(BackendKindHerdr)
+	if err != nil {
+		t.Fatalf("OwnershipBackendForKind(herdr) error = %v", err)
+	}
+	for i := 0; i < backendCount; i++ {
+		sessionName := "session-" + strconv.Itoa(i)
+		want := "ctx-" + strconv.Itoa(i) + ":1"
+		got, err := backend.SessionOwnerMarker(context.Background(), sessionName)
+		if err != nil {
+			t.Fatalf("SessionOwnerMarker(%q) error = %v", sessionName, err)
+		}
+		if got != want {
+			t.Fatalf("SessionOwnerMarker(%q) = %q, want %q", sessionName, got, want)
+		}
+	}
+}
+
+type testOwnershipBackend struct {
+	kind        BackendKind
+	sessionName string
+	owner       string
+}
+
+func (t *testOwnershipBackend) Kind() BackendKind {
+	return t.kind
+}
+
+func (t *testOwnershipBackend) SessionOwnerMarker(_ context.Context, sessionName string) (string, error) {
+	if sessionName != t.sessionName {
+		return "", fmt.Errorf("session %q not owned", sessionName)
+	}
+	return t.owner, nil
+}
+
+func (t *testOwnershipBackend) SetSessionOwnerMarker(context.Context, string, string, int) error {
+	return nil
+}
+
+func (t *testOwnershipBackend) ClearSessionOwnerMarker(context.Context, string) error {
+	return nil
+}
+
+func (t *testOwnershipBackend) PaneOwnerMarker(context.Context, ResourceID) (string, error) {
+	return "", fmt.Errorf("pane not owned")
+}
+
+func (t *testOwnershipBackend) SetPaneOwnerMarker(context.Context, ResourceID, string) error {
+	return fmt.Errorf("pane not owned")
+}
+
+func (t *testOwnershipBackend) ClearPaneOwnerMarker(context.Context, ResourceID) error {
+	return fmt.Errorf("pane not owned")
 }

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -159,10 +159,7 @@ func (n *PaneNotifier) SendToPane(paneID string, message string, enterDelay time
 	}
 	n.lastNotified[paneID] = now
 	n.mu.Unlock()
-	// Wrap with protocol sentinels so all pane output is clearly delimited.
-	message = "<!-- message start -->\n" + message + "\n<!-- end of message -->"
-	// Security: Sanitize message for tmux set-buffer (#301)
-	sanitized, err := sanitizeForTmux(message)
+	sanitized, err := PrepareInteractivePaneMessage(message)
 	if err != nil {
 		n.warnf("⚠️  postman: WARNING: sanitizeForTmux: %v\n", err)
 		return err
@@ -362,8 +359,18 @@ func StripVT(s string) (string, error) {
 	return string(buf), nil
 }
 
-// sanitizeForTmux sanitizes a string for safe use with tmux set-buffer
-// by stripping VT/ANSI sequences and invalid UTF-8 (#301).
-func sanitizeForTmux(s string) (string, error) {
+// PrepareInteractivePaneMessage wraps pane delivery with protocol sentinels and
+// strips VT/ANSI sequences before the target backend receives text.
+func PrepareInteractivePaneMessage(message string) (string, error) {
+	if strings.TrimSpace(message) == "" {
+		return "", fmt.Errorf("empty notification body")
+	}
+	message = "<!-- message start -->\n" + message + "\n<!-- end of message -->"
+	return sanitizeForPaneText(message)
+}
+
+// sanitizeForPaneText sanitizes a string for safe interactive pane text by
+// stripping VT/ANSI sequences and invalid UTF-8 (#301).
+func sanitizeForPaneText(s string) (string, error) {
 	return StripVT(s)
 }


### PR DESCRIPTION
## Summary

Adds gated Herdr interactive delivery and ownership mutation paths after read-only validation, including rediscovery error preservation.

Part of parent issue #652. Depends conceptually on #660 and #658 after the tmux-preserving abstraction issues. Review order: #653, #656, #654, #655, #657, #660, #658, #659.

## Validation

Previously verified in the issue worktree with focused lifecycle/rediscovery checks plus full ok  	github.com/i9wa4/tmux-a2a-postman	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/e2e	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/agentruntime	(cached)
?   	github.com/i9wa4/tmux-a2a-postman/internal/autoping	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/binding	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/cli	(cached)
?   	github.com/i9wa4/tmux-a2a-postman/internal/cliutil	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/config	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/controlplane	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/daemon	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/discovery	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/envelope	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/idle	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/journal	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/lock	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/message	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/msgtrace	(cached)
?   	github.com/i9wa4/tmux-a2a-postman/internal/nodeaddr	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/notification	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/paneutil	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/ping	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/projection	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/reconciler	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/router	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/runtimecontext	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/runtimeprofile	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/session	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/status	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/store	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/template	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/testfixture	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tmuxrunner	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tmuxtest	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/tui	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/uinode	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/verdictbackfill	(cached)
?   	github.com/i9wa4/tmux-a2a-postman/internal/verdictgate	[no test files]
ok  	github.com/i9wa4/tmux-a2a-postman/internal/version	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/internal/workspacetree	(cached)
ok  	github.com/i9wa4/tmux-a2a-postman/scripts/validation	(cached), , and .

Closes #659