### PR TITLE
fix(approval): prune stale decision history (#662)

### DIFF
--- a/docs/command-approvals.md
+++ b/docs/command-approvals.md
@@ -165,7 +165,44 @@ tmux-a2a-postman inspect-command-approvals
 The output shows each approval thread with requester, reviewer, label,
 category, digest, reason, expiry, timestamps, and status.
 
-## 6. Boundary
+## 6. Decision History
+
+Approver approval and rejection decisions are also accumulated as individual
+JSON files under:
+
+```text
+<session-dir>/command-approval-decisions/
+```
+
+Each file is named from the underlying journal event sequence and id. The
+layout is intentionally file-oriented instead of JSONL so maintainers can
+inspect, copy, remove, or archive one decision record at a time with ordinary
+filesystem tools.
+
+The schema includes:
+
+- `thread_id`, `decision`, and `effective_status`
+- requester, reviewer audit label, and trusted `command_approver_node`
+- label, category, mode, command digest, and request/decision reasons
+- requested, expiry, and decided timestamps
+- `decision_message_id` when the decision came from a reply
+
+Raw command text is omitted by default. It appears only when the original
+request opted into existing `--store-command-text` audit behavior, so the
+decision history keeps the same privacy boundary as the durable journal.
+
+Allowlist maintainers can search the accumulated history directly, for example:
+
+```sh
+find "$SESSION_DIR/command-approval-decisions" -name '*.json' -print
+rg '"decision":"approved"|"decision":"rejected"' "$SESSION_DIR/command-approval-decisions"
+```
+
+No automatic retention policy deletes these records. Treat them as local,
+owner-only audit data and rotate or archive the directory according to the
+operator's local retention policy.
+
+## 7. Boundary
 
 This is coordination, not enforcement. `execute-bash` does not sandbox bash,
 prevent direct shell execution, prevent another process from running the same

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -307,7 +307,7 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 		return err
 	}
 	if err := journal.SyncCommandApprovalDecisionHistory(opts.sessionDir); err != nil {
-		return err
+		_, _ = fmt.Fprintf(ctx.stderr, "postman: warning: command approval decision history sync failed after recording decision: %v\n", err)
 	}
 	result := executeBashResult{
 		Status:         "decision_recorded",

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -306,6 +306,9 @@ func recordExecuteBashDecision(ctx commandContext, opts executeBashDecisionOptio
 	if err := appendCommandEvent(opts.sessionDir, opts.contextID, opts.sessionName, journal.CommandApprovalDecidedEventType, journal.VisibilityOperatorVisible, payload, opts.threadID, ctx.now()); err != nil {
 		return err
 	}
+	if err := journal.SyncCommandApprovalDecisionHistory(opts.sessionDir); err != nil {
+		return err
+	}
 	result := executeBashResult{
 		Status:         "decision_recorded",
 		Reviewer:       authenticatedCaller,

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -883,6 +883,50 @@ func TestRunExecuteBashDecisionHistoryCommandTextOptIn(t *testing.T) {
 	}
 }
 
+func TestRunExecuteBashRecordDecisionWarnsWhenDecisionHistorySyncFailsAfterAppend(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	policy := resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Mode:      "blocking",
+		Label:     "protected",
+		TTL:       defaultCommandApprovalTTL,
+	}
+	threadID := fixture.appendCommandApprovalRequest(t, policy, "printf approve-with-history-sync-failure", time.Now().Add(time.Hour))
+	if err := os.WriteFile(journal.CommandApprovalDecisionHistoryDir(fixture.sessionDir), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile(history path as file) error = %v", err)
+	}
+
+	err := runExecuteBashWithContext(fixture.contextAsPane("orchestrator"), fixture.args(
+		"--thread-id", threadID,
+		"--record-decision", "approved",
+		"--reason", "authoritative decision survives derived sync failure",
+	))
+	if err != nil {
+		t.Fatalf("runExecuteBashWithContext(record decision) error = %v, want nil after authoritative append: stderr=%s", err, fixture.stderr.String())
+	}
+	if !strings.Contains(fixture.stderr.String(), "command approval decision history sync failed after recording decision") {
+		t.Fatalf("stderr = %q, want decision history sync warning", fixture.stderr.String())
+	}
+
+	state, ok, err := projection.ProjectCommandApprovalState(fixture.sessionDir, fixture.now)
+	if err != nil {
+		t.Fatalf("ProjectCommandApprovalState() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectCommandApprovalState() ok = false, want true")
+	}
+	if got := state.Threads[threadID].Status; got != projection.CommandApprovalStatusApproved {
+		t.Fatalf("thread status = %q, want approved", got)
+	}
+}
+
 func (f *executeBashFixture) appendCommandApproval(t *testing.T, policy resolvedCommandApprovalPolicy, commandText string, decision journal.ApprovalDecision, decisionReviewer string, expiresAt time.Time) string {
 	t.Helper()
 

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -745,6 +745,68 @@ func TestRunExecuteBashRecordDecisionAndInspectCommandApprovals(t *testing.T) {
 	if thread.DecidedAt == "" {
 		t.Fatalf("thread missing decided_at: %#v", thread)
 	}
+
+	history, err := journal.ListCommandApprovalDecisionHistory(fixture.sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("decision history entries = %d, want 1", len(history))
+	}
+	entry := history[0]
+	if entry.ThreadID != threadID || entry.Decision != journal.ApprovalDecisionApproved || entry.EffectiveStatus != "approved" {
+		t.Fatalf("decision history = %#v, want approved entry for thread %q", entry, threadID)
+	}
+	if entry.Requester != "worker" || entry.DecisionReviewer != "orchestrator" || entry.CommandApproverNode != "orchestrator" {
+		t.Fatalf("decision history identities = %#v", entry)
+	}
+	if entry.Label != "protected" || entry.CommandHash == "" || entry.DecisionReason != "digest reviewed" {
+		t.Fatalf("decision history command metadata = %#v", entry)
+	}
+	if entry.CommandText != "" {
+		t.Fatalf("decision history stored command text by default: %#v", entry)
+	}
+}
+
+func TestRunExecuteBashRecordRejectedDecisionWritesDecisionHistory(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	policy := resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Mode:      "blocking",
+		Label:     "protected",
+		TTL:       defaultCommandApprovalTTL,
+	}
+	threadID := fixture.appendCommandApprovalRequest(t, policy, "printf reject-me", time.Now().Add(time.Hour))
+
+	err := runExecuteBashWithContext(fixture.contextAsPane("orchestrator"), fixture.args(
+		"--thread-id", threadID,
+		"--record-decision", "rejected",
+		"--reason", "too broad for allowlist",
+	))
+	if err != nil {
+		t.Fatalf("runExecuteBashWithContext(record rejected decision) error = %v", err)
+	}
+
+	history, err := journal.ListCommandApprovalDecisionHistory(fixture.sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("decision history entries = %d, want 1", len(history))
+	}
+	if history[0].Decision != journal.ApprovalDecisionRejected || history[0].EffectiveStatus != "rejected" {
+		t.Fatalf("decision history = %#v, want rejected entry", history[0])
+	}
+	if history[0].DecisionReason != "too broad for allowlist" {
+		t.Fatalf("decision reason = %q, want allowlist review reason", history[0].DecisionReason)
+	}
 }
 
 func (f *executeBashFixture) appendCommandApproval(t *testing.T, policy resolvedCommandApprovalPolicy, commandText string, decision journal.ApprovalDecision, decisionReviewer string, expiresAt time.Time) string {

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -809,6 +809,80 @@ func TestRunExecuteBashRecordRejectedDecisionWritesDecisionHistory(t *testing.T)
 	}
 }
 
