### PR TITLE
fix(idle): close compaction ping episodes after marker resets

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -38,6 +38,17 @@ import (
 
 var newHerdrRuntimeClient herdrruntime.ClientFactory = herdrruntime.NewSocketClient
 
+var (
+	reserveCompactionPingAutoWake = reserveDirectPingAutoWake
+	sendCompactionPingToNode      = ping.SendPingToNodeWithOptions
+	markCompactionPingDelivered   = func(tracker *idle.IdleTracker, nodeKey, lifecycleIdentity, markerIdentity string) {
+		tracker.MarkCompactionPingDelivered(nodeKey, lifecycleIdentity, markerIdentity)
+	}
+	markCompactionPingDeliveryFailed = func(tracker *idle.IdleTracker, nodeKey, lifecycleIdentity, markerIdentity string) {
+		tracker.MarkCompactionPingDeliveryFailed(nodeKey, lifecycleIdentity, markerIdentity)
+	}
+)
+
 // safeGo starts a goroutine with panic recovery (Issue #57).
 func safeGo(name string, events chan<- tui.DaemonEvent, fn func()) {
 	go func() {
@@ -224,30 +235,34 @@ func sendCompactionPings(contextID string, cfg *config.Config, idleTracker *idle
 	for _, target := range targets {
 		nodeInfo, ok := nodes[target.NodeKey]
 		if !ok {
+			markCompactionPingDeliveryFailed(idleTracker, target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
+			log.Printf("postman: compaction-triggered PING skipped for %s: discovered node is no longer present\n", target.NodeKey)
 			continue
 		}
 		func() {
-			reservation, shouldSend := reserveDirectPingAutoWake(target.NodeKey, nodeInfo)
+			reservation, shouldSend := reserveCompactionPingAutoWake(target.NodeKey, nodeInfo)
 			if !shouldSend {
-				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
+				markCompactionPingDeliveryFailed(idleTracker, target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				log.Printf("postman: compaction-triggered PING skipped for %s: matching auto-PING already in flight\n", target.NodeKey)
 				return
 			}
-			defer reservation.Release()
+			if reservation != nil {
+				defer reservation.Release()
+			}
 
 			options := ping.SendOptions{CompactionTriggered: true, Runtime: target.Runtime}
-			result, err := ping.SendPingToNodeWithOptions(nodeInfo, contextID, target.NodeKey, cfg.DaemonMessageTemplate, cfg, activeNodes, livenessMap, pingAdjacency, nodes, options)
+			result, err := sendCompactionPingToNode(nodeInfo, contextID, target.NodeKey, cfg.DaemonMessageTemplate, cfg, activeNodes, livenessMap, pingAdjacency, nodes, options)
 			if err != nil {
-				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
+				markCompactionPingDeliveryFailed(idleTracker, target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				log.Printf("postman: compaction-triggered PING failed for %s: %v\n", target.NodeKey, err)
 				return
 			}
 			if result.Delivered {
-				idleTracker.MarkCompactionPingDelivered(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
+				markCompactionPingDelivered(idleTracker, target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 				recordDirectPingDelivered(target.NodeKey, nodeInfo, "compaction", time.Now())
 			}
 			if !result.Delivered {
-				idleTracker.MarkCompactionPingDeliveryFailed(target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
+				markCompactionPingDeliveryFailed(idleTracker, target.NodeKey, target.LifecycleIdentity, target.MarkerIdentity)
 			}
 			log.Printf("postman: compaction-triggered PING sent to %s trigger=%s runtime=%s\n", target.NodeKey, target.Trigger, target.Runtime)
 		}()

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/lock"
 	"github.com/i9wa4/tmux-a2a-postman/internal/multiplexer"
+	"github.com/i9wa4/tmux-a2a-postman/internal/ping"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 )
 
@@ -915,6 +917,123 @@ func TestSendCompactionPings_DeliversPingToDetectedNode(t *testing.T) {
 	}
 	if got.Reason != "discovered" || got.ResolutionReason != "compaction" {
 		t.Fatalf("compaction-resolved state = %#v", got)
+	}
+}
+
+func TestSendCompactionPings_MarksTerminalOutcomeForDeliveryPaths(t *testing.T) {
+	type outcome struct {
+		nodeKey           string
+		lifecycleIdentity string
+		markerIdentity    string
+	}
+
+	tests := []struct {
+		name          string
+		nodes         map[string]discovery.NodeInfo
+		reserve       func(string, discovery.NodeInfo) (*autoping.Reservation, bool)
+		sendResult    controlplane.SystemMessageResult
+		sendErr       error
+		wantDelivered []outcome
+		wantFailed    []outcome
+		wantSendCount int
+	}{
+		{
+			name: "delivered",
+			nodes: map[string]discovery.NodeInfo{
+				"review:worker": {PaneID: "%11", SessionName: "review"},
+			},
+			reserve:       func(string, discovery.NodeInfo) (*autoping.Reservation, bool) { return nil, true },
+			sendResult:    controlplane.SystemMessageResult{Delivered: true},
+			wantDelivered: []outcome{{nodeKey: "review:worker", lifecycleIdentity: "life-1", markerIdentity: "marker-1"}},
+			wantSendCount: 1,
+		},
+		{
+			name: "undelivered",
+			nodes: map[string]discovery.NodeInfo{
+				"review:worker": {PaneID: "%11", SessionName: "review"},
+			},
+			reserve:       func(string, discovery.NodeInfo) (*autoping.Reservation, bool) { return nil, true },
+			sendResult:    controlplane.SystemMessageResult{Delivered: false},
+			wantFailed:    []outcome{{nodeKey: "review:worker", lifecycleIdentity: "life-1", markerIdentity: "marker-1"}},
+			wantSendCount: 1,
+		},
+		{
+			name: "send error",
+			nodes: map[string]discovery.NodeInfo{
+				"review:worker": {PaneID: "%11", SessionName: "review"},
+			},
+			reserve:       func(string, discovery.NodeInfo) (*autoping.Reservation, bool) { return nil, true },
+			sendErr:       errors.New("boom"),
+			wantFailed:    []outcome{{nodeKey: "review:worker", lifecycleIdentity: "life-1", markerIdentity: "marker-1"}},
+			wantSendCount: 1,
+		},
+		{
+			name: "reservation skip",
+			nodes: map[string]discovery.NodeInfo{
+				"review:worker": {PaneID: "%11", SessionName: "review"},
+			},
+			reserve:       func(string, discovery.NodeInfo) (*autoping.Reservation, bool) { return nil, false },
+			wantFailed:    []outcome{{nodeKey: "review:worker", lifecycleIdentity: "life-1", markerIdentity: "marker-1"}},
+			wantSendCount: 0,
+		},
+		{
+			name:          "missing node",
+			nodes:         map[string]discovery.NodeInfo{},
+			reserve:       func(string, discovery.NodeInfo) (*autoping.Reservation, bool) { return nil, true },
+			wantFailed:    []outcome{{nodeKey: "review:worker", lifecycleIdentity: "life-1", markerIdentity: "marker-1"}},
+			wantSendCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalReserve := reserveCompactionPingAutoWake
+			originalSend := sendCompactionPingToNode
+			originalDelivered := markCompactionPingDelivered
+			originalFailed := markCompactionPingDeliveryFailed
+			t.Cleanup(func() {
+				reserveCompactionPingAutoWake = originalReserve
+				sendCompactionPingToNode = originalSend
+				markCompactionPingDelivered = originalDelivered
+				markCompactionPingDeliveryFailed = originalFailed
+			})
+
+			var gotDelivered []outcome
+			var gotFailed []outcome
+			sendCount := 0
+			reserveCompactionPingAutoWake = tt.reserve
+			sendCompactionPingToNode = func(nodeInfo discovery.NodeInfo, contextID, nodeName, tmpl string, cfg *config.Config, activeNodes []string, livenessMap map[string]bool, adjacency map[string][]string, nodes map[string]discovery.NodeInfo, options ping.SendOptions) (controlplane.SystemMessageResult, error) {
+				sendCount++
+				if !options.CompactionTriggered {
+					t.Fatal("CompactionTriggered option = false, want true")
+				}
+				return tt.sendResult, tt.sendErr
+			}
+			markCompactionPingDelivered = func(_ *idle.IdleTracker, nodeKey, lifecycleIdentity, markerIdentity string) {
+				gotDelivered = append(gotDelivered, outcome{nodeKey: nodeKey, lifecycleIdentity: lifecycleIdentity, markerIdentity: markerIdentity})
+			}
+			markCompactionPingDeliveryFailed = func(_ *idle.IdleTracker, nodeKey, lifecycleIdentity, markerIdentity string) {
+				gotFailed = append(gotFailed, outcome{nodeKey: nodeKey, lifecycleIdentity: lifecycleIdentity, markerIdentity: markerIdentity})
+			}
+
+			sendCompactionPings("ctx-compaction", &config.Config{}, idle.NewIdleTracker(), tt.nodes, []idle.CompactionPingTarget{{
+				NodeKey:           "review:worker",
+				Runtime:           "claude",
+				Trigger:           "claude:conversation-compaction",
+				LifecycleIdentity: "life-1",
+				MarkerIdentity:    "marker-1",
+			}})
+
+			if sendCount != tt.wantSendCount {
+				t.Fatalf("send count = %d, want %d", sendCount, tt.wantSendCount)
+			}
+			if got, want := fmt.Sprint(gotDelivered), fmt.Sprint(tt.wantDelivered); got != want {
+				t.Fatalf("delivered outcomes = %s, want %s", got, want)
+			}
+			if got, want := fmt.Sprint(gotFailed), fmt.Sprint(tt.wantFailed); got != want {
+				t.Fatalf("failed outcomes = %s, want %s", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -850,15 +850,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				}
 				if scan.Trigger == "" {
 					if compactionAbsenceAuthoritative(state, compactionScope) {
-						state.LastCompactionTrigger = ""
-						state.LastCompactionMarkerIdentity = ""
-						state.LastCompactionHash = 0
-						state.LastCompactionMarkers = 0
-						state.LastCompactionMarkerHash = 0
-						state.LastCompactionScope = ""
-						state.LastCompactionSuffix = compactionSuffixIdentity{}
-						state.LastCompactionPrefixHash = 0
-						state.LastCompactionPrefixLines = 0
+						clearCompactionState(&state)
 						t.clearNodeCompactionMemory(nodeKey)
 					} else {
 						// Preserve handled history across transient visible/recent absence.
@@ -899,15 +891,7 @@ func (t *IdleTracker) checkPaneCapture(cfg *config.Config, nodes map[string]disc
 				state.LastCompactionTrigger = scan.Trigger
 				t.rememberNodeCompaction(nodeKey, state)
 			} else if compactionAbsenceAuthoritative(state, compactionScope) {
-				state.LastCompactionTrigger = ""
-				state.LastCompactionMarkerIdentity = ""
-				state.LastCompactionHash = 0
-				state.LastCompactionMarkers = 0
-				state.LastCompactionMarkerHash = 0
-				state.LastCompactionScope = ""
-				state.LastCompactionSuffix = compactionSuffixIdentity{}
-				state.LastCompactionPrefixHash = 0
-				state.LastCompactionPrefixLines = 0
+				clearCompactionState(&state)
 				t.clearNodeCompactionMemory(nodeKey)
 			}
 		}

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -3054,11 +3054,20 @@ func TestCheckPaneCapture_RecreatedPaneAuthoritativeMarkerFreeHistoryClearsNodeM
 	state := tracker.paneCaptureState["%11"]
 	_, memoryExists = tracker.nodeCompactionMemory[nodeKey]
 	tracker.mu.Unlock()
-	if !state.LastCompactionPingAt.Equal(firstPingAt) {
-		t.Fatalf("LastCompactionPingAt = %v, want retained %v", state.LastCompactionPingAt, firstPingAt)
+	if !state.LastCompactionPingAt.IsZero() {
+		t.Fatalf("LastCompactionPingAt = %v, want cleared", state.LastCompactionPingAt)
 	}
 	if state.LastCompactionTrigger != "" {
 		t.Fatalf("LastCompactionTrigger = %q, want cleared", state.LastCompactionTrigger)
+	}
+	if state.LastCompactionDeliveryPending {
+		t.Fatal("LastCompactionDeliveryPending = true, want cleared")
+	}
+	if state.LastCompactionDeliveredIdentity != "" {
+		t.Fatalf("LastCompactionDeliveredIdentity = %q, want cleared", state.LastCompactionDeliveredIdentity)
+	}
+	if state.LastCompactionDeliveredKey != "" {
+		t.Fatalf("LastCompactionDeliveredKey = %q, want cleared", state.LastCompactionDeliveredKey)
 	}
 	if state.LastCompactionMarkerIdentity != "" {
 		t.Fatalf("LastCompactionMarkerIdentity = %q, want cleared", state.LastCompactionMarkerIdentity)
@@ -3098,16 +3107,16 @@ func TestCheckPaneCapture_RecreatedPaneAuthoritativeMarkerFreeHistoryClearsNodeM
 	if err := os.WriteFile(historyPath, []byte(markerHistory), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
-		t.Fatalf("same marker inside cooldown targets = %d, want 0", len(got))
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
+		t.Fatalf("same marker inside cooldown targets = %d, want 1 after authoritative absence clears compaction episode", len(got))
 	}
 
-	now = firstPingAt.Add(compactionPingCooldown + time.Second)
-	if err := os.WriteFile(visiblePath, []byte("visible marker returns after cooldown"), 0o644); err != nil {
+	now = now.Add(time.Second)
+	if err := os.WriteFile(visiblePath, []byte("visible marker remains after immediate reappearance"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 1 {
-		t.Fatalf("same marker after cooldown targets = %d, want 1", len(got))
+	if got := tracker.checkPaneCapture(cfg, nodes); len(got) != 0 {
+		t.Fatalf("same marker after immediate reappearance targets = %d, want 0 for exact-once re-emit", len(got))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to merged #691 for #609.
- Clear compaction ping episode state when authoritative marker-free history proves a pane was recreated.
- Mark all compaction ping delivery terminal outcomes so retries are not suppressed by stale pending state.

## Repaired blockers
- Recreated panes could keep stale compaction ping cooldown/identity state after marker reset.
- Failed, skipped, or missing-node compaction ping sends could leave delivery state pending.

## Verification
- `go test ./internal/idle -run 'TestCheckPaneCapture_RecreatedPaneAuthoritativeMarkerFreeHistoryClearsNodeMemory' -count=5`
- `go test ./internal/cli -run 'TestSendCompactionPings' -count=5`
- `git diff --check`
- `git diff --cached --check`
- `git diff HEAD --check`
- `go test -race ./internal/idle -count=1`
- `go test ./... -count=1`
- `golangci-lint run ./...`
- `nix flake check`
- `nix build`
