### PR TITLE
fix: deduplicate compaction pings after marker refresh (#609)

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -108,6 +108,7 @@ func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle
 		func() {
 			reservation, shouldSend := reserveDirectPingAutoWake(target.NodeKey, nodeInfo)
 			if !shouldSend {
+				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				log.Printf("postman: compaction-triggered PING skipped for %s: matching auto-PING already in flight\n", target.NodeKey)
 				return
 			}
@@ -116,12 +117,16 @@ func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle
 			options := ping.SendOptions{CompactionTriggered: true, Runtime: target.Runtime}
 			result, err := ping.SendPingToNodeWithOptions(nodeInfo, contextID, target.NodeKey, cfg.DaemonMessageTemplate, cfg, activeNodes, livenessMap, pingAdjacency, nodes, options)
 			if err != nil {
+				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				log.Printf("postman: compaction-triggered PING failed for %s: %v\n", target.NodeKey, err)
 				return
 			}
 			if result.Delivered {
-				idleTracker.MarkCompactionPingDelivered(target.NodeKey, target.MarkerIdentity)
+				idleTracker.MarkCompactionPingDelivered(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				recordDirectPingDelivered(target.NodeKey, nodeInfo, "compaction", time.Now())
+			}
+			if !result.Delivered {
+				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 			}
 			log.Printf("postman: compaction-triggered PING sent to %s trigger=%s runtime=%s\n", target.NodeKey, target.Trigger, target.Runtime)
 		}()

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -120,6 +120,7 @@ func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle
 				return
 			}
 			if result.Delivered {
+				idleTracker.MarkCompactionPingDelivered(target.NodeKey, target.MarkerIdentity)
 				recordDirectPingDelivered(target.NodeKey, nodeInfo, "compaction", time.Now())
 			}
 			log.Printf("postman: compaction-triggered PING sent to %s trigger=%s runtime=%s\n", target.NodeKey, target.Trigger, target.Runtime)

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -82,6 +82,7 @@ type PaneCaptureState struct {
 	LastCompactionDeliveryPending   bool
 	LastCompactionLifecycleIdentity string // Verified pane lifecycle discriminator
 	LastCompactionPaneID            string // Structural pane identity for retained compaction memory
+	FullHistoryRetry                bool   // Retry history after a transient capture failure
 	LastCompactionHash              uint32 // Scanned compaction content hash for the most recent compaction marker state
 	LastCompactionMarkers           int    // Marker occurrences in scanned content for the most recent compaction state
 	LastCompactionMarkerHash        uint32 // Hash of the normalized latest marker line, independent of capture scope
@@ -787,15 +788,19 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 
 		// Get previous state
 		state, exists := t.paneCaptureState[paneID]
-		allowFullHistory := supportsCompactionRuntime(runtime) && (!exists || currentHash != state.LastHash)
+		allowFullHistory := supportsCompactionRuntime(runtime) && (!exists || currentHash != state.LastHash || state.FullHistoryRetry)
 		compactionContent, compactionHash, compactionScope := captureCompactionContent(paneID, runtime, content, currentHash, cfg.PaneCaptureTailLines, allowFullHistory)
+		if allowFullHistory && supportsCompactionRuntime(runtime) {
+			state.FullHistoryRetry = compactionScope != compactionScopeHistory
+		}
 		if !exists {
 			// First time seeing this pane - initialize state
 			state = PaneCaptureState{
-				LastHash:      currentHash,
-				LastChangeAt:  now,
-				ChangeCount:   0,
-				LastCaptureAt: now,
+				LastHash:         currentHash,
+				LastChangeAt:     now,
+				ChangeCount:      0,
+				LastCaptureAt:    now,
+				FullHistoryRetry: allowFullHistory && supportsCompactionRuntime(runtime) && compactionScope != compactionScopeHistory,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
 				state.LastCompactionPaneID = paneID

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -470,7 +470,7 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 		return false
 	}
 	identity := compactionMarkerIdentity(scan)
-	if identity == state.LastCompactionDeliveredIdentity && identity != "" {
+	if identity == state.LastCompactionDeliveredIdentity && identity != "" && sameCompactionMarker(state, scan, compactionHash, scope) {
 		return false
 	}
 	if key := compactionMarkerDeliveryKey(scan); key != "" && key == state.LastCompactionDeliveredKey && sameCompactionMarker(state, scan, compactionHash, scope) {

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -617,6 +617,17 @@ func (t *IdleTracker) clearNodeCompactionMemoryForLifecycle(lifecycleIdentity st
 	}
 }
 
+func (t *IdleTracker) clearOtherNodeCompactionMemoryForPane(nodeKey, paneID string) {
+	for memoryNodeKey, memory := range t.nodeCompactionMemory {
+		if memoryNodeKey == nodeKey {
+			continue
+		}
+		if compactionLifecyclePaneID(memory.LastCompactionLifecycleIdentity) == paneID {
+			delete(t.nodeCompactionMemory, memoryNodeKey)
+		}
+	}
+}
+
 func (t *IdleTracker) pruneNodeCompactionMemory(now time.Time) {
 	for nodeKey, memory := range t.nodeCompactionMemory {
 		if memory.LastCompactionPingAt.IsZero() || now.Sub(memory.LastCompactionPingAt) > compactionMemoryRetention {
@@ -669,6 +680,14 @@ func compactionLifecycleIdentity(nodeKey, paneID, paneProcessGeneration string) 
 
 func compactionEndpointIdentity(nodeKey, paneID string) string {
 	return nodeKey + "|" + paneID
+}
+
+func compactionLifecyclePaneID(identity string) string {
+	parts := strings.Split(identity, "|")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
 }
 
 func sameCompactionEndpoint(identity, nodeKey, paneID string) bool {
@@ -784,6 +803,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+				t.clearOtherNodeCompactionMemoryForPane(nodeKey, paneID)
 				memory, hasMemory := t.nodeCompactionMemoryFor(nodeKey, now)
 				lifecycle := compactionLifecycleIdentityForNewPane(nodeKey, paneID, paneProcessGenerations[paneID], memory, hasMemory)
 				if hasMemory {
@@ -835,6 +855,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		// Update last capture time
 		state.LastCaptureAt = now
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+			t.clearOtherNodeCompactionMemoryForPane(nodeKey, paneID)
 			lifecycle, lifecycleChanged := compactionLifecycleIdentityForExistingPane(nodeKey, paneID, paneProcessGenerations[paneID], state.LastCompactionLifecycleIdentity)
 			if lifecycleChanged {
 				t.clearNodeCompactionMemoryForLifecycle(state.LastCompactionLifecycleIdentity)

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -566,6 +566,21 @@ func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionPrefixLines = memory.LastCompactionPrefixLines
 }
 
+func clearCompactionState(state *PaneCaptureState) {
+	state.LastCompactionPingAt = time.Time{}
+	state.LastCompactionTrigger = ""
+	state.LastCompactionMarkerIdentity = ""
+	state.LastCompactionDeliveredIdentity = ""
+	state.LastCompactionDeliveryPending = false
+	state.LastCompactionHash = 0
+	state.LastCompactionMarkers = 0
+	state.LastCompactionMarkerHash = 0
+	state.LastCompactionScope = ""
+	state.LastCompactionSuffix = compactionSuffixIdentity{}
+	state.LastCompactionPrefixHash = 0
+	state.LastCompactionPrefixLines = 0
+}
+
 func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureState) {
 	if t.nodeCompactionMemory == nil {
 		t.nodeCompactionMemory = make(map[string]PaneCaptureState)
@@ -615,6 +630,27 @@ func compactionAbsenceAuthoritative(state PaneCaptureState, scope compactionCapt
 	return state.LastCompactionTrigger != "" && scope == compactionScopeHistory
 }
 
+func queryPaneProcessGenerations(paneIDs []string) map[string]string {
+	generations := make(map[string]string)
+	for _, paneID := range paneIDs {
+		output, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{pane_pid}").CombinedOutput()
+		if err != nil {
+			continue
+		}
+		if pid := strings.TrimSpace(string(output)); pid != "" {
+			generations[paneID] = pid
+		}
+	}
+	return generations
+}
+
+func compactionLifecycleIdentity(nodeKey, paneID, paneProcessGeneration string) string {
+	if paneProcessGeneration == "" {
+		return nodeKey + "|" + paneID
+	}
+	return nodeKey + "|" + paneID + "|pid:" + paneProcessGeneration
+}
+
 // checkPaneCapture performs pane content capture and updates NodeActivity on consecutive changes.
 func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]discovery.NodeInfo) []CompactionPingTarget {
 	if !config.BoolVal(cfg.PaneCaptureEnabled, true) {
@@ -662,6 +698,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 	if maxPanes > 0 && len(nodePaneIDs) > maxPanes {
 		nodePaneIDs = nodePaneIDs[:maxPanes]
 	}
+	paneProcessGenerations := queryPaneProcessGenerations(nodePaneIDs)
 
 	now := t.now()
 	// Reject expired node memory before any pane-state lookup/application.
@@ -694,7 +731,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
-				lifecycle := nodeKey + "|" + paneID
+				lifecycle := compactionLifecycleIdentity(nodeKey, paneID, paneProcessGenerations[paneID])
 				if memory, ok := t.nodeCompactionMemoryFor(nodeKey, now); ok {
 					if memory.LastCompactionLifecycleIdentity == lifecycle {
 						applyCompactionMemory(&state, memory)
@@ -744,7 +781,11 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		// Update last capture time
 		state.LastCaptureAt = now
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
-			state.LastCompactionLifecycleIdentity = nodeKey + "|" + paneID
+			lifecycle := compactionLifecycleIdentity(nodeKey, paneID, paneProcessGenerations[paneID])
+			if state.LastCompactionLifecycleIdentity != "" && state.LastCompactionLifecycleIdentity != lifecycle {
+				clearCompactionState(&state)
+			}
+			state.LastCompactionLifecycleIdentity = lifecycle
 			if scan := compactionTriggerScan(runtime, compactionContent); scan.Trigger != "" {
 				if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 					recordCompactionPing(&state, scan, compactionHash, compactionScope, now)

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -473,7 +473,7 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 	if identity == state.LastCompactionDeliveredIdentity && identity != "" {
 		return false
 	}
-	if key := compactionMarkerDeliveryKey(scan); key != "" && key == state.LastCompactionDeliveredKey {
+	if key := compactionMarkerDeliveryKey(scan); key != "" && key == state.LastCompactionDeliveredKey && sameCompactionMarker(state, scan, compactionHash, scope) {
 		return false
 	}
 	// A matching observed marker that has not been positively delivered is retryable;

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -606,6 +606,17 @@ func (t *IdleTracker) clearNodeCompactionMemory(nodeKey string) {
 	delete(t.nodeCompactionMemory, nodeKey)
 }
 
+func (t *IdleTracker) clearNodeCompactionMemoryForLifecycle(lifecycleIdentity string) {
+	if lifecycleIdentity == "" {
+		return
+	}
+	for nodeKey, memory := range t.nodeCompactionMemory {
+		if memory.LastCompactionLifecycleIdentity == lifecycleIdentity {
+			delete(t.nodeCompactionMemory, nodeKey)
+		}
+	}
+}
+
 func (t *IdleTracker) pruneNodeCompactionMemory(now time.Time) {
 	for nodeKey, memory := range t.nodeCompactionMemory {
 		if memory.LastCompactionPingAt.IsZero() || now.Sub(memory.LastCompactionPingAt) > compactionMemoryRetention {
@@ -826,6 +837,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
 			lifecycle, lifecycleChanged := compactionLifecycleIdentityForExistingPane(nodeKey, paneID, paneProcessGenerations[paneID], state.LastCompactionLifecycleIdentity)
 			if lifecycleChanged {
+				t.clearNodeCompactionMemoryForLifecycle(state.LastCompactionLifecycleIdentity)
 				clearCompactionState(&state)
 			}
 			state.LastCompactionLifecycleIdentity = lifecycle

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -55,10 +55,11 @@ type PaneActivityExport struct {
 }
 
 type CompactionPingTarget struct {
-	NodeKey        string
-	Runtime        string
-	Trigger        string
-	MarkerIdentity string
+	NodeKey           string
+	Runtime           string
+	Trigger           string
+	MarkerIdentity    string
+	LifecycleIdentity string
 }
 
 type compactionSuffixIdentity struct {
@@ -78,10 +79,11 @@ type PaneCaptureState struct {
 	LastCompactionTrigger           string    // Non-empty while a compaction marker remains in scanned content
 	LastCompactionMarkerIdentity    string    // Stable trigger/marker/count identity handled for this node
 	LastCompactionDeliveredIdentity string    // Identity confirmed delivered to the node
-	LastCompactionLifecycleIdentity string    // Verified pane lifecycle discriminator
-	LastCompactionHash              uint32    // Scanned compaction content hash for the most recent compaction marker state
-	LastCompactionMarkers           int       // Marker occurrences in scanned content for the most recent compaction state
-	LastCompactionMarkerHash        uint32    // Hash of the normalized latest marker line, independent of capture scope
+	LastCompactionDeliveryPending   bool
+	LastCompactionLifecycleIdentity string // Verified pane lifecycle discriminator
+	LastCompactionHash              uint32 // Scanned compaction content hash for the most recent compaction marker state
+	LastCompactionMarkers           int    // Marker occurrences in scanned content for the most recent compaction state
+	LastCompactionMarkerHash        uint32 // Hash of the normalized latest marker line, independent of capture scope
 	LastCompactionScope             compactionCaptureScope
 	LastCompactionSuffix            compactionSuffixIdentity
 	LastCompactionPrefixHash        uint32 // Hash of scanned content through the latest marker occurrence
@@ -464,10 +466,14 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 	if !state.LastCompactionPingAt.IsZero() && now.Sub(state.LastCompactionPingAt) < compactionPingCooldown {
 		return false
 	}
-	if state.LastCompactionDeliveredIdentity != "" {
-		if compactionMarkerIdentity(scan) == state.LastCompactionDeliveredIdentity {
-			return false
-		}
+	identity := compactionMarkerIdentity(scan)
+	if identity == state.LastCompactionDeliveredIdentity && identity != "" {
+		return false
+	}
+	// A matching observed marker that has not been positively delivered is retryable;
+	// do not fall through to legacy same-marker suppression.
+	if identity == state.LastCompactionMarkerIdentity && identity != "" {
+		return !state.LastCompactionDeliveryPending
 	}
 	if state.LastCompactionTrigger != "" {
 		if scan.Trigger == state.LastCompactionTrigger &&
@@ -490,21 +496,39 @@ func recordCompactionPing(state *PaneCaptureState, scan compactionMarkerScan, co
 	state.LastCompactionPrefixHash = scan.MarkerPrefixHash
 	state.LastCompactionPrefixLines = scan.MarkerPrefixLines
 	state.LastCompactionMarkerIdentity = compactionMarkerIdentity(scan)
+	state.LastCompactionDeliveryPending = true
 }
 
 // MarkCompactionPingDelivered promotes a pending marker only after the delivery
 // boundary positively acknowledges it. Failed or unconfirmed sends remain retryable.
-func (t *IdleTracker) MarkCompactionPingDelivered(nodeKey, markerIdentity string) {
+func (t *IdleTracker) MarkCompactionPingDelivered(nodeKey, lifecycleIdentity, markerIdentity string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for paneID, state := range t.paneCaptureState {
-		if state.LastCompactionMarkerIdentity == markerIdentity {
+		if state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
 			state.LastCompactionDeliveredIdentity = markerIdentity
+			state.LastCompactionDeliveryPending = false
 			t.paneCaptureState[paneID] = state
 		}
 	}
-	if state, ok := t.nodeCompactionMemory[nodeKey]; ok && state.LastCompactionMarkerIdentity == markerIdentity {
+	if state, ok := t.nodeCompactionMemory[nodeKey]; ok && state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
 		state.LastCompactionDeliveredIdentity = markerIdentity
+		state.LastCompactionDeliveryPending = false
+		t.nodeCompactionMemory[nodeKey] = state
+	}
+}
+
+func (t *IdleTracker) MarkCompactionPingDeliveryFailed(nodeKey, lifecycleIdentity, markerIdentity string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for paneID, state := range t.paneCaptureState {
+		if state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
+			state.LastCompactionDeliveryPending = false
+			t.paneCaptureState[paneID] = state
+		}
+	}
+	if state, ok := t.nodeCompactionMemory[nodeKey]; ok && state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
+		state.LastCompactionDeliveryPending = false
 		t.nodeCompactionMemory[nodeKey] = state
 	}
 }
@@ -531,6 +555,7 @@ func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionTrigger = memory.LastCompactionTrigger
 	state.LastCompactionMarkerIdentity = memory.LastCompactionMarkerIdentity
 	state.LastCompactionDeliveredIdentity = memory.LastCompactionDeliveredIdentity
+	state.LastCompactionDeliveryPending = memory.LastCompactionDeliveryPending
 	state.LastCompactionLifecycleIdentity = memory.LastCompactionLifecycleIdentity
 	state.LastCompactionHash = memory.LastCompactionHash
 	state.LastCompactionMarkers = memory.LastCompactionMarkers
@@ -550,6 +575,7 @@ func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureSt
 		LastCompactionTrigger:           state.LastCompactionTrigger,
 		LastCompactionMarkerIdentity:    state.LastCompactionMarkerIdentity,
 		LastCompactionDeliveredIdentity: state.LastCompactionDeliveredIdentity,
+		LastCompactionDeliveryPending:   state.LastCompactionDeliveryPending,
 		LastCompactionLifecycleIdentity: state.LastCompactionLifecycleIdentity,
 		LastCompactionHash:              state.LastCompactionHash,
 		LastCompactionMarkers:           state.LastCompactionMarkers,
@@ -680,10 +706,11 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 					if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 						recordCompactionPing(&state, scan, compactionHash, compactionScope, now)
 						compactionTargets[nodeKey] = CompactionPingTarget{
-							NodeKey:        nodeKey,
-							Runtime:        runtime,
-							Trigger:        scan.Trigger,
-							MarkerIdentity: compactionMarkerIdentity(scan),
+							NodeKey:           nodeKey,
+							Runtime:           runtime,
+							Trigger:           scan.Trigger,
+							MarkerIdentity:    compactionMarkerIdentity(scan),
+							LifecycleIdentity: state.LastCompactionLifecycleIdentity,
 						}
 					} else {
 						refreshSameCompactionMarker(&state, scan, compactionHash, compactionScope)
@@ -722,10 +749,11 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 					recordCompactionPing(&state, scan, compactionHash, compactionScope, now)
 					compactionTargets[nodeKey] = CompactionPingTarget{
-						NodeKey:        nodeKey,
-						Runtime:        runtime,
-						Trigger:        scan.Trigger,
-						MarkerIdentity: compactionMarkerIdentity(scan),
+						NodeKey:           nodeKey,
+						Runtime:           runtime,
+						Trigger:           scan.Trigger,
+						MarkerIdentity:    compactionMarkerIdentity(scan),
+						LifecycleIdentity: state.LastCompactionLifecycleIdentity,
 					}
 				} else {
 					refreshSameCompactionMarker(&state, scan, compactionHash, compactionScope)

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -81,6 +81,7 @@ type PaneCaptureState struct {
 	LastCompactionDeliveredIdentity string    // Identity confirmed delivered to the node
 	LastCompactionDeliveryPending   bool
 	LastCompactionLifecycleIdentity string // Verified pane lifecycle discriminator
+	LastCompactionPaneID            string // Structural pane identity for retained compaction memory
 	LastCompactionHash              uint32 // Scanned compaction content hash for the most recent compaction marker state
 	LastCompactionMarkers           int    // Marker occurrences in scanned content for the most recent compaction state
 	LastCompactionMarkerHash        uint32 // Hash of the normalized latest marker line, independent of capture scope
@@ -557,6 +558,7 @@ func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionDeliveredIdentity = memory.LastCompactionDeliveredIdentity
 	state.LastCompactionDeliveryPending = memory.LastCompactionDeliveryPending
 	state.LastCompactionLifecycleIdentity = memory.LastCompactionLifecycleIdentity
+	state.LastCompactionPaneID = memory.LastCompactionPaneID
 	state.LastCompactionHash = memory.LastCompactionHash
 	state.LastCompactionMarkers = memory.LastCompactionMarkers
 	state.LastCompactionMarkerHash = memory.LastCompactionMarkerHash
@@ -592,6 +594,7 @@ func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureSt
 		LastCompactionDeliveredIdentity: state.LastCompactionDeliveredIdentity,
 		LastCompactionDeliveryPending:   state.LastCompactionDeliveryPending,
 		LastCompactionLifecycleIdentity: state.LastCompactionLifecycleIdentity,
+		LastCompactionPaneID:            state.LastCompactionPaneID,
 		LastCompactionHash:              state.LastCompactionHash,
 		LastCompactionMarkers:           state.LastCompactionMarkers,
 		LastCompactionMarkerHash:        state.LastCompactionMarkerHash,
@@ -622,7 +625,7 @@ func (t *IdleTracker) clearOtherNodeCompactionMemoryForPane(nodeKey, paneID stri
 		if memoryNodeKey == nodeKey {
 			continue
 		}
-		if compactionLifecyclePaneID(memory.LastCompactionLifecycleIdentity) == paneID {
+		if memory.LastCompactionPaneID == paneID {
 			delete(t.nodeCompactionMemory, memoryNodeKey)
 		}
 	}
@@ -636,12 +639,12 @@ func (t *IdleTracker) pruneNodeCompactionMemory(now time.Time) {
 	}
 }
 
-func (t *IdleTracker) nodeCompactionMemoryFor(nodeKey string, now time.Time) (PaneCaptureState, bool) {
+func (t *IdleTracker) nodeCompactionMemoryFor(nodeKey, paneID string, now time.Time) (PaneCaptureState, bool) {
 	memory, ok := t.nodeCompactionMemory[nodeKey]
 	if !ok {
 		return PaneCaptureState{}, false
 	}
-	if memory.LastCompactionPingAt.IsZero() || now.Sub(memory.LastCompactionPingAt) > compactionMemoryRetention {
+	if memory.LastCompactionPaneID != paneID || memory.LastCompactionPingAt.IsZero() || now.Sub(memory.LastCompactionPingAt) > compactionMemoryRetention {
 		delete(t.nodeCompactionMemory, nodeKey)
 		return PaneCaptureState{}, false
 	}
@@ -680,14 +683,6 @@ func compactionLifecycleIdentity(nodeKey, paneID, paneProcessGeneration string) 
 
 func compactionEndpointIdentity(nodeKey, paneID string) string {
 	return nodeKey + "|" + paneID
-}
-
-func compactionLifecyclePaneID(identity string) string {
-	parts := strings.Split(identity, "|")
-	if len(parts) < 2 {
-		return ""
-	}
-	return parts[1]
 }
 
 func sameCompactionEndpoint(identity, nodeKey, paneID string) bool {
@@ -803,8 +798,9 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+				state.LastCompactionPaneID = paneID
 				t.clearOtherNodeCompactionMemoryForPane(nodeKey, paneID)
-				memory, hasMemory := t.nodeCompactionMemoryFor(nodeKey, now)
+				memory, hasMemory := t.nodeCompactionMemoryFor(nodeKey, paneID, now)
 				lifecycle := compactionLifecycleIdentityForNewPane(nodeKey, paneID, paneProcessGenerations[paneID], memory, hasMemory)
 				if hasMemory {
 					if memory.LastCompactionLifecycleIdentity == lifecycle {
@@ -855,6 +851,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		// Update last capture time
 		state.LastCaptureAt = now
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+			state.LastCompactionPaneID = paneID
 			t.clearOtherNodeCompactionMemoryForPane(nodeKey, paneID)
 			lifecycle, lifecycleChanged := compactionLifecycleIdentityForExistingPane(nodeKey, paneID, paneProcessGenerations[paneID], state.LastCompactionLifecycleIdentity)
 			if lifecycleChanged {

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -79,6 +79,7 @@ type PaneCaptureState struct {
 	LastCompactionTrigger           string    // Non-empty while a compaction marker remains in scanned content
 	LastCompactionMarkerIdentity    string    // Stable trigger/marker/count identity handled for this node
 	LastCompactionDeliveredIdentity string    // Identity confirmed delivered to the node
+	LastCompactionDeliveredKey      string    // Stable marker key confirmed delivered
 	LastCompactionDeliveryPending   bool
 	LastCompactionLifecycleIdentity string // Verified pane lifecycle discriminator
 	LastCompactionPaneID            string // Structural pane identity for retained compaction memory
@@ -472,6 +473,9 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 	if identity == state.LastCompactionDeliveredIdentity && identity != "" {
 		return false
 	}
+	if key := compactionMarkerDeliveryKey(scan); key != "" && key == state.LastCompactionDeliveredKey {
+		return false
+	}
 	// A matching observed marker that has not been positively delivered is retryable;
 	// do not fall through to legacy same-marker suppression.
 	if identity == state.LastCompactionMarkerIdentity && identity != "" {
@@ -509,12 +513,14 @@ func (t *IdleTracker) MarkCompactionPingDelivered(nodeKey, lifecycleIdentity, ma
 	for paneID, state := range t.paneCaptureState {
 		if state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
 			state.LastCompactionDeliveredIdentity = markerIdentity
+			state.LastCompactionDeliveredKey = compactionStateDeliveryKey(state)
 			state.LastCompactionDeliveryPending = false
 			t.paneCaptureState[paneID] = state
 		}
 	}
 	if state, ok := t.nodeCompactionMemory[nodeKey]; ok && state.LastCompactionLifecycleIdentity == lifecycleIdentity && state.LastCompactionMarkerIdentity == markerIdentity {
 		state.LastCompactionDeliveredIdentity = markerIdentity
+		state.LastCompactionDeliveredKey = compactionStateDeliveryKey(state)
 		state.LastCompactionDeliveryPending = false
 		t.nodeCompactionMemory[nodeKey] = state
 	}
@@ -540,6 +546,14 @@ func compactionMarkerIdentity(scan compactionMarkerScan) string {
 	return fmt.Sprintf("%s:%08x:%d:%08x:%d:%d:%x:%s:%s", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount, scan.MarkerPrefixHash, scan.MarkerPrefixLines, suffix.Length, suffix.Hash, suffix.Head, suffix.Tail)
 }
 
+func compactionMarkerDeliveryKey(scan compactionMarkerScan) string {
+	return fmt.Sprintf("%s:%08x:%d:%08x:%d", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount, scan.MarkerPrefixHash, scan.MarkerPrefixLines)
+}
+
+func compactionStateDeliveryKey(state PaneCaptureState) string {
+	return fmt.Sprintf("%s:%08x:%d:%08x:%d", state.LastCompactionTrigger, state.LastCompactionMarkerHash, state.LastCompactionMarkers, state.LastCompactionPrefixHash, state.LastCompactionPrefixLines)
+}
+
 func refreshSameCompactionMarker(state *PaneCaptureState, scan compactionMarkerScan, compactionHash uint32, scope compactionCaptureScope) {
 	if sameCompactionMarker(*state, scan, compactionHash, scope) {
 		state.LastCompactionMarkers = scan.MarkerCount
@@ -557,6 +571,7 @@ func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionTrigger = memory.LastCompactionTrigger
 	state.LastCompactionMarkerIdentity = memory.LastCompactionMarkerIdentity
 	state.LastCompactionDeliveredIdentity = memory.LastCompactionDeliveredIdentity
+	state.LastCompactionDeliveredKey = memory.LastCompactionDeliveredKey
 	state.LastCompactionDeliveryPending = memory.LastCompactionDeliveryPending
 	state.LastCompactionLifecycleIdentity = memory.LastCompactionLifecycleIdentity
 	state.LastCompactionPaneID = memory.LastCompactionPaneID
@@ -574,6 +589,7 @@ func clearCompactionState(state *PaneCaptureState) {
 	state.LastCompactionTrigger = ""
 	state.LastCompactionMarkerIdentity = ""
 	state.LastCompactionDeliveredIdentity = ""
+	state.LastCompactionDeliveredKey = ""
 	state.LastCompactionDeliveryPending = false
 	state.LastCompactionHash = 0
 	state.LastCompactionMarkers = 0

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -547,11 +547,11 @@ func compactionMarkerIdentity(scan compactionMarkerScan) string {
 }
 
 func compactionMarkerDeliveryKey(scan compactionMarkerScan) string {
-	return fmt.Sprintf("%s:%08x:%d:%08x:%d", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount, scan.MarkerPrefixHash, scan.MarkerPrefixLines)
+	return fmt.Sprintf("%s:%08x:%d", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount)
 }
 
 func compactionStateDeliveryKey(state PaneCaptureState) string {
-	return fmt.Sprintf("%s:%08x:%d:%08x:%d", state.LastCompactionTrigger, state.LastCompactionMarkerHash, state.LastCompactionMarkers, state.LastCompactionPrefixHash, state.LastCompactionPrefixLines)
+	return fmt.Sprintf("%s:%08x:%d", state.LastCompactionTrigger, state.LastCompactionMarkerHash, state.LastCompactionMarkers)
 }
 
 func refreshSameCompactionMarker(state *PaneCaptureState, scan compactionMarkerScan, compactionHash uint32, scope compactionCaptureScope) {
@@ -609,6 +609,7 @@ func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureSt
 		LastCompactionTrigger:           state.LastCompactionTrigger,
 		LastCompactionMarkerIdentity:    state.LastCompactionMarkerIdentity,
 		LastCompactionDeliveredIdentity: state.LastCompactionDeliveredIdentity,
+		LastCompactionDeliveredKey:      state.LastCompactionDeliveredKey,
 		LastCompactionDeliveryPending:   state.LastCompactionDeliveryPending,
 		LastCompactionLifecycleIdentity: state.LastCompactionLifecycleIdentity,
 		LastCompactionPaneID:            state.LastCompactionPaneID,

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -55,9 +55,10 @@ type PaneActivityExport struct {
 }
 
 type CompactionPingTarget struct {
-	NodeKey string
-	Runtime string
-	Trigger string
+	NodeKey        string
+	Runtime        string
+	Trigger        string
+	MarkerIdentity string
 }
 
 type compactionSuffixIdentity struct {
@@ -69,20 +70,22 @@ type compactionSuffixIdentity struct {
 
 // PaneCaptureState holds pane capture state for hybrid idle detection.
 type PaneCaptureState struct {
-	LastHash                     uint32    // CRC32 hash of pane content
-	LastChangeAt                 time.Time // Last time content change was detected
-	ChangeCount                  int       // Consecutive change count (2 = active)
-	LastCaptureAt                time.Time // Last capture time
-	LastCompactionPingAt         time.Time // Last compaction-triggered PING for this pane
-	LastCompactionTrigger        string    // Non-empty while a compaction marker remains in scanned content
-	LastCompactionMarkerIdentity string    // Stable trigger/marker/count identity handled for this node
-	LastCompactionHash           uint32    // Scanned compaction content hash for the most recent compaction marker state
-	LastCompactionMarkers        int       // Marker occurrences in scanned content for the most recent compaction state
-	LastCompactionMarkerHash     uint32    // Hash of the normalized latest marker line, independent of capture scope
-	LastCompactionScope          compactionCaptureScope
-	LastCompactionSuffix         compactionSuffixIdentity
-	LastCompactionPrefixHash     uint32 // Hash of scanned content through the latest marker occurrence
-	LastCompactionPrefixLines    int    // Line count through the latest marker occurrence
+	LastHash                        uint32    // CRC32 hash of pane content
+	LastChangeAt                    time.Time // Last time content change was detected
+	ChangeCount                     int       // Consecutive change count (2 = active)
+	LastCaptureAt                   time.Time // Last capture time
+	LastCompactionPingAt            time.Time // Last compaction-triggered PING for this pane
+	LastCompactionTrigger           string    // Non-empty while a compaction marker remains in scanned content
+	LastCompactionMarkerIdentity    string    // Stable trigger/marker/count identity handled for this node
+	LastCompactionDeliveredIdentity string    // Identity confirmed delivered to the node
+	LastCompactionLifecycleIdentity string    // Verified pane lifecycle discriminator
+	LastCompactionHash              uint32    // Scanned compaction content hash for the most recent compaction marker state
+	LastCompactionMarkers           int       // Marker occurrences in scanned content for the most recent compaction state
+	LastCompactionMarkerHash        uint32    // Hash of the normalized latest marker line, independent of capture scope
+	LastCompactionScope             compactionCaptureScope
+	LastCompactionSuffix            compactionSuffixIdentity
+	LastCompactionPrefixHash        uint32 // Hash of scanned content through the latest marker occurrence
+	LastCompactionPrefixLines       int    // Line count through the latest marker occurrence
 }
 
 // IdleTracker manages idle detection state (Issue #71).
@@ -461,8 +464,8 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 	if !state.LastCompactionPingAt.IsZero() && now.Sub(state.LastCompactionPingAt) < compactionPingCooldown {
 		return false
 	}
-	if state.LastCompactionMarkerIdentity != "" {
-		if compactionMarkerIdentity(scan) == state.LastCompactionMarkerIdentity {
+	if state.LastCompactionDeliveredIdentity != "" {
+		if compactionMarkerIdentity(scan) == state.LastCompactionDeliveredIdentity {
 			return false
 		}
 	}
@@ -489,6 +492,23 @@ func recordCompactionPing(state *PaneCaptureState, scan compactionMarkerScan, co
 	state.LastCompactionMarkerIdentity = compactionMarkerIdentity(scan)
 }
 
+// MarkCompactionPingDelivered promotes a pending marker only after the delivery
+// boundary positively acknowledges it. Failed or unconfirmed sends remain retryable.
+func (t *IdleTracker) MarkCompactionPingDelivered(nodeKey, markerIdentity string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for paneID, state := range t.paneCaptureState {
+		if state.LastCompactionMarkerIdentity == markerIdentity {
+			state.LastCompactionDeliveredIdentity = markerIdentity
+			t.paneCaptureState[paneID] = state
+		}
+	}
+	if state, ok := t.nodeCompactionMemory[nodeKey]; ok && state.LastCompactionMarkerIdentity == markerIdentity {
+		state.LastCompactionDeliveredIdentity = markerIdentity
+		t.nodeCompactionMemory[nodeKey] = state
+	}
+}
+
 func compactionMarkerIdentity(scan compactionMarkerScan) string {
 	suffix := scan.LatestMarkerSuffixID
 	return fmt.Sprintf("%s:%08x:%d:%08x:%d:%d:%x:%s:%s", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount, scan.MarkerPrefixHash, scan.MarkerPrefixLines, suffix.Length, suffix.Hash, suffix.Head, suffix.Tail)
@@ -510,6 +530,8 @@ func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionPingAt = memory.LastCompactionPingAt
 	state.LastCompactionTrigger = memory.LastCompactionTrigger
 	state.LastCompactionMarkerIdentity = memory.LastCompactionMarkerIdentity
+	state.LastCompactionDeliveredIdentity = memory.LastCompactionDeliveredIdentity
+	state.LastCompactionLifecycleIdentity = memory.LastCompactionLifecycleIdentity
 	state.LastCompactionHash = memory.LastCompactionHash
 	state.LastCompactionMarkers = memory.LastCompactionMarkers
 	state.LastCompactionMarkerHash = memory.LastCompactionMarkerHash
@@ -524,16 +546,18 @@ func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureSt
 		t.nodeCompactionMemory = make(map[string]PaneCaptureState)
 	}
 	t.nodeCompactionMemory[nodeKey] = PaneCaptureState{
-		LastCompactionPingAt:         state.LastCompactionPingAt,
-		LastCompactionTrigger:        state.LastCompactionTrigger,
-		LastCompactionMarkerIdentity: state.LastCompactionMarkerIdentity,
-		LastCompactionHash:           state.LastCompactionHash,
-		LastCompactionMarkers:        state.LastCompactionMarkers,
-		LastCompactionMarkerHash:     state.LastCompactionMarkerHash,
-		LastCompactionScope:          state.LastCompactionScope,
-		LastCompactionSuffix:         state.LastCompactionSuffix,
-		LastCompactionPrefixHash:     state.LastCompactionPrefixHash,
-		LastCompactionPrefixLines:    state.LastCompactionPrefixLines,
+		LastCompactionPingAt:            state.LastCompactionPingAt,
+		LastCompactionTrigger:           state.LastCompactionTrigger,
+		LastCompactionMarkerIdentity:    state.LastCompactionMarkerIdentity,
+		LastCompactionDeliveredIdentity: state.LastCompactionDeliveredIdentity,
+		LastCompactionLifecycleIdentity: state.LastCompactionLifecycleIdentity,
+		LastCompactionHash:              state.LastCompactionHash,
+		LastCompactionMarkers:           state.LastCompactionMarkers,
+		LastCompactionMarkerHash:        state.LastCompactionMarkerHash,
+		LastCompactionScope:             state.LastCompactionScope,
+		LastCompactionSuffix:            state.LastCompactionSuffix,
+		LastCompactionPrefixHash:        state.LastCompactionPrefixHash,
+		LastCompactionPrefixLines:       state.LastCompactionPrefixLines,
 	}
 }
 
@@ -644,17 +668,22 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+				lifecycle := nodeKey + "|" + paneID
 				if memory, ok := t.nodeCompactionMemoryFor(nodeKey, now); ok {
-					applyCompactionMemory(&state, memory)
+					if memory.LastCompactionLifecycleIdentity == lifecycle {
+						applyCompactionMemory(&state, memory)
+					}
 				}
+				state.LastCompactionLifecycleIdentity = lifecycle
 				scan := compactionTriggerScan(runtime, compactionContent)
 				if scan.Trigger != "" {
 					if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 						recordCompactionPing(&state, scan, compactionHash, compactionScope, now)
 						compactionTargets[nodeKey] = CompactionPingTarget{
-							NodeKey: nodeKey,
-							Runtime: runtime,
-							Trigger: scan.Trigger,
+							NodeKey:        nodeKey,
+							Runtime:        runtime,
+							Trigger:        scan.Trigger,
+							MarkerIdentity: compactionMarkerIdentity(scan),
 						}
 					} else {
 						refreshSameCompactionMarker(&state, scan, compactionHash, compactionScope)
@@ -688,13 +717,15 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		// Update last capture time
 		state.LastCaptureAt = now
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
+			state.LastCompactionLifecycleIdentity = nodeKey + "|" + paneID
 			if scan := compactionTriggerScan(runtime, compactionContent); scan.Trigger != "" {
 				if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 					recordCompactionPing(&state, scan, compactionHash, compactionScope, now)
 					compactionTargets[nodeKey] = CompactionPingTarget{
-						NodeKey: nodeKey,
-						Runtime: runtime,
-						Trigger: scan.Trigger,
+						NodeKey:        nodeKey,
+						Runtime:        runtime,
+						Trigger:        scan.Trigger,
+						MarkerIdentity: compactionMarkerIdentity(scan),
 					}
 				} else {
 					refreshSameCompactionMarker(&state, scan, compactionHash, compactionScope)

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -656,8 +656,17 @@ func compactionLifecycleIdentity(nodeKey, paneID, paneProcessGeneration string) 
 	return nodeKey + "|" + paneID + "|pid:" + paneProcessGeneration
 }
 
+func compactionEndpointIdentity(nodeKey, paneID string) string {
+	return nodeKey + "|" + paneID
+}
+
+func sameCompactionEndpoint(identity, nodeKey, paneID string) bool {
+	endpoint := compactionEndpointIdentity(nodeKey, paneID)
+	return identity == endpoint || strings.HasPrefix(identity, endpoint+"|")
+}
+
 func pidQualifiedCompactionLifecycle(identity, nodeKey, paneID string) bool {
-	return strings.HasPrefix(identity, nodeKey+"|"+paneID+"|pid:")
+	return strings.HasPrefix(identity, compactionEndpointIdentity(nodeKey, paneID)+"|pid:")
 }
 
 func compactionLifecycleIdentityForNewPane(nodeKey, paneID string, generation paneProcessGeneration, memory PaneCaptureState, hasMemory bool) string {
@@ -671,6 +680,9 @@ func compactionLifecycleIdentityForNewPane(nodeKey, paneID string, generation pa
 }
 
 func compactionLifecycleIdentityForExistingPane(nodeKey, paneID string, generation paneProcessGeneration, previous string) (string, bool) {
+	if previous != "" && !sameCompactionEndpoint(previous, nodeKey, paneID) {
+		return compactionLifecycleIdentity(nodeKey, paneID, generation.Value), true
+	}
 	if generation.Known {
 		lifecycle := compactionLifecycleIdentity(nodeKey, paneID, generation.Value)
 		return lifecycle, pidQualifiedCompactionLifecycle(previous, nodeKey, paneID) && previous != lifecycle

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -630,15 +630,20 @@ func compactionAbsenceAuthoritative(state PaneCaptureState, scope compactionCapt
 	return state.LastCompactionTrigger != "" && scope == compactionScopeHistory
 }
 
-func queryPaneProcessGenerations(paneIDs []string) map[string]string {
-	generations := make(map[string]string)
+type paneProcessGeneration struct {
+	Value string
+	Known bool
+}
+
+func queryPaneProcessGenerations(paneIDs []string) map[string]paneProcessGeneration {
+	generations := make(map[string]paneProcessGeneration)
 	for _, paneID := range paneIDs {
 		output, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{pane_pid}").CombinedOutput()
 		if err != nil {
 			continue
 		}
 		if pid := strings.TrimSpace(string(output)); pid != "" {
-			generations[paneID] = pid
+			generations[paneID] = paneProcessGeneration{Value: pid, Known: true}
 		}
 	}
 	return generations
@@ -649,6 +654,31 @@ func compactionLifecycleIdentity(nodeKey, paneID, paneProcessGeneration string) 
 		return nodeKey + "|" + paneID
 	}
 	return nodeKey + "|" + paneID + "|pid:" + paneProcessGeneration
+}
+
+func pidQualifiedCompactionLifecycle(identity, nodeKey, paneID string) bool {
+	return strings.HasPrefix(identity, nodeKey+"|"+paneID+"|pid:")
+}
+
+func compactionLifecycleIdentityForNewPane(nodeKey, paneID string, generation paneProcessGeneration, memory PaneCaptureState, hasMemory bool) string {
+	if generation.Known {
+		return compactionLifecycleIdentity(nodeKey, paneID, generation.Value)
+	}
+	if hasMemory && pidQualifiedCompactionLifecycle(memory.LastCompactionLifecycleIdentity, nodeKey, paneID) {
+		return memory.LastCompactionLifecycleIdentity
+	}
+	return compactionLifecycleIdentity(nodeKey, paneID, "")
+}
+
+func compactionLifecycleIdentityForExistingPane(nodeKey, paneID string, generation paneProcessGeneration, previous string) (string, bool) {
+	if generation.Known {
+		lifecycle := compactionLifecycleIdentity(nodeKey, paneID, generation.Value)
+		return lifecycle, pidQualifiedCompactionLifecycle(previous, nodeKey, paneID) && previous != lifecycle
+	}
+	if previous != "" {
+		return previous, false
+	}
+	return compactionLifecycleIdentity(nodeKey, paneID, ""), false
 }
 
 // checkPaneCapture performs pane content capture and updates NodeActivity on consecutive changes.
@@ -731,8 +761,9 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
-				lifecycle := compactionLifecycleIdentity(nodeKey, paneID, paneProcessGenerations[paneID])
-				if memory, ok := t.nodeCompactionMemoryFor(nodeKey, now); ok {
+				memory, hasMemory := t.nodeCompactionMemoryFor(nodeKey, now)
+				lifecycle := compactionLifecycleIdentityForNewPane(nodeKey, paneID, paneProcessGenerations[paneID], memory, hasMemory)
+				if hasMemory {
 					if memory.LastCompactionLifecycleIdentity == lifecycle {
 						applyCompactionMemory(&state, memory)
 					}
@@ -781,8 +812,8 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 		// Update last capture time
 		state.LastCaptureAt = now
 		if nodeKey, hasNode := paneToNode[paneID]; hasNode {
-			lifecycle := compactionLifecycleIdentity(nodeKey, paneID, paneProcessGenerations[paneID])
-			if state.LastCompactionLifecycleIdentity != "" && state.LastCompactionLifecycleIdentity != lifecycle {
+			lifecycle, lifecycleChanged := compactionLifecycleIdentityForExistingPane(nodeKey, paneID, paneProcessGenerations[paneID], state.LastCompactionLifecycleIdentity)
+			if lifecycleChanged {
 				clearCompactionState(&state)
 			}
 			state.LastCompactionLifecycleIdentity = lifecycle

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -69,19 +69,20 @@ type compactionSuffixIdentity struct {
 
 // PaneCaptureState holds pane capture state for hybrid idle detection.
 type PaneCaptureState struct {
-	LastHash                  uint32    // CRC32 hash of pane content
-	LastChangeAt              time.Time // Last time content change was detected
-	ChangeCount               int       // Consecutive change count (2 = active)
-	LastCaptureAt             time.Time // Last capture time
-	LastCompactionPingAt      time.Time // Last compaction-triggered PING for this pane
-	LastCompactionTrigger     string    // Non-empty while a compaction marker remains in scanned content
-	LastCompactionHash        uint32    // Scanned compaction content hash for the most recent compaction marker state
-	LastCompactionMarkers     int       // Marker occurrences in scanned content for the most recent compaction state
-	LastCompactionMarkerHash  uint32    // Hash of the normalized latest marker line, independent of capture scope
-	LastCompactionScope       compactionCaptureScope
-	LastCompactionSuffix      compactionSuffixIdentity
-	LastCompactionPrefixHash  uint32 // Hash of scanned content through the latest marker occurrence
-	LastCompactionPrefixLines int    // Line count through the latest marker occurrence
+	LastHash                     uint32    // CRC32 hash of pane content
+	LastChangeAt                 time.Time // Last time content change was detected
+	ChangeCount                  int       // Consecutive change count (2 = active)
+	LastCaptureAt                time.Time // Last capture time
+	LastCompactionPingAt         time.Time // Last compaction-triggered PING for this pane
+	LastCompactionTrigger        string    // Non-empty while a compaction marker remains in scanned content
+	LastCompactionMarkerIdentity string    // Stable trigger/marker/count identity handled for this node
+	LastCompactionHash           uint32    // Scanned compaction content hash for the most recent compaction marker state
+	LastCompactionMarkers        int       // Marker occurrences in scanned content for the most recent compaction state
+	LastCompactionMarkerHash     uint32    // Hash of the normalized latest marker line, independent of capture scope
+	LastCompactionScope          compactionCaptureScope
+	LastCompactionSuffix         compactionSuffixIdentity
+	LastCompactionPrefixHash     uint32 // Hash of scanned content through the latest marker occurrence
+	LastCompactionPrefixLines    int    // Line count through the latest marker occurrence
 }
 
 // IdleTracker manages idle detection state (Issue #71).
@@ -460,10 +461,18 @@ func shouldPingCompaction(state PaneCaptureState, scan compactionMarkerScan, com
 	if !state.LastCompactionPingAt.IsZero() && now.Sub(state.LastCompactionPingAt) < compactionPingCooldown {
 		return false
 	}
+	if state.LastCompactionMarkerIdentity != "" {
+		if compactionMarkerIdentity(scan) == state.LastCompactionMarkerIdentity {
+			return false
+		}
+	}
 	if state.LastCompactionTrigger != "" {
-		return scan.Trigger != state.LastCompactionTrigger ||
-			scan.MarkerCount > state.LastCompactionMarkers ||
-			!sameCompactionMarker(state, scan, compactionHash, scope)
+		if scan.Trigger == state.LastCompactionTrigger &&
+			scan.MarkerCount <= state.LastCompactionMarkers &&
+			sameCompactionMarker(state, scan, compactionHash, scope) {
+			return false
+		}
+		return true
 	}
 	return state.LastCompactionHash != compactionHash
 }
@@ -477,6 +486,12 @@ func recordCompactionPing(state *PaneCaptureState, scan compactionMarkerScan, co
 	state.LastCompactionSuffix = scan.LatestMarkerSuffixID
 	state.LastCompactionPrefixHash = scan.MarkerPrefixHash
 	state.LastCompactionPrefixLines = scan.MarkerPrefixLines
+	state.LastCompactionMarkerIdentity = compactionMarkerIdentity(scan)
+}
+
+func compactionMarkerIdentity(scan compactionMarkerScan) string {
+	suffix := scan.LatestMarkerSuffixID
+	return fmt.Sprintf("%s:%08x:%d:%08x:%d:%d:%x:%s:%s", scan.Trigger, scan.MarkerLineHash, scan.MarkerCount, scan.MarkerPrefixHash, scan.MarkerPrefixLines, suffix.Length, suffix.Hash, suffix.Head, suffix.Tail)
 }
 
 func refreshSameCompactionMarker(state *PaneCaptureState, scan compactionMarkerScan, compactionHash uint32, scope compactionCaptureScope) {
@@ -487,12 +502,14 @@ func refreshSameCompactionMarker(state *PaneCaptureState, scan compactionMarkerS
 		state.LastCompactionSuffix = scan.LatestMarkerSuffixID
 		state.LastCompactionPrefixHash = scan.MarkerPrefixHash
 		state.LastCompactionPrefixLines = scan.MarkerPrefixLines
+		state.LastCompactionMarkerIdentity = compactionMarkerIdentity(scan)
 	}
 }
 
 func applyCompactionMemory(state *PaneCaptureState, memory PaneCaptureState) {
 	state.LastCompactionPingAt = memory.LastCompactionPingAt
 	state.LastCompactionTrigger = memory.LastCompactionTrigger
+	state.LastCompactionMarkerIdentity = memory.LastCompactionMarkerIdentity
 	state.LastCompactionHash = memory.LastCompactionHash
 	state.LastCompactionMarkers = memory.LastCompactionMarkers
 	state.LastCompactionMarkerHash = memory.LastCompactionMarkerHash
@@ -507,15 +524,16 @@ func (t *IdleTracker) rememberNodeCompaction(nodeKey string, state PaneCaptureSt
 		t.nodeCompactionMemory = make(map[string]PaneCaptureState)
 	}
 	t.nodeCompactionMemory[nodeKey] = PaneCaptureState{
-		LastCompactionPingAt:      state.LastCompactionPingAt,
-		LastCompactionTrigger:     state.LastCompactionTrigger,
-		LastCompactionHash:        state.LastCompactionHash,
-		LastCompactionMarkers:     state.LastCompactionMarkers,
-		LastCompactionMarkerHash:  state.LastCompactionMarkerHash,
-		LastCompactionScope:       state.LastCompactionScope,
-		LastCompactionSuffix:      state.LastCompactionSuffix,
-		LastCompactionPrefixHash:  state.LastCompactionPrefixHash,
-		LastCompactionPrefixLines: state.LastCompactionPrefixLines,
+		LastCompactionPingAt:         state.LastCompactionPingAt,
+		LastCompactionTrigger:        state.LastCompactionTrigger,
+		LastCompactionMarkerIdentity: state.LastCompactionMarkerIdentity,
+		LastCompactionHash:           state.LastCompactionHash,
+		LastCompactionMarkers:        state.LastCompactionMarkers,
+		LastCompactionMarkerHash:     state.LastCompactionMarkerHash,
+		LastCompactionScope:          state.LastCompactionScope,
+		LastCompactionSuffix:         state.LastCompactionSuffix,
+		LastCompactionPrefixHash:     state.LastCompactionPrefixHash,
+		LastCompactionPrefixLines:    state.LastCompactionPrefixLines,
 	}
 }
 
@@ -531,10 +549,20 @@ func (t *IdleTracker) pruneNodeCompactionMemory(now time.Time) {
 	}
 }
 
+func (t *IdleTracker) nodeCompactionMemoryFor(nodeKey string, now time.Time) (PaneCaptureState, bool) {
+	memory, ok := t.nodeCompactionMemory[nodeKey]
+	if !ok {
+		return PaneCaptureState{}, false
+	}
+	if memory.LastCompactionPingAt.IsZero() || now.Sub(memory.LastCompactionPingAt) > compactionMemoryRetention {
+		delete(t.nodeCompactionMemory, nodeKey)
+		return PaneCaptureState{}, false
+	}
+	return memory, true
+}
+
 func compactionAbsenceAuthoritative(state PaneCaptureState, scope compactionCaptureScope) bool {
-	return state.LastCompactionTrigger == "" ||
-		scope == compactionScopeHistory ||
-		state.LastCompactionScope != compactionScopeHistory
+	return state.LastCompactionTrigger != "" && scope == compactionScopeHistory
 }
 
 // checkPaneCapture performs pane content capture and updates NodeActivity on consecutive changes.
@@ -586,6 +614,8 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 	}
 
 	now := t.now()
+	// Reject expired node memory before any pane-state lookup/application.
+	t.pruneNodeCompactionMemory(now)
 	compactionTargets := make(map[string]CompactionPingTarget)
 
 	for _, paneID := range nodePaneIDs {
@@ -614,10 +644,11 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				LastCaptureAt: now,
 			}
 			if nodeKey, hasNode := paneToNode[paneID]; hasNode {
-				if scan := compactionTriggerScan(runtime, compactionContent); scan.Trigger != "" {
-					if memory, ok := t.nodeCompactionMemory[nodeKey]; ok {
-						applyCompactionMemory(&state, memory)
-					}
+				if memory, ok := t.nodeCompactionMemoryFor(nodeKey, now); ok {
+					applyCompactionMemory(&state, memory)
+				}
+				scan := compactionTriggerScan(runtime, compactionContent)
+				if scan.Trigger != "" {
 					if shouldPingCompaction(state, scan, compactionHash, compactionScope, now) {
 						recordCompactionPing(&state, scan, compactionHash, compactionScope, now)
 						compactionTargets[nodeKey] = CompactionPingTarget{
@@ -629,6 +660,24 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 						refreshSameCompactionMarker(&state, scan, compactionHash, compactionScope)
 					}
 					state.LastCompactionTrigger = scan.Trigger
+				}
+				if scan.Trigger == "" {
+					if compactionAbsenceAuthoritative(state, compactionScope) {
+						state.LastCompactionTrigger = ""
+						state.LastCompactionMarkerIdentity = ""
+						state.LastCompactionHash = 0
+						state.LastCompactionMarkers = 0
+						state.LastCompactionMarkerHash = 0
+						state.LastCompactionScope = ""
+						state.LastCompactionSuffix = compactionSuffixIdentity{}
+						state.LastCompactionPrefixHash = 0
+						state.LastCompactionPrefixLines = 0
+						t.clearNodeCompactionMemory(nodeKey)
+					} else {
+						// Preserve handled history across transient visible/recent absence.
+						t.rememberNodeCompaction(nodeKey, state)
+					}
+				} else {
 					t.rememberNodeCompaction(nodeKey, state)
 				}
 			}
@@ -654,6 +703,8 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				t.rememberNodeCompaction(nodeKey, state)
 			} else if compactionAbsenceAuthoritative(state, compactionScope) {
 				state.LastCompactionTrigger = ""
+				state.LastCompactionMarkerIdentity = ""
+				state.LastCompactionHash = 0
 				state.LastCompactionMarkers = 0
 				state.LastCompactionMarkerHash = 0
 				state.LastCompactionScope = ""

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -445,12 +445,14 @@ func sameCompactionMarker(state PaneCaptureState, scan compactionMarkerScan, com
 	if state.LastCompactionTrigger == "" || scan.Trigger != state.LastCompactionTrigger {
 		return false
 	}
+	sameLineAndCount := state.LastCompactionMarkerHash != 0 &&
+		state.LastCompactionMarkerHash == scan.MarkerLineHash &&
+		scan.MarkerCount == state.LastCompactionMarkers
+	sameSuffixContinuation := sameLineAndCount &&
+		compactionSuffixContinues(state.LastCompactionSuffix, scan.LatestMarkerSuffix)
 	if scope == compactionScopeHistory &&
 		state.LastCompactionScope != compactionScopeHistory &&
-		state.LastCompactionMarkerHash != 0 &&
-		state.LastCompactionMarkerHash == scan.MarkerLineHash &&
-		scan.MarkerCount == state.LastCompactionMarkers &&
-		compactionSuffixContinues(state.LastCompactionSuffix, scan.LatestMarkerSuffix) {
+		sameSuffixContinuation {
 		return true
 	}
 	if state.LastCompactionPrefixLines <= 0 {
@@ -458,7 +460,7 @@ func sameCompactionMarker(state PaneCaptureState, scan compactionMarkerScan, com
 	}
 	if state.LastCompactionPrefixHash == scan.MarkerPrefixHash {
 		if scan.MarkerPrefixLines <= 1 {
-			return state.LastCompactionHash == compactionHash
+			return state.LastCompactionHash == compactionHash || sameSuffixContinuation
 		}
 		return true
 	}

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1618,9 +1618,17 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameMarkerAfterStalePrun
 	if len(reobservedTargets) != 0 {
 		t.Fatalf("reobserved checkPaneCapture() returned %d targets, want 0 for already-handled marker", len(reobservedTargets))
 	}
+	// Once per-node memory expires, the same marker is a fresh event and emits once.
+	now = now.Add(compactionMemoryRetention + time.Second)
+	tracker.mu.Lock()
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+	if targets := tracker.checkPaneCapture(cfg, nodes); len(targets) != 1 {
+		t.Fatalf("post-retention reobserved targets = %d, want 1", len(targets))
+	}
 }
 
-func TestCheckPaneCapture_CompactionTriggerClearedMarkerAllowsFreshInitialMarkerAfterStalePrune(t *testing.T) {
+func TestCheckPaneCapture_NonAuthoritativeCompactionAbsencePreservesMemoryAndSuppressesReplay(t *testing.T) {
 	scriptDir := t.TempDir()
 	listPath := filepath.Join(scriptDir, "list.txt")
 	capturePath := filepath.Join(scriptDir, "capture.txt")
@@ -1683,8 +1691,8 @@ func TestCheckPaneCapture_CompactionTriggerClearedMarkerAllowsFreshInitialMarker
 	tracker.mu.Lock()
 	_, memoryExists := tracker.nodeCompactionMemory["review:worker"]
 	tracker.mu.Unlock()
-	if memoryExists {
-		t.Fatal("checkPaneCapture() kept node compaction memory after marker cleared")
+	if !memoryExists {
+		t.Fatal("checkPaneCapture() cleared node compaction memory after non-authoritative marker absence")
 	}
 
 	now = now.Add(2 * time.Second)
@@ -1703,8 +1711,8 @@ func TestCheckPaneCapture_CompactionTriggerClearedMarkerAllowsFreshInitialMarker
 		t.Fatalf("WriteFile(capture fresh marker): %v", err)
 	}
 	freshTargets := tracker.checkPaneCapture(cfg, nodes)
-	if len(freshTargets) != 1 {
-		t.Fatalf("fresh checkPaneCapture() returned %d targets, want 1", len(freshTargets))
+	if len(freshTargets) != 0 {
+		t.Fatalf("fresh checkPaneCapture() returned %d targets, want 0 after non-authoritative absence", len(freshTargets))
 	}
 }
 
@@ -2268,6 +2276,353 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatWhileMarkerRemainsVisibl
 	secondTargets := tracker.checkPaneCapture(cfg, nodes)
 	if len(secondTargets) != 0 {
 		t.Fatalf("second checkPaneCapture() returned %d targets, want 0 while marker remains visible", len(secondTargets))
+	}
+}
+
+func TestCheckPaneCapture_CompactionMarkerIdentitySurvivesPaneStateRecreation(t *testing.T) {
+	scriptDir := t.TempDir()
+	capturePath := filepath.Join(scriptDir, "capture.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ]; then cat \"$TMUX_A2A_TEST_CAPTURE\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_CAPTURE", capturePath)
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]discovery.NodeInfo{"review:worker": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	now := time.Date(2026, time.August, 5, 1, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	if err := os.WriteFile(capturePath, []byte("ready"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("initial targets = %d, want 0", len(got))
+	}
+	if err := os.WriteFile(capturePath, []byte("• Context compacted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("first targets = %d, want 1", len(got))
+	}
+	tracker.mu.Lock()
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+	now = now.Add(time.Second)
+	if err := os.WriteFile(capturePath, []byte("visible tail without marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("transient marker-free targets = %d, want 0", len(got))
+	}
+	tracker.mu.Lock()
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+	now = now.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(capturePath, []byte("• Context compacted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("recreated-pane targets = %d, want 0 for same marker", len(got))
+	}
+	if err := os.WriteFile(capturePath, []byte("• Context compacted\n• Context compacted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("newer-marker targets = %d, want 1", len(got))
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerEmitsAfterAuthoritativeMarkerFreeHistoryClearsSameMarker(t *testing.T) {
+	scriptDir := t.TempDir()
+	visiblePath := filepath.Join(scriptDir, "visible.txt")
+	recentPath := filepath.Join(scriptDir, "recent.txt")
+	historyPath := filepath.Join(scriptDir, "history.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ] && [ \"$6\" = '-' ]; then cat \"$TMUX_A2A_TEST_HISTORY\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ]; then cat \"$TMUX_A2A_TEST_RECENT\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then cat \"$TMUX_A2A_TEST_VISIBLE\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
+	t.Setenv("TMUX_A2A_TEST_RECENT", recentPath)
+	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
+
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]discovery.NodeInfo{"review:worker": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+		PaneCaptureTailLines:  1,
+	}
+	now := time.Date(2026, time.August, 6, 3, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+
+	markerHistory := "older retained output\n• Context compacted\nsame post-marker output"
+	if err := os.WriteFile(visiblePath, []byte("visible first"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent first without marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte(markerHistory), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("first targets = %d, want 1 for marker in full history", len(got))
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker-free"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent marker-free"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte("full history marker-free"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("marker-free history targets = %d, want 0", len(got))
+	}
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if state.LastCompactionTrigger != "" {
+		t.Fatalf("LastCompactionTrigger = %q, want cleared", state.LastCompactionTrigger)
+	}
+	if state.LastCompactionHash != 0 {
+		t.Fatalf("LastCompactionHash = %d, want cleared", state.LastCompactionHash)
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker returns"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent marker-free again"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte(markerHistory), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("returned marker targets = %d, want 1 after authoritative marker-free history cleared prior marker", len(got))
+	}
+}
+
+func TestCheckPaneCapture_RecreatedPaneAuthoritativeMarkerFreeHistoryClearsNodeMemory(t *testing.T) {
+	scriptDir := t.TempDir()
+	visiblePath := filepath.Join(scriptDir, "visible.txt")
+	recentPath := filepath.Join(scriptDir, "recent.txt")
+	historyPath := filepath.Join(scriptDir, "history.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ] && [ \"$6\" = '-' ]; then cat \"$TMUX_A2A_TEST_HISTORY\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ]; then cat \"$TMUX_A2A_TEST_RECENT\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then cat \"$TMUX_A2A_TEST_VISIBLE\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
+	t.Setenv("TMUX_A2A_TEST_RECENT", recentPath)
+	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
+
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	const nodeKey = "review:worker"
+	nodes := map[string]discovery.NodeInfo{nodeKey: {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+		PaneCaptureTailLines:  1,
+	}
+	now := time.Date(2026, time.August, 6, 3, 30, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+
+	markerHistory := "prelude\n• Context compacted\nsame post-marker output"
+	if err := os.WriteFile(visiblePath, []byte("visible initial without marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent initial without marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte(markerHistory), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("first targets = %d, want 1 for marker in full history", len(got))
+	}
+
+	tracker.mu.Lock()
+	memory, memoryExists := tracker.nodeCompactionMemory[nodeKey]
+	tracker.mu.Unlock()
+	if !memoryExists {
+		t.Fatal("node compaction memory was not established")
+	}
+	if memory.LastCompactionTrigger == "" {
+		t.Fatal("node compaction memory has empty trigger, want handled marker memory")
+	}
+	if memory.LastCompactionMarkerIdentity == "" {
+		t.Fatal("node compaction memory has empty marker identity, want handled marker memory")
+	}
+	if memory.LastCompactionHash == 0 {
+		t.Fatal("node compaction memory has zero hash, want handled marker memory")
+	}
+	if memory.LastCompactionMarkers == 0 {
+		t.Fatal("node compaction memory has zero marker count, want handled marker memory")
+	}
+	if memory.LastCompactionScope != compactionScopeHistory {
+		t.Fatalf("node compaction memory scope = %q, want full history", memory.LastCompactionScope)
+	}
+	firstPingAt := memory.LastCompactionPingAt
+	if firstPingAt.IsZero() {
+		t.Fatal("node compaction memory has zero ping time, want handled marker memory")
+	}
+
+	tracker.mu.Lock()
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+	now = now.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker-free after pane recreation"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent marker-free after pane recreation"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte("full history marker-free after pane recreation"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("marker-free recreated-pane targets = %d, want 0", len(got))
+	}
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	_, memoryExists = tracker.nodeCompactionMemory[nodeKey]
+	tracker.mu.Unlock()
+	if !state.LastCompactionPingAt.Equal(firstPingAt) {
+		t.Fatalf("LastCompactionPingAt = %v, want retained %v", state.LastCompactionPingAt, firstPingAt)
+	}
+	if state.LastCompactionTrigger != "" {
+		t.Fatalf("LastCompactionTrigger = %q, want cleared", state.LastCompactionTrigger)
+	}
+	if state.LastCompactionMarkerIdentity != "" {
+		t.Fatalf("LastCompactionMarkerIdentity = %q, want cleared", state.LastCompactionMarkerIdentity)
+	}
+	if state.LastCompactionHash != 0 {
+		t.Fatalf("LastCompactionHash = %d, want cleared", state.LastCompactionHash)
+	}
+	if state.LastCompactionMarkers != 0 {
+		t.Fatalf("LastCompactionMarkers = %d, want cleared", state.LastCompactionMarkers)
+	}
+	if state.LastCompactionMarkerHash != 0 {
+		t.Fatalf("LastCompactionMarkerHash = %d, want cleared", state.LastCompactionMarkerHash)
+	}
+	if state.LastCompactionScope != "" {
+		t.Fatalf("LastCompactionScope = %q, want cleared", state.LastCompactionScope)
+	}
+	if state.LastCompactionSuffix != (compactionSuffixIdentity{}) {
+		t.Fatalf("LastCompactionSuffix = %#v, want cleared", state.LastCompactionSuffix)
+	}
+	if state.LastCompactionPrefixHash != 0 {
+		t.Fatalf("LastCompactionPrefixHash = %d, want cleared", state.LastCompactionPrefixHash)
+	}
+	if state.LastCompactionPrefixLines != 0 {
+		t.Fatalf("LastCompactionPrefixLines = %d, want cleared", state.LastCompactionPrefixLines)
+	}
+	if memoryExists {
+		t.Fatal("node compaction memory still exists, want cleared")
+	}
+
+	now = firstPingAt.Add(compactionPingCooldown - time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker returns inside cooldown"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("recent marker-free inside cooldown"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte(markerHistory), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("same marker inside cooldown targets = %d, want 0", len(got))
+	}
+
+	now = firstPingAt.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker returns after cooldown"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("same marker after cooldown targets = %d, want 1", len(got))
+	}
+}
+
+func TestCheckPaneCapture_CompactionMarkersRemainIndependentPerNode(t *testing.T) {
+	scriptDir := t.TempDir()
+	firstPath, secondPath := filepath.Join(scriptDir, "first"), filepath.Join(scriptDir, "second")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex' '%12\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$4\" = '%11' ]; then cat \"$TMUX_A2A_TEST_FIRST\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$4\" = '%12' ]; then cat \"$TMUX_A2A_TEST_SECOND\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_FIRST", firstPath)
+	t.Setenv("TMUX_A2A_TEST_SECOND", secondPath)
+	for _, path := range []string{firstPath, secondPath} {
+		if err := os.WriteFile(path, []byte("ready"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:first":  {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+		"review:second": {PaneID: "%12", SessionName: "review", SessionDir: sessionDir},
+	}
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	tracker := NewIdleTracker()
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("initial targets = %d, want 0", len(got))
+	}
+	if err := os.WriteFile(firstPath, []byte("• Context compacted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 || got[0].NodeKey != "review:first" {
+		t.Fatalf("first-node targets = %#v, want review:first", got)
+	}
+	if err := os.WriteFile(secondPath, []byte("• Context compacted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := tracker.checkPaneCapture(cfg, nodes)
+	if len(got) != 1 || got[0].NodeKey != "review:second" {
+		t.Fatalf("second-node targets = %#v, want review:second", got)
 	}
 }
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1543,6 +1543,70 @@ func TestCheckPaneCapture_CompactionTriggerKeepsFullHistoryMemoryAcrossTailOnlyA
 	}
 }
 
+func TestCheckPaneCapture_RetriesFullHistoryAfterTransientCaptureFailure(t *testing.T) {
+	scriptDir := t.TempDir()
+	listPath := filepath.Join(scriptDir, "list.txt")
+	visiblePath := filepath.Join(scriptDir, "visible.txt")
+	recentPath := filepath.Join(scriptDir, "recent.txt")
+	historyPath := filepath.Join(scriptDir, "history.txt")
+	attemptsPath := filepath.Join(scriptDir, "history-attempts")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_LIST\"\n  exit 0\nfi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ] && [ \"$6\" = '-3' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_RECENT\"\n  exit 0\nfi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '-S' ] && [ \"$6\" = '-' ]; then\n" +
+		"  attempts=0\n  if [ -f \"$TMUX_A2A_TEST_HISTORY_ATTEMPTS\" ]; then attempts=$(cat \"$TMUX_A2A_TEST_HISTORY_ATTEMPTS\"); fi\n  attempts=$((attempts + 1))\n  printf '%s\\n' \"$attempts\" > \"$TMUX_A2A_TEST_HISTORY_ATTEMPTS\"\n  if [ \"$attempts\" -eq 1 ]; then exit 1; fi\n  cat \"$TMUX_A2A_TEST_HISTORY\"\n  exit 0\nfi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_VISIBLE\"\n  exit 0\nfi\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_LIST", listPath)
+	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
+	t.Setenv("TMUX_A2A_TEST_RECENT", recentPath)
+	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
+	t.Setenv("TMUX_A2A_TEST_HISTORY_ATTEMPTS", attemptsPath)
+
+	now := time.Date(2026, time.May, 21, 4, 0, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600, PaneCaptureTailLines: 3}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	nodes := map[string]discovery.NodeInfo{"review:worker": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	if err := os.WriteFile(listPath, []byte("%11\tcodex\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(list): %v", err)
+	}
+	visible := "unchanged visible content"
+	if err := os.WriteFile(visiblePath, []byte(visible), 0o644); err != nil {
+		t.Fatalf("WriteFile(visible): %v", err)
+	}
+	if err := os.WriteFile(recentPath, []byte("ordinary tail\n"+visible), 0o644); err != nil {
+		t.Fatalf("WriteFile(recent): %v", err)
+	}
+	if err := os.WriteFile(historyPath, []byte("older retained context\n• Context compacted\n"+visible), 0o644); err != nil {
+		t.Fatalf("WriteFile(history): %v", err)
+	}
+	if targets := tracker.checkPaneCapture(cfg, nodes); len(targets) != 0 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 0 after transient history failure", len(targets))
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	targets := tracker.checkPaneCapture(cfg, nodes)
+	if len(targets) != 1 || targets[0].NodeKey != "review:worker" {
+		tracker.mu.Lock()
+		state := tracker.paneCaptureState["%11"]
+		tracker.mu.Unlock()
+		t.Fatalf("second checkPaneCapture() targets = %#v, state=%+v, want one review:worker target after retry", targets, state)
+	}
+	if got, err := os.ReadFile(attemptsPath); err != nil || strings.TrimSpace(string(got)) != "2" {
+		t.Fatalf("history attempts = %q, err=%v, want 2", got, err)
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameMarkerAfterStalePrune(t *testing.T) {
 	scriptDir := t.TempDir()
 	listPath := filepath.Join(scriptDir, "list.txt")

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1637,6 +1637,143 @@ func TestShouldPingCompaction_DeliveredKeyDoesNotCollapseDistinctHistoryWindows(
 	}
 }
 
+func TestCheckPaneCapture_PositiveDeliverySuppressesFirstLineMarkerSuffixRefresh(t *testing.T) {
+	scriptDir := t.TempDir()
+	capturePath := filepath.Join(scriptDir, "capture.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then printf '%s\\n' '100'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ]; then cat \"$TMUX_A2A_TEST_CAPTURE\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_CAPTURE", capturePath)
+
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]discovery.NodeInfo{"review:worker": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	now := time.Date(2026, time.August, 9, 21, 20, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+
+	if err := os.WriteFile(capturePath, []byte("• Context compacted\nfirst output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first targets = %d, want 1", len(firstTargets))
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	if err := os.WriteFile(capturePath, []byte("• Context compacted\nfirst output\nsecond output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("already-delivered first-line marker emitted after suffix append: got %d target(s), want 0: %#v", len(got), got)
+	}
+}
+
+func TestCheckPaneCapture_DeliveredMarkerRefreshSurvivesScopeTransitionAndStateRecreation(t *testing.T) {
+	scriptDir := t.TempDir()
+	visiblePath := filepath.Join(scriptDir, "visible.txt")
+	recentPath := filepath.Join(scriptDir, "recent.txt")
+	historyPath := filepath.Join(scriptDir, "history.txt")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ]; then printf '%b\\n' '%11\\tcodex'; exit 0; fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then printf '%s\\n' '100'; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$5\" = '-S' ] && [ \"$6\" = '-' ]; then cat \"$TMUX_A2A_TEST_HISTORY\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$5\" = '-S' ]; then cat \"$TMUX_A2A_TEST_RECENT\"; exit 0; fi\n" +
+		"if [ \"$1\" = 'capture-pane' ]; then cat \"$TMUX_A2A_TEST_VISIBLE\"; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_VISIBLE", visiblePath)
+	t.Setenv("TMUX_A2A_TEST_RECENT", recentPath)
+	t.Setenv("TMUX_A2A_TEST_HISTORY", historyPath)
+
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]discovery.NodeInfo{"review:worker": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir}}
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600, PaneCaptureTailLines: 3}
+	now := time.Date(2026, time.August, 9, 21, 25, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+
+	if err := os.WriteFile(visiblePath, []byte("first output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("• Context compacted\nfirst output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, []byte("unused history"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first targets = %d, want 1 for recent marker", len(firstTargets))
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	if err := os.WriteFile(visiblePath, []byte("second output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recentPath, []byte("first output\nsecond output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshedHistory := "older retained context\n• Context compacted\nfirst output\nsecond output"
+	if err := os.WriteFile(historyPath, []byte(refreshedHistory), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshedTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(refreshedTargets) != 0 {
+		t.Fatalf("refresh targets = %d, want 0 while delivery cooldown suppresses same marker", len(refreshedTargets))
+	}
+	tracker.mu.Lock()
+	refreshedState := tracker.paneCaptureState["%11"]
+	refreshedMemory := tracker.nodeCompactionMemory["review:worker"]
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+	if refreshedState.LastCompactionScope != compactionScopeHistory {
+		t.Fatalf("refreshed scope = %q, want history", refreshedState.LastCompactionScope)
+	}
+	if refreshedState.LastCompactionMarkerIdentity == firstTargets[0].MarkerIdentity {
+		t.Fatal("refresh did not replace the suffix-derived marker identity")
+	}
+	if refreshedMemory.LastCompactionDeliveredKey == "" {
+		t.Fatal("refreshed memory lost delivered key")
+	}
+	if refreshedMemory.LastCompactionDeliveryPending {
+		t.Fatal("refreshed memory retained pending delivery after positive callback")
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("recreated-pane targets = %d, want 0 for delivered refreshed marker", len(got))
+	}
+	tracker.mu.Lock()
+	recreatedState := tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if recreatedState.LastCompactionScope != compactionScopeHistory {
+		t.Fatalf("recreated scope = %q, want history", recreatedState.LastCompactionScope)
+	}
+	if recreatedState.LastCompactionDeliveredKey != refreshedMemory.LastCompactionDeliveredKey {
+		t.Fatal("recreated pane did not restore delivered key from node memory")
+	}
+	if recreatedState.LastCompactionDeliveryPending {
+		t.Fatal("recreated pane restored pending delivery after positive callback")
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameMarkerAfterStalePrune(t *testing.T) {
 	scriptDir := t.TempDir()
 	listPath := filepath.Join(scriptDir, "list.txt")

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -2703,9 +2703,11 @@ func TestCheckPaneCapture_CompactionMarkerIdentitySurvivesPaneStateRecreation(t 
 	if err := os.WriteFile(capturePath, []byte("• Context compacted"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
-		t.Fatalf("first targets = %d, want 1", len(got))
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first targets = %d, want 1", len(firstTargets))
 	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
 	tracker.mu.Lock()
 	delete(tracker.paneCaptureState, "%11")
 	tracker.mu.Unlock()

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -3093,6 +3093,12 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePa
 	if memory.LastCompactionLifecycleIdentity != "review:second|%11|pid:100" {
 		t.Fatalf("memory lifecycle identity = %q, want second node PID lifecycle", memory.LastCompactionLifecycleIdentity)
 	}
+	if state.LastCompactionPaneID != "%11" {
+		t.Fatalf("state pane identity = %q, want %%11", state.LastCompactionPaneID)
+	}
+	if memory.LastCompactionPaneID != "%11" {
+		t.Fatalf("memory pane identity = %q, want %%11", memory.LastCompactionPaneID)
+	}
 
 	now = now.Add(compactionPingCooldown + time.Second)
 	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
@@ -3166,6 +3172,12 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentN
 	}
 	if memory.LastCompactionLifecycleIdentity != "review:second|%11" {
 		t.Fatalf("memory lifecycle identity = %q, want second node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+	if state.LastCompactionPaneID != "%11" {
+		t.Fatalf("state pane identity = %q, want %%11", state.LastCompactionPaneID)
+	}
+	if memory.LastCompactionPaneID != "%11" {
+		t.Fatalf("memory pane identity = %q, want %%11", memory.LastCompactionPaneID)
 	}
 }
 
@@ -3247,6 +3259,12 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePa
 	if memory.LastCompactionLifecycleIdentity != "review:first|%11" {
 		t.Fatalf("memory lifecycle identity = %q, want first node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
 	}
+	if state.LastCompactionPaneID != "%11" {
+		t.Fatalf("state pane identity = %q, want %%11", state.LastCompactionPaneID)
+	}
+	if memory.LastCompactionPaneID != "%11" {
+		t.Fatalf("memory pane identity = %q, want %%11", memory.LastCompactionPaneID)
+	}
 
 	tracker.mu.Lock()
 	if stale := tracker.nodeCompactionMemory["review:second"].LastCompactionLifecycleIdentity; stale != "" {
@@ -3280,6 +3298,12 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePa
 	if memory.LastCompactionLifecycleIdentity != "review:second|%11" {
 		t.Fatalf("memory lifecycle identity = %q, want second node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
 	}
+	if state.LastCompactionPaneID != "%11" {
+		t.Fatalf("state pane identity = %q, want %%11", state.LastCompactionPaneID)
+	}
+	if memory.LastCompactionPaneID != "%11" {
+		t.Fatalf("memory pane identity = %q, want %%11", memory.LastCompactionPaneID)
+	}
 
 	now = now.Add(compactionPingCooldown + time.Second)
 	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
@@ -3296,14 +3320,17 @@ func TestIdleTracker_ClearOtherNodeCompactionMemoryForPaneKeepsCurrentAndOtherPa
 	tracker.nodeCompactionMemory["review:first"] = PaneCaptureState{
 		LastCompactionPingAt:            now,
 		LastCompactionLifecycleIdentity: "review:first|%11|pid:100",
+		LastCompactionPaneID:            "%11",
 	}
 	tracker.nodeCompactionMemory["review:second"] = PaneCaptureState{
 		LastCompactionPingAt:            now,
 		LastCompactionLifecycleIdentity: "review:second|%11|pid:100",
+		LastCompactionPaneID:            "%11",
 	}
 	tracker.nodeCompactionMemory["review:other"] = PaneCaptureState{
 		LastCompactionPingAt:            now,
 		LastCompactionLifecycleIdentity: "review:other|%12|pid:200",
+		LastCompactionPaneID:            "%12",
 	}
 
 	tracker.clearOtherNodeCompactionMemoryForPane("review:second", "%11")
@@ -3316,6 +3343,168 @@ func TestIdleTracker_ClearOtherNodeCompactionMemoryForPaneKeepsCurrentAndOtherPa
 	}
 	if _, ok := tracker.nodeCompactionMemory["review:other"]; !ok {
 		t.Fatal("other-pane memory was cleared, want retained")
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenPipeNodeKeyRemapsBackWithUnknownPID(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	now := time.Date(2026, time.August, 9, 0, 20, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	sessionDir := filepath.Join(t.TempDir(), "team|blue")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	firstNodeKey := "team|blue:first"
+	secondNodeKey := "team|blue:second"
+
+	firstTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		firstNodeKey: {PaneID: "%11", SessionName: "team|blue", SessionDir: sessionDir},
+	})
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		secondNodeKey: {PaneID: "%11", SessionName: "team|blue", SessionDir: sessionDir},
+	})
+	if len(secondTargets) != 1 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 after pipe-node remap", len(secondTargets))
+	}
+	tracker.MarkCompactionPingDelivered(secondTargets[0].NodeKey, secondTargets[0].LifecycleIdentity, secondTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory[firstNodeKey].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale first-node memory lifecycle = %q, want cleared after pipe-node remap", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	thirdTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		firstNodeKey: {PaneID: "%11", SessionName: "team|blue", SessionDir: sessionDir},
+	})
+	if len(thirdTargets) != 1 {
+		t.Fatalf("third checkPaneCapture() returned %d targets, want 1 after pipe-node remap back and state recreation", len(thirdTargets))
+	}
+	if thirdTargets[0].NodeKey != firstNodeKey {
+		t.Fatalf("third target node = %q, want %q", thirdTargets[0].NodeKey, firstNodeKey)
+	}
+	if thirdTargets[0].LifecycleIdentity != "team|blue:first|%11" {
+		t.Fatalf("third lifecycle identity = %q, want first pipe-node lifecycle", thirdTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(thirdTargets[0].NodeKey, thirdTargets[0].LifecycleIdentity, thirdTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory[secondNodeKey].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale second-node memory lifecycle = %q, want cleared after pipe-node remap back", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	fourthTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		secondNodeKey: {PaneID: "%11", SessionName: "team|blue", SessionDir: sessionDir},
+	})
+	if len(fourthTargets) != 1 {
+		t.Fatalf("fourth checkPaneCapture() returned %d targets, want 1 after second pipe-node remap and state recreation", len(fourthTargets))
+	}
+	if fourthTargets[0].NodeKey != secondNodeKey {
+		t.Fatalf("fourth target node = %q, want %q", fourthTargets[0].NodeKey, secondNodeKey)
+	}
+	if fourthTargets[0].LifecycleIdentity != "team|blue:second|%11" {
+		t.Fatalf("fourth lifecycle identity = %q, want second pipe-node lifecycle", fourthTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(fourthTargets[0].NodeKey, fourthTargets[0].LifecycleIdentity, fourthTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	memory := tracker.nodeCompactionMemory[secondNodeKey]
+	tracker.mu.Unlock()
+	if state.LastCompactionPaneID != "%11" {
+		t.Fatalf("state pane identity = %q, want %%11", state.LastCompactionPaneID)
+	}
+	if memory.LastCompactionPaneID != "%11" {
+		t.Fatalf("memory pane identity = %q, want %%11", memory.LastCompactionPaneID)
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		secondNodeKey: {PaneID: "%11", SessionName: "team|blue", SessionDir: sessionDir},
+	})
+	if len(repeatTargets) != 0 {
+		t.Fatalf("repeat checkPaneCapture() returned %d targets, want 0 after pipe-node delivery", len(repeatTargets))
+	}
+}
+
+func TestIdleTracker_ClearOtherNodeCompactionMemoryForPaneWithPipeNodeKeysKeepsCurrentAndOtherPanes(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 0, 25, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	tracker.nodeCompactionMemory["team|blue:first"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "team|blue:first|%11|pid:100",
+		LastCompactionPaneID:            "%11",
+	}
+	tracker.nodeCompactionMemory["team|blue:second"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "team|blue:second|%11|pid:100",
+		LastCompactionPaneID:            "%11",
+	}
+	tracker.nodeCompactionMemory["team|blue:other"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "team|blue:other|%12|pid:200",
+		LastCompactionPaneID:            "%12",
+	}
+
+	tracker.clearOtherNodeCompactionMemoryForPane("team|blue:second", "%11")
+
+	if _, ok := tracker.nodeCompactionMemory["team|blue:first"]; ok {
+		t.Fatal("stale first pipe-node memory still exists, want cleared")
+	}
+	if _, ok := tracker.nodeCompactionMemory["team|blue:second"]; !ok {
+		t.Fatal("current second pipe-node memory was cleared, want retained")
+	}
+	if _, ok := tracker.nodeCompactionMemory["team|blue:other"]; !ok {
+		t.Fatal("other-pane pipe-node memory was cleared, want retained")
+	}
+}
+
+func TestIdleTracker_NodeCompactionMemoryForDropsZeroValuePaneIdentity(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 0, 30, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	tracker.nodeCompactionMemory["team|blue:worker"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "team|blue:worker|%11|pid:100",
+		LastCompactionTrigger:           "codex:conversation-compaction",
+	}
+
+	if _, ok := tracker.nodeCompactionMemoryFor("team|blue:worker", "%11", now); ok {
+		t.Fatal("zero-value pane identity memory was reusable, want dropped")
+	}
+	if _, ok := tracker.nodeCompactionMemory["team|blue:worker"]; ok {
+		t.Fatal("zero-value pane identity memory still exists, want deleted")
 	}
 }
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -2289,7 +2289,11 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsAfterSamePaneProcessGeneration
 		"  exit 0\n" +
 		"fi\n" +
 		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
-		"  cat \"$TMUX_A2A_TEST_PANE_PID\"\n" +
+		"  pid=$(cat \"$TMUX_A2A_TEST_PANE_PID\")\n" +
+		"  if [ \"$pid\" = 'fail' ]; then\n" +
+		"    exit 1\n" +
+		"  fi\n" +
+		"  printf '%s\\n' \"$pid\"\n" +
 		"  exit 0\n" +
 		"fi\n" +
 		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
@@ -2339,6 +2343,30 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsAfterSamePaneProcessGeneration
 		t.Fatalf("same-generation checkPaneCapture() returned %d targets, want 0", len(sameGenerationTargets))
 	}
 
+	if err := os.WriteFile(pidPath, []byte("fail\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid lookup failure): %v", err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	unknownGenerationTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(unknownGenerationTargets) != 0 {
+		t.Fatalf("unknown-generation checkPaneCapture() returned %d targets, want 0", len(unknownGenerationTargets))
+	}
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:worker|%11|pid:100" {
+		t.Fatalf("unknown-generation lifecycle identity = %q, want retained pid-qualified identity", state.LastCompactionLifecycleIdentity)
+	}
+
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid restored): %v", err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	restoredGenerationTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(restoredGenerationTargets) != 0 {
+		t.Fatalf("restored-generation checkPaneCapture() returned %d targets, want 0", len(restoredGenerationTargets))
+	}
+
 	if err := os.WriteFile(pidPath, []byte("200\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(pid second): %v", err)
 	}
@@ -2349,6 +2377,93 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsAfterSamePaneProcessGeneration
 	}
 	if newGenerationTargets[0].LifecycleIdentity != "review:worker|%11|pid:200" {
 		t.Fatalf("new lifecycle identity = %q, want updated pid-qualified identity", newGenerationTargets[0].LifecycleIdentity)
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerPreservesRetainedPIDLifecycleAcrossLookupFailureStateRecreation(t *testing.T) {
+	scriptDir := t.TempDir()
+	pidPath := filepath.Join(scriptDir, "pane-pid")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
+		"  pid=$(cat \"$TMUX_A2A_TEST_PANE_PID\")\n" +
+		"  if [ \"$pid\" = 'fail' ]; then\n" +
+		"    exit 1\n" +
+		"  fi\n" +
+		"  printf '%s\\n' \"$pid\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_PANE_PID", pidPath)
+
+	now := time.Date(2026, time.August, 8, 22, 45, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+	}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  sessionDir,
+		},
+	}
+
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid first): %v", err)
+	}
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	if firstTargets[0].LifecycleIdentity != "review:worker|%11|pid:100" {
+		t.Fatalf("first lifecycle identity = %q, want pid-qualified identity", firstTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	if err := os.WriteFile(pidPath, []byte("fail\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid lookup failure): %v", err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	recreatedTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(recreatedTargets) != 0 {
+		t.Fatalf("recreated-state checkPaneCapture() returned %d targets, want 0", len(recreatedTargets))
+	}
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:worker|%11|pid:100" {
+		t.Fatalf("recreated lifecycle identity = %q, want retained pid-qualified identity", state.LastCompactionLifecycleIdentity)
+	}
+
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid restored): %v", err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	restoredTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(restoredTargets) != 0 {
+		t.Fatalf("restored checkPaneCapture() returned %d targets, want 0", len(restoredTargets))
 	}
 }
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -2926,6 +2926,133 @@ func TestCheckPaneCapture_CompactionMarkersRemainIndependentPerNode(t *testing.T
 	}
 }
 
+func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentNodeWithKnownPID(t *testing.T) {
+	scriptDir := t.TempDir()
+	pidPath := filepath.Join(scriptDir, "pane-pid")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_PANE_PID\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_PANE_PID", pidPath)
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid): %v", err)
+	}
+
+	now := time.Date(2026, time.August, 8, 23, 25, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	if firstTargets[0].LifecycleIdentity != "review:first|%11|pid:100" {
+		t.Fatalf("first lifecycle identity = %q, want first node PID lifecycle", firstTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(secondTargets) != 1 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 after node remap", len(secondTargets))
+	}
+	if secondTargets[0].NodeKey != "review:second" {
+		t.Fatalf("second target node = %q, want review:second", secondTargets[0].NodeKey)
+	}
+	if secondTargets[0].LifecycleIdentity != "review:second|%11|pid:100" {
+		t.Fatalf("second lifecycle identity = %q, want second node PID lifecycle", secondTargets[0].LifecycleIdentity)
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentNodeWithUnknownPID(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	now := time.Date(2026, time.August, 8, 23, 30, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	if firstTargets[0].LifecycleIdentity != "review:first|%11" {
+		t.Fatalf("first lifecycle identity = %q, want first node legacy lifecycle", firstTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(secondTargets) != 1 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 after node remap", len(secondTargets))
+	}
+	if secondTargets[0].NodeKey != "review:second" {
+		t.Fatalf("second target node = %q, want review:second", secondTargets[0].NodeKey)
+	}
+	if secondTargets[0].LifecycleIdentity != "review:second|%11" {
+		t.Fatalf("second lifecycle identity = %q, want second node legacy lifecycle", secondTargets[0].LifecycleIdentity)
+	}
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	memory := tracker.nodeCompactionMemory["review:second"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:second|%11" {
+		t.Fatalf("state lifecycle identity = %q, want second node legacy lifecycle", state.LastCompactionLifecycleIdentity)
+	}
+	if memory.LastCompactionLifecycleIdentity != "review:second|%11" {
+		t.Fatalf("memory lifecycle identity = %q, want second node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameCaptureAfterMarkerClears(t *testing.T) {
 	scriptDir := t.TempDir()
 	capturePath := filepath.Join(scriptDir, "capture.txt")

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1626,6 +1626,17 @@ func TestShouldPingCompaction_SuppressesDeliveredSuffixRefreshAfterCooldown(t *t
 	}
 }
 
+func TestShouldPingCompaction_DeliveredKeyDoesNotCollapseDistinctHistoryWindows(t *testing.T) {
+	now := time.Date(2026, time.May, 21, 4, 0, 0, 0, time.UTC)
+	first := codexCompactionTriggerScan("prefix one\n• Context compacted\noutput")
+	distinct := codexCompactionTriggerScan("prefix two\n• Context compacted\noutput")
+	state := PaneCaptureState{LastCompactionTrigger: first.Trigger, LastCompactionMarkerHash: first.MarkerLineHash, LastCompactionMarkers: first.MarkerCount, LastCompactionPrefixHash: first.MarkerPrefixHash, LastCompactionPrefixLines: first.MarkerPrefixLines, LastCompactionScope: compactionScopeHistory, LastCompactionHash: hashContentCRC32("window one"), LastCompactionPingAt: now.Add(-compactionPingCooldown - time.Second)}
+	state.LastCompactionDeliveredKey = compactionStateDeliveryKey(state)
+	if !shouldPingCompaction(state, distinct, hashContentCRC32("window two"), compactionScopeHistory, now) {
+		t.Fatal("distinct history window was suppressed by a collapsed delivered key")
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameMarkerAfterStalePrune(t *testing.T) {
 	scriptDir := t.TempDir()
 	listPath := filepath.Join(scriptDir, "list.txt")

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -1607,6 +1607,25 @@ func TestCheckPaneCapture_RetriesFullHistoryAfterTransientCaptureFailure(t *test
 	}
 }
 
+func TestShouldPingCompaction_SuppressesDeliveredSuffixRefreshAfterCooldown(t *testing.T) {
+	now := time.Date(2026, time.May, 21, 4, 0, 0, 0, time.UTC)
+	first := codexCompactionTriggerScan("older context\n• Context compacted\nfirst output")
+	second := codexCompactionTriggerScan("older context\n• Context compacted\nfirst output\nsecond output")
+	state := PaneCaptureState{}
+	if !shouldPingCompaction(state, first, hashContentCRC32("first"), compactionScopeHistory, now) {
+		t.Fatal("initial marker was not emitted")
+	}
+	recordCompactionPing(&state, first, hashContentCRC32("first"), compactionScopeHistory, now)
+	state.LastCompactionDeliveredIdentity = state.LastCompactionMarkerIdentity
+	state.LastCompactionDeliveredKey = compactionStateDeliveryKey(state)
+	now = now.Add(compactionPingCooldown + time.Second)
+	state.LastCompactionMarkerIdentity = compactionMarkerIdentity(second)
+	state.LastCompactionSuffix = second.LatestMarkerSuffixID
+	if shouldPingCompaction(state, second, hashContentCRC32("second"), compactionScopeHistory, now) {
+		t.Fatal("suffix-only refresh of a delivered marker emitted a duplicate after cooldown")
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatSameMarkerAfterStalePrune(t *testing.T) {
 	scriptDir := t.TempDir()
 	listPath := filepath.Join(scriptDir, "list.txt")

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -2987,6 +2987,89 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentN
 	}
 }
 
+func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePaneRemapsBackWithKnownPID(t *testing.T) {
+	scriptDir := t.TempDir()
+	pidPath := filepath.Join(scriptDir, "pane-pid")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_PANE_PID\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_PANE_PID", pidPath)
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid): %v", err)
+	}
+
+	now := time.Date(2026, time.August, 8, 23, 45, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(secondTargets) != 1 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 after node remap", len(secondTargets))
+	}
+	tracker.MarkCompactionPingDelivered(secondTargets[0].NodeKey, secondTargets[0].LifecycleIdentity, secondTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory["review:first"].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale first-node memory lifecycle = %q, want cleared after remap", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	thirdTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(thirdTargets) != 1 {
+		t.Fatalf("third checkPaneCapture() returned %d targets, want 1 after remap back and state recreation", len(thirdTargets))
+	}
+	if thirdTargets[0].NodeKey != "review:first" {
+		t.Fatalf("third target node = %q, want review:first", thirdTargets[0].NodeKey)
+	}
+	if thirdTargets[0].LifecycleIdentity != "review:first|%11|pid:100" {
+		t.Fatalf("third lifecycle identity = %q, want first node PID lifecycle", thirdTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(thirdTargets[0].NodeKey, thirdTargets[0].LifecycleIdentity, thirdTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(repeatTargets) != 0 {
+		t.Fatalf("repeat checkPaneCapture() returned %d targets, want 0 after delivery", len(repeatTargets))
+	}
+}
+
 func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentNodeWithUnknownPID(t *testing.T) {
 	scriptDir := t.TempDir()
 	scriptPath := filepath.Join(scriptDir, "tmux")
@@ -3050,6 +3133,94 @@ func TestCheckPaneCapture_CompactionTriggerRepeatsWhenSamePaneRemapsToDifferentN
 	}
 	if memory.LastCompactionLifecycleIdentity != "review:second|%11" {
 		t.Fatalf("memory lifecycle identity = %q, want second node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePaneRemapsBackWithUnknownPID(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	now := time.Date(2026, time.August, 8, 23, 50, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{ActivityWindowSeconds: 120, NodeStaleSeconds: 600}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(secondTargets) != 1 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 1 after node remap", len(secondTargets))
+	}
+	tracker.MarkCompactionPingDelivered(secondTargets[0].NodeKey, secondTargets[0].LifecycleIdentity, secondTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory["review:first"].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale first-node memory lifecycle = %q, want cleared after remap", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	thirdTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(thirdTargets) != 1 {
+		t.Fatalf("third checkPaneCapture() returned %d targets, want 1 after remap back and state recreation", len(thirdTargets))
+	}
+	if thirdTargets[0].NodeKey != "review:first" {
+		t.Fatalf("third target node = %q, want review:first", thirdTargets[0].NodeKey)
+	}
+	if thirdTargets[0].LifecycleIdentity != "review:first|%11" {
+		t.Fatalf("third lifecycle identity = %q, want first node legacy lifecycle", thirdTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(thirdTargets[0].NodeKey, thirdTargets[0].LifecycleIdentity, thirdTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	memory := tracker.nodeCompactionMemory["review:first"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:first|%11" {
+		t.Fatalf("state lifecycle identity = %q, want first node legacy lifecycle", state.LastCompactionLifecycleIdentity)
+	}
+	if memory.LastCompactionLifecycleIdentity != "review:first|%11" {
+		t.Fatalf("memory lifecycle identity = %q, want first node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(repeatTargets) != 0 {
+		t.Fatalf("repeat checkPaneCapture() returned %d targets, want 0 after delivery", len(repeatTargets))
 	}
 }
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -3061,9 +3061,42 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePa
 	}
 	tracker.MarkCompactionPingDelivered(thirdTargets[0].NodeKey, thirdTargets[0].LifecycleIdentity, thirdTargets[0].MarkerIdentity)
 
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory["review:second"].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale second-node memory lifecycle = %q, want cleared after remap back", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	fourthTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(fourthTargets) != 1 {
+		t.Fatalf("fourth checkPaneCapture() returned %d targets, want 1 after second remap and state recreation", len(fourthTargets))
+	}
+	if fourthTargets[0].NodeKey != "review:second" {
+		t.Fatalf("fourth target node = %q, want review:second", fourthTargets[0].NodeKey)
+	}
+	if fourthTargets[0].LifecycleIdentity != "review:second|%11|pid:100" {
+		t.Fatalf("fourth lifecycle identity = %q, want second node PID lifecycle", fourthTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(fourthTargets[0].NodeKey, fourthTargets[0].LifecycleIdentity, fourthTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	state := tracker.paneCaptureState["%11"]
+	memory := tracker.nodeCompactionMemory["review:second"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:second|%11|pid:100" {
+		t.Fatalf("state lifecycle identity = %q, want second node PID lifecycle", state.LastCompactionLifecycleIdentity)
+	}
+	if memory.LastCompactionLifecycleIdentity != "review:second|%11|pid:100" {
+		t.Fatalf("memory lifecycle identity = %q, want second node PID lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+
 	now = now.Add(compactionPingCooldown + time.Second)
 	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
-		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
 	})
 	if len(repeatTargets) != 0 {
 		t.Fatalf("repeat checkPaneCapture() returned %d targets, want 0 after delivery", len(repeatTargets))
@@ -3215,12 +3248,74 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotReuseStaleNodeMemoryWhenSamePa
 		t.Fatalf("memory lifecycle identity = %q, want first node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
 	}
 
+	tracker.mu.Lock()
+	if stale := tracker.nodeCompactionMemory["review:second"].LastCompactionLifecycleIdentity; stale != "" {
+		t.Fatalf("stale second-node memory lifecycle = %q, want cleared after remap back", stale)
+	}
+	delete(tracker.paneCaptureState, "%11")
+	tracker.mu.Unlock()
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	fourthTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+	})
+	if len(fourthTargets) != 1 {
+		t.Fatalf("fourth checkPaneCapture() returned %d targets, want 1 after second remap and state recreation", len(fourthTargets))
+	}
+	if fourthTargets[0].NodeKey != "review:second" {
+		t.Fatalf("fourth target node = %q, want review:second", fourthTargets[0].NodeKey)
+	}
+	if fourthTargets[0].LifecycleIdentity != "review:second|%11" {
+		t.Fatalf("fourth lifecycle identity = %q, want second node legacy lifecycle", fourthTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(fourthTargets[0].NodeKey, fourthTargets[0].LifecycleIdentity, fourthTargets[0].MarkerIdentity)
+
+	tracker.mu.Lock()
+	state = tracker.paneCaptureState["%11"]
+	memory = tracker.nodeCompactionMemory["review:second"]
+	tracker.mu.Unlock()
+	if state.LastCompactionLifecycleIdentity != "review:second|%11" {
+		t.Fatalf("state lifecycle identity = %q, want second node legacy lifecycle", state.LastCompactionLifecycleIdentity)
+	}
+	if memory.LastCompactionLifecycleIdentity != "review:second|%11" {
+		t.Fatalf("memory lifecycle identity = %q, want second node legacy lifecycle", memory.LastCompactionLifecycleIdentity)
+	}
+
 	now = now.Add(compactionPingCooldown + time.Second)
 	repeatTargets := tracker.checkPaneCapture(cfg, map[string]discovery.NodeInfo{
-		"review:first": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
+		"review:second": {PaneID: "%11", SessionName: "review", SessionDir: sessionDir},
 	})
 	if len(repeatTargets) != 0 {
 		t.Fatalf("repeat checkPaneCapture() returned %d targets, want 0 after delivery", len(repeatTargets))
+	}
+}
+
+func TestIdleTracker_ClearOtherNodeCompactionMemoryForPaneKeepsCurrentAndOtherPanes(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 0, 5, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	tracker.nodeCompactionMemory["review:first"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "review:first|%11|pid:100",
+	}
+	tracker.nodeCompactionMemory["review:second"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "review:second|%11|pid:100",
+	}
+	tracker.nodeCompactionMemory["review:other"] = PaneCaptureState{
+		LastCompactionPingAt:            now,
+		LastCompactionLifecycleIdentity: "review:other|%12|pid:200",
+	}
+
+	tracker.clearOtherNodeCompactionMemoryForPane("review:second", "%11")
+
+	if _, ok := tracker.nodeCompactionMemory["review:first"]; ok {
+		t.Fatal("stale first-node memory still exists, want cleared")
+	}
+	if _, ok := tracker.nodeCompactionMemory["review:second"]; !ok {
+		t.Fatal("current second-node memory was cleared, want retained")
+	}
+	if _, ok := tracker.nodeCompactionMemory["review:other"]; !ok {
+		t.Fatal("other-pane memory was cleared, want retained")
 	}
 }
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -2279,6 +2279,191 @@ func TestCheckPaneCapture_CompactionTriggerDoesNotRepeatWhileMarkerRemainsVisibl
 	}
 }
 
+func TestCheckPaneCapture_CompactionTriggerRepeatsAfterSamePaneProcessGenerationChanges(t *testing.T) {
+	scriptDir := t.TempDir()
+	pidPath := filepath.Join(scriptDir, "pane-pid")
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
+		"  cat \"$TMUX_A2A_TEST_PANE_PID\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_A2A_TEST_PANE_PID", pidPath)
+
+	now := time.Date(2026, time.August, 8, 22, 30, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+	}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  sessionDir,
+		},
+	}
+
+	if err := os.WriteFile(pidPath, []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid first): %v", err)
+	}
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	if firstTargets[0].LifecycleIdentity != "review:worker|%11|pid:100" {
+		t.Fatalf("first lifecycle identity = %q, want pid-qualified identity", firstTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	sameGenerationTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(sameGenerationTargets) != 0 {
+		t.Fatalf("same-generation checkPaneCapture() returned %d targets, want 0", len(sameGenerationTargets))
+	}
+
+	if err := os.WriteFile(pidPath, []byte("200\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid second): %v", err)
+	}
+	now = now.Add(compactionPingCooldown + time.Second)
+	newGenerationTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(newGenerationTargets) != 1 {
+		t.Fatalf("new-generation checkPaneCapture() returned %d targets, want 1", len(newGenerationTargets))
+	}
+	if newGenerationTargets[0].LifecycleIdentity != "review:worker|%11|pid:200" {
+		t.Fatalf("new lifecycle identity = %q, want updated pid-qualified identity", newGenerationTargets[0].LifecycleIdentity)
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerUsesLegacyLifecycleWhenPanePIDLookupFails(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tcodex'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '• Context compacted'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	now := time.Date(2026, time.August, 8, 22, 40, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+	}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  sessionDir,
+		},
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	if firstTargets[0].LifecycleIdentity != "review:worker|%11" {
+		t.Fatalf("lifecycle identity = %q, want legacy pane identity", firstTargets[0].LifecycleIdentity)
+	}
+	tracker.MarkCompactionPingDelivered(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+
+	now = now.Add(compactionPingCooldown + time.Second)
+	secondTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(secondTargets) != 0 {
+		t.Fatalf("second checkPaneCapture() returned %d targets, want 0 when pid lookup fails and marker is already delivered", len(secondTargets))
+	}
+}
+
+func TestCheckPaneCapture_CompactionTriggerRetriesAfterDeliveryFailure(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "tmux")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = 'list-panes' ] && [ \"$2\" = '-a' ] && [ \"$3\" = '-F' ] && [ \"$4\" = '#{pane_id}\t#{pane_current_command}' ]; then\n" +
+		"  printf '%s\\n' '%11\tclaude'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'display-message' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ] && [ \"$5\" = '#{pane_pid}' ]; then\n" +
+		"  printf '%s\\n' '100'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = 'capture-pane' ] && [ \"$2\" = '-p' ] && [ \"$3\" = '-t' ] && [ \"$4\" = '%11' ]; then\n" +
+		"  printf '%s\\n' '✻ Conversation compacted (ctrl+o for history)'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake tmux): %v", err)
+	}
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	now := time.Date(2026, time.August, 8, 22, 50, 0, 0, time.UTC)
+	tracker := newIdleTrackerWithClock(func() time.Time { return now })
+	cfg := &config.Config{
+		ActivityWindowSeconds: 120,
+		NodeStaleSeconds:      600,
+	}
+	sessionDir := filepath.Join(t.TempDir(), "review")
+	if err := config.CreateSessionDirs(sessionDir); err != nil {
+		t.Fatalf("CreateSessionDirs: %v", err)
+	}
+	nodes := map[string]discovery.NodeInfo{
+		"review:worker": {
+			PaneID:      "%11",
+			SessionName: "review",
+			SessionDir:  sessionDir,
+		},
+	}
+
+	firstTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(firstTargets) != 1 {
+		t.Fatalf("first checkPaneCapture() returned %d targets, want 1", len(firstTargets))
+	}
+	pendingTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(pendingTargets) != 0 {
+		t.Fatalf("pending checkPaneCapture() returned %d targets, want 0 while delivery is pending", len(pendingTargets))
+	}
+
+	tracker.MarkCompactionPingDeliveryFailed(firstTargets[0].NodeKey, firstTargets[0].LifecycleIdentity, firstTargets[0].MarkerIdentity)
+	now = now.Add(compactionPingCooldown + time.Second)
+	retryTargets := tracker.checkPaneCapture(cfg, nodes)
+	if len(retryTargets) != 1 {
+		t.Fatalf("retry checkPaneCapture() returned %d targets, want 1 after failed/skipped/undelivered delivery", len(retryTargets))
+	}
+}
+
 func TestCheckPaneCapture_CompactionMarkerIdentitySurvivesPaneStateRecreation(t *testing.T) {
 	scriptDir := t.TempDir()
 	capturePath := filepath.Join(scriptDir, "capture.txt")


### PR DESCRIPTION
## Summary

- Prevent duplicate compaction-triggered pings when marker suffix refresh, node/remap transitions, pane owner changes, or delivered-state reconstruction reuse stale compaction delivery memory.
- Track compaction delivery identity structurally in `internal/idle/idle.go`, including pane/process generation and delivered-state equivalence gates, so already-delivered compaction work is not resent as a fresh ping.
- Add regression coverage in `internal/idle/idle_test.go` for retryable capture failures, endpoint/node remaps, pane owner invalidation, delivered lifecycle recreation, and suffix-refresh suppression; wire the new idle behavior from `internal/cli/start.go`.

## Changed files

- `internal/cli/start.go`
- `internal/idle/idle.go`
- `internal/idle/idle_test.go`

## Verification

- `go test ./internal/idle -count=1`
- `go test ./... -count=1`
- `go test -race ./internal/idle -count=1`
- `nix flake check`
- `nix build`

Closes #609.