+func TestRunExecuteBashFailsOpenDoesNotWriteDecisionHistory(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	fixture.commandApproverNode = ""
+	fixture.nodes = nil
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--command", "printf fail-open",
+	))
+	if err != nil {
+		t.Fatalf("runExecuteBashWithContext() error = %v, want nil (fail open)", err)
+	}
+
+	history, err := journal.ListCommandApprovalDecisionHistory(fixture.sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 0 {
+		t.Fatalf("decision history entries = %d, want 0 for auto_approved_no_reviewer: %#v", len(history), history)
+	}
+}
+
+func TestRunExecuteBashDecisionHistoryCommandTextOptIn(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	commandText := "printf store-me"
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--store-command-text",
+		"--command", commandText,
+	))
+	if err == nil {
+		t.Fatal("initial blocking command error = nil, want pending approval")
+	}
+	threadID := commandApprovalThreadID(resolvedCommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Mode:      "blocking",
+		Label:     "protected",
+	}, commandDigest(commandText))
+
+	err = runExecuteBashWithContext(fixture.contextAsPane("orchestrator"), fixture.args(
+		"--thread-id", threadID,
+		"--record-decision", "approved",
+		"--reason", "safe exact command",
+	))
+	if err != nil {
+		t.Fatalf("record decision error = %v", err)
+	}
+
+	history, err := journal.ListCommandApprovalDecisionHistory(fixture.sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("decision history entries = %d, want 1", len(history))
+	}
+	if history[0].CommandText != commandText {
+		t.Fatalf("command_text = %q, want opt-in command text %q", history[0].CommandText, commandText)
+	}
+}
+
 func (f *executeBashFixture) appendCommandApproval(t *testing.T, policy resolvedCommandApprovalPolicy, commandText string, decision journal.ApprovalDecision, decisionReviewer string, expiresAt time.Time) string {
 	t.Helper()
 

--- a/internal/journal/command_approval_decision_history.go
+++ b/internal/journal/command_approval_decision_history.go
@@ -47,6 +47,7 @@ func SyncCommandApprovalDecisionHistory(sessionDir string) error {
 	}
 	requests := make(map[string]CommandApprovalRequestPayload)
 	requestedAt := make(map[string]string)
+	expected := make(map[string]CommandApprovalDecisionHistoryEntry)
 	for _, event := range events {
 		switch event.Type {
 		case CommandApprovalRequestedEventType:
@@ -66,10 +67,19 @@ func SyncCommandApprovalDecisionHistory(sessionDir string) error {
 				continue
 			}
 			entry := commandApprovalDecisionHistoryEntry(event, request, requestedAt[event.ThreadID], payload)
-			if err := writeJSONAtomically(commandApprovalDecisionHistoryPath(sessionDir, event), entry); err != nil {
-				return fmt.Errorf("writing command approval decision history: %w", err)
-			}
+			expected[commandApprovalDecisionHistoryFilename(event)] = entry
 		}
+	}
+	if len(expected) == 0 {
+		return pruneCommandApprovalDecisionHistory(sessionDir, expected)
+	}
+	for filename, entry := range expected {
+		if err := writeJSONAtomically(filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), filename), entry); err != nil {
+			return fmt.Errorf("writing command approval decision history: %w", err)
+		}
+	}
+	if err := pruneCommandApprovalDecisionHistory(sessionDir, expected); err != nil {
+		return fmt.Errorf("pruning command approval decision history: %w", err)
 	}
 	return nil
 }
