### PR TITLE
docs(readme): show topology source beside diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ gh skill install i9wa4/tmux-a2a-postman postman-config-auditor \
 The daemon works without these skills; they only help assistants send first
 messages, inspect live session state, and audit config.
 
-Create tmux panes for a small conversation topology:
+Create tmux panes for a small conversation topology. In postman, the graph is
+the coordination map: nodes are tmux pane titles/agent roles, edges are the
+allowed conversation paths, and `ui_node` marks the role the human talks to
+first. The same graph appears in `postman.md`, so the screenshot and the
+copyable config stay aligned:
 
 ```mermaid
 graph LR
@@ -156,6 +160,17 @@ graph LR
     class messenger ui_node
     classDef ui_node fill:#e0f2fe,stroke:#0369a1,color:#0f172a
 ```
+
+````text
+```mermaid
+graph LR
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- reviewer
+    class messenger ui_node
+    classDef ui_node fill:#e0f2fe,stroke:#0369a1,color:#0f172a
+```
+````
 
 For repeatable agent teams, use
 [yuki-yano/vde-layout](https://github.com/yuki-yano/vde-layout) presets to


### PR DESCRIPTION
## Summary

- clarify the Quick Start topology as a coordination map of pane-title roles and allowed conversation paths
- show the literal Mermaid source block directly under the rendered diagram for screenshot-friendly docs
- keep the example scoped to README.md without changing runtime behavior

## Tests

- git diff --check
- nix flake check
- nix build
- deprecated-reference scan over README.md and skills/*/SKILL.md