@@ -121,7 +131,33 @@ func commandApprovalDecisionEffectiveStatus(request CommandApprovalRequestPayloa
 }
 
 func commandApprovalDecisionHistoryPath(sessionDir string, event Event) string {
-	return filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), fmt.Sprintf("%012d-%s.json", event.Sequence, event.EventID))
+	return filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), commandApprovalDecisionHistoryFilename(event))
+}
+
+func commandApprovalDecisionHistoryFilename(event Event) string {
+	return fmt.Sprintf("%012d-%s.json", event.Sequence, event.EventID)
+}
+
+func pruneCommandApprovalDecisionHistory(sessionDir string, expected map[string]CommandApprovalDecisionHistoryEntry) error {
+	entries, err := os.ReadDir(CommandApprovalDecisionHistoryDir(sessionDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if _, ok := expected[entry.Name()]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ListCommandApprovalDecisionHistory(sessionDir string) ([]CommandApprovalDecisionHistoryEntry, error) {

--- a/internal/journal/command_approval_decision_history.go
+++ b/internal/journal/command_approval_decision_history.go
@@ -1,0 +1,143 @@
+package journal
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const commandApprovalDecisionHistorySchemaVersion = 1
+
+type CommandApprovalDecisionHistoryEntry struct {
+	SchemaVersion       int              `json:"schema_version"`
+	SessionKey          string           `json:"session_key"`
+	TmuxSessionName     string           `json:"tmux_session_name"`
+	Generation          int              `json:"generation"`
+	EventSequence       int              `json:"event_sequence"`
+	EventID             string           `json:"event_id"`
+	ThreadID            string           `json:"thread_id"`
+	Decision            ApprovalDecision `json:"decision"`
+	EffectiveStatus     string           `json:"effective_status"`
+	Requester           string           `json:"requester,omitempty"`
+	Reviewer            string           `json:"reviewer,omitempty"`
+	CommandApproverNode string           `json:"command_approver_node,omitempty"`
+	DecisionReviewer    string           `json:"decision_reviewer"`
+	Mode                string           `json:"mode,omitempty"`
+	Label               string           `json:"label,omitempty"`
+	Category            string           `json:"category,omitempty"`
+	CommandHash         string           `json:"command_hash,omitempty"`
+	RequestReason       string           `json:"request_reason,omitempty"`
+	DecisionReason      string           `json:"decision_reason,omitempty"`
+	RequestedAt         string           `json:"requested_at,omitempty"`
+	ExpiresAt           string           `json:"expires_at,omitempty"`
+	DecidedAt           string           `json:"decided_at"`
+	DecisionMessageID   string           `json:"decision_message_id,omitempty"`
+	CommandText         string           `json:"command_text,omitempty"`
+}
+
+func CommandApprovalDecisionHistoryDir(sessionDir string) string {
+	return filepath.Join(sessionDir, "command-approval-decisions")
+}
+
+func SyncCommandApprovalDecisionHistory(sessionDir string) error {
+	events, err := Replay(sessionDir)
+	if err != nil {
+		return err
+	}
+	requests := make(map[string]CommandApprovalRequestPayload)
+	requestedAt := make(map[string]string)
+	for _, event := range events {
+		switch event.Type {
+		case CommandApprovalRequestedEventType:
+			var payload CommandApprovalRequestPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return fmt.Errorf("command approval request %d decode: %w", event.Sequence, err)
+			}
+			requests[event.ThreadID] = payload
+			requestedAt[event.ThreadID] = event.OccurredAt
+		case CommandApprovalDecidedEventType:
+			var payload CommandApprovalDecisionPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return fmt.Errorf("command approval decision %d decode: %w", event.Sequence, err)
+			}
+			entry := commandApprovalDecisionHistoryEntry(event, requests[event.ThreadID], requestedAt[event.ThreadID], payload)
+			if err := writeJSONAtomically(commandApprovalDecisionHistoryPath(sessionDir, event), entry); err != nil {
+				return fmt.Errorf("writing command approval decision history: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func commandApprovalDecisionHistoryEntry(event Event, request CommandApprovalRequestPayload, requestOccurredAt string, decision CommandApprovalDecisionPayload) CommandApprovalDecisionHistoryEntry {
+	return CommandApprovalDecisionHistoryEntry{
+		SchemaVersion:       commandApprovalDecisionHistorySchemaVersion,
+		SessionKey:          event.SessionKey,
+		TmuxSessionName:     event.TmuxSessionName,
+		Generation:          event.Generation,
+		EventSequence:       event.Sequence,
+		EventID:             event.EventID,
+		ThreadID:            event.ThreadID,
+		Decision:            decision.Decision,
+		EffectiveStatus:     commandApprovalDecisionEffectiveStatus(request, decision),
+		Requester:           request.Requester,
+		Reviewer:            request.Reviewer,
+		CommandApproverNode: request.CommandApproverNode,
+		DecisionReviewer:    decision.Reviewer,
+		Mode:                request.Mode,
+		Label:               request.Label,
+		Category:            request.Category,
+		CommandHash:         request.CommandHash,
+		RequestReason:       request.Reason,
+		DecisionReason:      decision.Reason,
+		RequestedAt:         requestOccurredAt,
+		ExpiresAt:           request.ExpiresAt,
+		DecidedAt:           event.OccurredAt,
+		DecisionMessageID:   decision.MessageID,
+		CommandText:         request.CommandText,
+	}
+}
+
+func commandApprovalDecisionEffectiveStatus(request CommandApprovalRequestPayload, decision CommandApprovalDecisionPayload) string {
+	if request.Requester == "" {
+		return "stale"
+	}
+	if request.CommandApproverNode == "" || decision.Reviewer != request.CommandApproverNode {
+		return "wrong_reviewer"
+	}
+	switch decision.Decision {
+	case ApprovalDecisionApproved:
+		return "approved"
+	case ApprovalDecisionRejected:
+		return "rejected"
+	default:
+		return "unknown"
+	}
+}
+
+func commandApprovalDecisionHistoryPath(sessionDir string, event Event) string {
+	return filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), fmt.Sprintf("%012d-%s.json", event.Sequence, event.EventID))
+}
+
+func ListCommandApprovalDecisionHistory(sessionDir string) ([]CommandApprovalDecisionHistoryEntry, error) {
+	entries, err := os.ReadDir(CommandApprovalDecisionHistoryDir(sessionDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	history := make([]CommandApprovalDecisionHistoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		var record CommandApprovalDecisionHistoryEntry
+		if err := readJSONFile(filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), entry.Name()), &record); err != nil {
+			return nil, fmt.Errorf("reading command approval decision history %s: %w", entry.Name(), err)
+		}
+		history = append(history, record)
+	}
+	return history, nil
+}

--- a/internal/journal/command_approval_decision_history.go
+++ b/internal/journal/command_approval_decision_history.go
@@ -130,10 +130,6 @@ func commandApprovalDecisionEffectiveStatus(request CommandApprovalRequestPayloa
 	}
 }
 
-func commandApprovalDecisionHistoryPath(sessionDir string, event Event) string {
-	return filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), commandApprovalDecisionHistoryFilename(event))
-}
-
 func commandApprovalDecisionHistoryFilename(event Event) string {
 	return fmt.Sprintf("%012d-%s.json", event.Sequence, event.EventID)
 }

--- a/internal/journal/command_approval_decision_history.go
+++ b/internal/journal/command_approval_decision_history.go
@@ -61,7 +61,11 @@ func SyncCommandApprovalDecisionHistory(sessionDir string) error {
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
 				return fmt.Errorf("command approval decision %d decode: %w", event.Sequence, err)
 			}
-			entry := commandApprovalDecisionHistoryEntry(event, requests[event.ThreadID], requestedAt[event.ThreadID], payload)
+			request, ok := requests[event.ThreadID]
+			if !ok {
+				continue
+			}
+			entry := commandApprovalDecisionHistoryEntry(event, request, requestedAt[event.ThreadID], payload)
 			if err := writeJSONAtomically(commandApprovalDecisionHistoryPath(sessionDir, event), entry); err != nil {
 				return fmt.Errorf("writing command approval decision history: %w", err)
 			}

--- a/internal/journal/command_approval_decision_history_test.go
+++ b/internal/journal/command_approval_decision_history_test.go
@@ -1,0 +1,42 @@
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSyncCommandApprovalDecisionHistorySkipsDecisionWithoutMatchingRequest(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "session")
+	now := time.Date(2026, time.July, 20, 0, 30, 0, 0, time.UTC)
+	writer, err := OpenShadowWriter(sessionDir, "ctx-662", "session", os.Getpid(), now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+
+	if _, err := writer.AppendEventWithOptions(
+		CommandApprovalDecidedEventType,
+		VisibilityOperatorVisible,
+		CommandApprovalDecisionPayload{
+			Reviewer: "orchestrator",
+			Decision: ApprovalDecisionApproved,
+			Reason:   "reply session lacks the request",
+		},
+		AppendOptions{ThreadID: "command-approval-no-request"},
+		now.Add(time.Second),
+	); err != nil {
+		t.Fatalf("AppendEventWithOptions(decision) error = %v", err)
+	}
+
+	if err := SyncCommandApprovalDecisionHistory(sessionDir); err != nil {
+		t.Fatalf("SyncCommandApprovalDecisionHistory() error = %v", err)
+	}
+	history, err := ListCommandApprovalDecisionHistory(sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 0 {
+		t.Fatalf("history entries = %d, want 0 for decision without local request: %#v", len(history), history)
+	}
+}

--- a/internal/journal/command_approval_decision_history_test.go
+++ b/internal/journal/command_approval_decision_history_test.go
@@ -40,3 +40,48 @@ func TestSyncCommandApprovalDecisionHistorySkipsDecisionWithoutMatchingRequest(t
 		t.Fatalf("history entries = %d, want 0 for decision without local request: %#v", len(history), history)
 	}
 }
+
+func TestSyncCommandApprovalDecisionHistoryRemovesStaleGeneratedJSON(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "session")
+	now := time.Date(2026, time.July, 20, 1, 5, 0, 0, time.UTC)
+	writer, err := OpenShadowWriter(sessionDir, "ctx-662", "session", os.Getpid(), now)
+	if err != nil {
+		t.Fatalf("OpenShadowWriter() error = %v", err)
+	}
+
+	if _, err := writer.AppendEventWithOptions(
+		CommandApprovalDecidedEventType,
+		VisibilityOperatorVisible,
+		CommandApprovalDecisionPayload{
+			Reviewer: "orchestrator",
+			Decision: ApprovalDecisionApproved,
+			Reason:   "reply session lacks the request",
+		},
+		AppendOptions{ThreadID: "command-approval-no-request"},
+		now.Add(time.Second),
+	); err != nil {
+		t.Fatalf("AppendEventWithOptions(decision) error = %v", err)
+	}
+
+	stalePath := filepath.Join(CommandApprovalDecisionHistoryDir(sessionDir), "000000000003-stale.json")
+	if err := os.MkdirAll(filepath.Dir(stalePath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(history dir) error = %v", err)
+	}
+	if err := os.WriteFile(stalePath, []byte(`{"thread_id":"command-approval-no-request","effective_status":"stale","command_text":"wrong-session-secret"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(stale history) error = %v", err)
+	}
+
+	if err := SyncCommandApprovalDecisionHistory(sessionDir); err != nil {
+		t.Fatalf("SyncCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale history file still exists or stat failed: %v", err)
+	}
+	history, err := ListCommandApprovalDecisionHistory(sessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory() error = %v", err)
+	}
+	if len(history) != 0 {
+		t.Fatalf("history entries = %d, want 0 after pruning stale generated JSON: %#v", len(history), history)
+	}
+}

--- a/internal/journal/command_approval_event.go
+++ b/internal/journal/command_approval_event.go
@@ -26,9 +26,10 @@ type CommandApprovalRequestPayload struct {
 }
 
 type CommandApprovalDecisionPayload struct {
-	Reviewer string           `json:"reviewer"`
-	Decision ApprovalDecision `json:"decision"`
-	Reason   string           `json:"reason,omitempty"`
+	Reviewer  string           `json:"reviewer"`
+	Decision  ApprovalDecision `json:"decision"`
+	Reason    string           `json:"reason,omitempty"`
+	MessageID string           `json:"message_id,omitempty"`
 }
 
 type CommandExecutionDecisionPayload struct {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -206,10 +206,10 @@ func EnsureEnvelopeParams(content string, fields map[string]string) string {
 	return envelope.EnsureParams(content, fields)
 }
 
-func approvalDecisionFromContent(content string) (journal.ApprovalDecision, bool) {
+func approvalDecisionFromContent(content string) (journal.ApprovalDecision, string, bool) {
 	body := messageBodyFromContent(content)
 	if body == "" {
-		return "", false
+		return "", "", false
 	}
 	firstLine := body
 	if idx := strings.Index(firstLine, "\n"); idx >= 0 {
@@ -218,11 +218,11 @@ func approvalDecisionFromContent(content string) (journal.ApprovalDecision, bool
 	firstLine = strings.TrimSpace(firstLine)
 	switch {
 	case strings.HasPrefix(firstLine, "APPROVED:"):
-		return journal.ApprovalDecisionApproved, true
+		return journal.ApprovalDecisionApproved, strings.TrimSpace(strings.TrimPrefix(firstLine, "APPROVED:")), true
 	case strings.HasPrefix(firstLine, "NOT APPROVED:"):
-		return journal.ApprovalDecisionRejected, true
+		return journal.ApprovalDecisionRejected, strings.TrimSpace(strings.TrimPrefix(firstLine, "NOT APPROVED:")), true
 	default:
-		return "", false
+		return "", "", false
 	}
 }
 
@@ -253,7 +253,7 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 			ThreadID: threadID,
 		}, true
 	case sender == "critic" && recipient == "orchestrator":
-		decision, ok := approvalDecisionFromContent(content)
+		decision, _, ok := approvalDecisionFromContent(content)
 		if !ok {
 			return approvalDeliveryEvent{}, false
 		}
@@ -274,7 +274,7 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 		// above, but records via #625's own CommandApproval* event types,
 		// never the older ApprovalDecidedEventType/ApprovalDecisionPayload
 		// pair used by that unrelated hardcoded flow.
-		decision, ok := approvalDecisionFromContent(content)
+		decision, reason, ok := approvalDecisionFromContent(content)
 		if !ok {
 			log.Printf("postman: WARNING: message %s on command approval thread %s did not start with APPROVED:/NOT APPROVED: — not recorded as a decision\n", messageID, threadID)
 			return approvalDeliveryEvent{}, false
@@ -284,6 +284,7 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 			Payload: journal.CommandApprovalDecisionPayload{
 				Reviewer:  sender,
 				Decision:  decision,
+				Reason:    reason,
 				MessageID: messageID,
 			},
 			ThreadID: threadID,

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -282,8 +282,9 @@ func approvalEventForDelivery(messageID, from, to, content string) (approvalDeli
 		return approvalDeliveryEvent{
 			EventType: journal.CommandApprovalDecidedEventType,
 			Payload: journal.CommandApprovalDecisionPayload{
-				Reviewer: sender,
-				Decision: decision,
+				Reviewer:  sender,
+				Decision:  decision,
+				MessageID: messageID,
 			},
 			ThreadID: threadID,
 		}, true
@@ -303,6 +304,12 @@ func recordApprovalEvent(sessionDir, sessionName string, event approvalDeliveryE
 		now,
 	); err != nil {
 		log.Printf("postman: WARNING: journal approval append failed for %s: %v\n", event.EventType, err)
+		return
+	}
+	if event.EventType == journal.CommandApprovalDecidedEventType {
+		if err := journal.SyncCommandApprovalDecisionHistory(sessionDir); err != nil {
+			log.Printf("postman: WARNING: command approval decision history sync failed: %v\n", err)
+		}
 	}
 }
 

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1687,6 +1687,20 @@ func TestDeliverMessage_CommandApprovalReplyFromRealCommandApproverNodeRecordsAp
 	if thread.Status != projection.CommandApprovalStatusApproved {
 		t.Fatalf("thread status = %q, want %q", thread.Status, projection.CommandApprovalStatusApproved)
 	}
+
+	history, err := journal.ListCommandApprovalDecisionHistory(requesterSessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory(requester) error = %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("requester decision history entries = %d, want 1", len(history))
+	}
+	if history[0].ThreadID != threadID || history[0].Decision != journal.ApprovalDecisionApproved || history[0].EffectiveStatus != "approved" {
+		t.Fatalf("requester decision history = %#v, want approved entry for thread %q", history[0], threadID)
+	}
+	if history[0].DecisionMessageID != replyFilename {
+		t.Fatalf("decision message id = %q, want %q", history[0].DecisionMessageID, replyFilename)
+	}
 }
 
 // TestDeliverMessage_CommandApprovalReplyFromWrongSenderIsRejected is the

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1474,21 +1474,24 @@ func TestApprovalDecisionFromContent(t *testing.T) {
 		name    string
 		content string
 		want    journal.ApprovalDecision
+		reason  string
 		ok      bool
 	}{
 		{
 			name: "approved",
 			content: "---\nparams:\n  from: critic\n  to: orchestrator\n" +
 				"  thread_id: thread-review-01\n---\n\nAPPROVED: looks good\n",
-			want: journal.ApprovalDecisionApproved,
-			ok:   true,
+			want:   journal.ApprovalDecisionApproved,
+			reason: "looks good",
+			ok:     true,
 		},
 		{
 			name: "not approved",
 			content: "---\nparams:\n  from: critic\n  to: orchestrator\n" +
 				"  thread_id: thread-review-01\n---\n\nNOT APPROVED: missing verification\n",
-			want: journal.ApprovalDecisionRejected,
-			ok:   true,
+			want:   journal.ApprovalDecisionRejected,
+			reason: "missing verification",
+			ok:     true,
 		},
 		{
 			name: "plain body is not a decision",
@@ -1500,12 +1503,15 @@ func TestApprovalDecisionFromContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := approvalDecisionFromContent(tt.content)
+			got, reason, ok := approvalDecisionFromContent(tt.content)
 			if ok != tt.ok {
 				t.Fatalf("approvalDecisionFromContent() ok = %v, want %v", ok, tt.ok)
 			}
 			if got != tt.want {
 				t.Fatalf("approvalDecisionFromContent() = %q, want %q", got, tt.want)
+			}
+			if reason != tt.reason {
+				t.Fatalf("approvalDecisionFromContent() reason = %q, want %q", reason, tt.reason)
 			}
 		})
 	}
@@ -1700,6 +1706,17 @@ func TestDeliverMessage_CommandApprovalReplyFromRealCommandApproverNodeRecordsAp
 	}
 	if history[0].DecisionMessageID != replyFilename {
 		t.Fatalf("decision message id = %q, want %q", history[0].DecisionMessageID, replyFilename)
+	}
+	if history[0].DecisionReason != "digest reviewed." {
+		t.Fatalf("decision reason = %q, want reply prefix reason", history[0].DecisionReason)
+	}
+
+	reviewerHistory, err := journal.ListCommandApprovalDecisionHistory(reviewerSessionDir)
+	if err != nil {
+		t.Fatalf("ListCommandApprovalDecisionHistory(reviewer) error = %v", err)
+	}
+	if len(reviewerHistory) != 0 {
+		t.Fatalf("reviewer decision history entries = %d, want 0 because reviewer session has no matching request: %#v", len(reviewerHistory), reviewerHistory)
 	}
 }
 


### PR DESCRIPTION
## Summary

Accumulates command approval decision history and prunes stale decision state for the approval workflow.

Included as local-complete approved follow-up work alongside the publication set.

## Validation

Previously verified in its issue worktree.

Closes #662