### PR TITLE
fix(cli): resolve command approvers in requester session

### DIFF
--- a/internal/cli/command_approval_delivery.go
+++ b/internal/cli/command_approval_delivery.go
@@ -20,12 +20,10 @@ import (
 var discoverNodesForCommandApprovalDeliveryFn = discovery.DiscoverNodesWithCollisions
 
 // deliverCommandApprovalRequest sends a reply-required postman message to
-// the resolved command_approver_node when a command needs approval (#626). This is
-// best-effort: a delivery failure is logged, not returned as an error — the
-// approval request has already been journaled by the caller regardless, so
-// a failed delivery only means the reviewer must be notified some other way
-// (e.g. inspect-command-approvals), never that anything blocks or that the
-// request goes unrecorded.
+// the resolved command_approver_node when a command needs approval (#626).
+// The approval request has already been journaled by the caller regardless;
+// returning an error lets blocking mode fail closed when a configured
+// approver cannot be reached through live discovery (#680).
 //
 // The reviewer's reply is matched back to this request by thread_id (the
 // same content-level correlation the daemon already uses for the
@@ -35,30 +33,31 @@ var discoverNodesForCommandApprovalDeliveryFn = discovery.DiscoverNodesWithColli
 // for the reviewer, reusing the existing fill-tracking UX; the reviewer's
 // reply must preserve the given thread_id in its own frontmatter for the
 // decision to be recorded automatically.
-func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, commandApproverNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) {
+func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, requesterSessionName string, policy resolvedCommandApprovalPolicy, commandApproverNode, threadID, commandHash, reason string, storeCommandText bool, now time.Time) error {
 	nodes, _, err := discoverNodesForCommandApprovalDeliveryFn(baseDir, contextID, requesterSessionName)
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: discovering nodes: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: discovering nodes: %w", err)
 	}
-	reviewerInfo, ok := nodes[commandApproverNode]
+	resolvedApproverNode := discovery.ResolveNodeName(commandApproverNode, requesterSessionName, nodes)
+	reviewerInfo, ok := nodes[resolvedApproverNode]
 	if !ok {
 		log.Printf("postman: WARNING: command approval delivery: command_approver_node %q not found among discovered nodes; falling back to inspect-command-approvals\n", commandApproverNode)
-		return
+		return fmt.Errorf("command approval delivery failed: command_approver_node %q not found among discovered nodes", commandApproverNode)
 	}
 	if err := config.CreateSessionDirs(reviewerInfo.SessionDir); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: creating reviewer session directories: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: creating reviewer session directories: %w", err)
 	}
 	inputRequestID, err := generateInputRequestID()
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: generating input request id: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: generating input request id: %w", err)
 	}
 	filename, err := message.GenerateFilename(now.Format("20060102-150405"), policy.Requester, commandApproverNode, reviewerInfo.SessionName)
 	if err != nil {
 		log.Printf("postman: WARNING: command approval delivery: generating filename: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: generating filename: %w", err)
 	}
 
 	var body strings.Builder
@@ -84,19 +83,21 @@ func deliverCommandApprovalRequest(cfg *config.Config, baseDir, contextID, reque
 	draftDir := filepath.Join(reviewerInfo.SessionDir, "draft")
 	if err := os.MkdirAll(draftDir, 0o700); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: creating draft directory: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: creating draft directory: %w", err)
 	}
 	draftPath := filepath.Join(draftDir, filename)
 	if err := os.WriteFile(draftPath, []byte(content), 0o600); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: writing draft: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: writing draft: %w", err)
 	}
 	postDir := filepath.Join(reviewerInfo.SessionDir, "post")
 	if err := os.MkdirAll(postDir, 0o700); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: creating post directory: %v\n", err)
-		return
+		return fmt.Errorf("command approval delivery failed: creating post directory: %w", err)
 	}
 	if err := os.Rename(draftPath, filepath.Join(postDir, filename)); err != nil {
 		log.Printf("postman: WARNING: command approval delivery: moving message into post: %v\n", err)
+		return fmt.Errorf("command approval delivery failed: moving message into post: %w", err)
 	}
+	return nil
 }

--- a/internal/cli/command_approval_delivery_test.go
+++ b/internal/cli/command_approval_delivery_test.go
@@ -20,7 +20,7 @@ import (
 // expected frontmatter and thread id instructions.
 func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testing.T) {
 	baseDir := t.TempDir()
-	reviewerSessionDir := filepath.Join(baseDir, "ctx-626", "reviewer-session")
+	reviewerSessionDir := filepath.Join(baseDir, "ctx-626", "worker-session")
 	if err := config.CreateSessionDirs(reviewerSessionDir); err != nil {
 		t.Fatalf("config.CreateSessionDirs(reviewer) failed: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testi
 	original := discoverNodesForCommandApprovalDeliveryFn
 	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
 		return map[string]discovery.NodeInfo{
-			"orchestrator": {PaneID: "%2", SessionName: "reviewer-session", SessionDir: reviewerSessionDir},
+			"worker-session:orchestrator": {PaneID: "%2", SessionName: "worker-session", SessionDir: reviewerSessionDir},
 		}, nil, nil
 	}
 	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
@@ -43,7 +43,9 @@ func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testi
 	now := time.Date(2026, time.July, 8, 1, 0, 0, 0, time.UTC)
 	threadID := "command-approval-aabbccdd11223344"
 
-	deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", threadID, "sha256:deadbeef", "verify release build", false, now)
+	if err := deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", threadID, "sha256:deadbeef", "verify release build", false, now); err != nil {
+		t.Fatalf("deliverCommandApprovalRequest() error = %v", err)
+	}
 
 	draftEntries, err := os.ReadDir(filepath.Join(reviewerSessionDir, "draft"))
 	if err != nil {
@@ -90,12 +92,59 @@ func TestDeliverCommandApprovalRequest_WritesMessageIntoReviewerPostDir(t *testi
 	}
 }
 
-// TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort guards the
-// no-op-not-crash behavior when the command_approver_node isn't currently
-// discoverable: delivery must log and return without writing anything or
-// panicking, since the approval request has already been journaled by the
-// caller regardless of delivery outcome.
-func TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort(t *testing.T) {
+// TestCommandApproverStatusAndDeliveryAgreeWithinRequesterSession verifies
+// #695's configuration/status and runtime-delivery agreement: the same bare
+// Mermaid-designated approver is healthy in status and resolves to the
+// requester's session-qualified discovery key for delivery.
+func TestCommandApproverStatusAndDeliveryAgreeWithinRequesterSession(t *testing.T) {
+	baseDir := t.TempDir()
+	reviewerSessionDir := filepath.Join(baseDir, "ctx-695", "worker-session")
+	if err := config.CreateSessionDirs(reviewerSessionDir); err != nil {
+		t.Fatalf("config.CreateSessionDirs(reviewer) failed: %v", err)
+	}
+
+	cfg := &config.Config{
+		CommandApproverNode: "orchestrator",
+		Nodes:               map[string]config.NodeConfig{"orchestrator": {}},
+	}
+	approver, valid := cfg.ResolveCommandApproverNode()
+	if approver != "orchestrator" || !valid {
+		t.Fatalf("ResolveCommandApproverNode() = (%q, %v), want (orchestrator, true)", approver, valid)
+	}
+	if status := buildCommandApprovalStatus(cfg); status != nil {
+		t.Fatalf("buildCommandApprovalStatus() = %#v, want nil for a resolvable configured approver", status)
+	}
+
+	original := discoverNodesForCommandApprovalDeliveryFn
+	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"worker-session:orchestrator": {
+				PaneID:      "%2",
+				SessionName: "worker-session",
+				SessionDir:  reviewerSessionDir,
+			},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
+
+	policy := resolvedCommandApprovalPolicy{Requester: "worker", Mode: "blocking", Label: "protected"}
+	if err := deliverCommandApprovalRequest(cfg, baseDir, "ctx-695", "worker-session", policy, approver, "command-approval-status-delivery", "sha256:deadbeef", "", false, time.Now()); err != nil {
+		t.Fatalf("deliverCommandApprovalRequest() error = %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(reviewerSessionDir, "post"))
+	if err != nil {
+		t.Fatalf("ReadDir(post) error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("post/ has %d entries, want 1", len(entries))
+	}
+}
+
+// TestDeliverCommandApprovalRequest_UnknownNodeReturnsError guards #680:
+// when the configured command_approver_node is not currently discoverable,
+// delivery must report that fact so blocking mode can fail closed after the
+// approval request is journaled.
+func TestDeliverCommandApprovalRequest_UnknownNodeReturnsError(t *testing.T) {
 	baseDir := t.TempDir()
 
 	original := discoverNodesForCommandApprovalDeliveryFn
@@ -105,10 +154,44 @@ func TestDeliverCommandApprovalRequest_UnknownNodeIsBestEffort(t *testing.T) {
 	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
 
 	policy := resolvedCommandApprovalPolicy{Requester: "worker", Mode: "blocking", Label: "protected"}
-	deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", "command-approval-x", "sha256:x", "", false, time.Now())
+	err := deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-626", "worker-session", policy, "orchestrator", "command-approval-x", "sha256:x", "", false, time.Now())
+	if err == nil {
+		t.Fatal("deliverCommandApprovalRequest() error = nil, want missing approver error")
+	}
+	if !strings.Contains(err.Error(), `command_approver_node "orchestrator" not found among discovered nodes`) {
+		t.Fatalf("deliverCommandApprovalRequest() error = %v", err)
+	}
 	// No panic and no filesystem assertion needed: absence of a reviewer
 	// session directory under baseDir is itself proof nothing was written.
 	if _, err := os.Stat(filepath.Join(baseDir, "ctx-626")); !os.IsNotExist(err) {
 		t.Fatalf("expected no session directories to be created, stat error = %v", err)
+	}
+}
+
+// TestDeliverCommandApprovalRequest_DoesNotRouteBareApproverAcrossSessions
+// verifies that a bare command_approver_node remains scoped to the requester
+// session. Cross-session delivery requires an explicitly qualified node name.
+func TestDeliverCommandApprovalRequest_DoesNotRouteBareApproverAcrossSessions(t *testing.T) {
+	baseDir := t.TempDir()
+
+	original := discoverNodesForCommandApprovalDeliveryFn
+	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return map[string]discovery.NodeInfo{
+			"other-session:orchestrator": {
+				PaneID:      "%2",
+				SessionName: "other-session",
+				SessionDir:  filepath.Join(baseDir, contextID, "other-session"),
+			},
+		}, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = original })
+
+	policy := resolvedCommandApprovalPolicy{Requester: "worker", Mode: "blocking", Label: "protected"}
+	err := deliverCommandApprovalRequest(&config.Config{}, baseDir, "ctx-680", "worker-session", policy, "orchestrator", "command-approval-x", "sha256:x", "", false, time.Now())
+	if err == nil {
+		t.Fatal("deliverCommandApprovalRequest() error = nil, want missing same-session approver error")
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "ctx-680")); !os.IsNotExist(err) {
+		t.Fatalf("expected no cross-session delivery, stat error = %v", err)
 	}
 }

--- a/internal/cli/execute_bash.go
+++ b/internal/cli/execute_bash.go
@@ -158,21 +158,23 @@ func runExecuteBashWithContext(ctx commandContext, args []string) error {
 	}
 	expiresAt := ctx.now().Add(policy.TTL).UTC().Format(time.RFC3339Nano)
 	commandApproverNode, validReviewer := cfg.ResolveCommandApproverNode()
+	approverConfigured := strings.TrimSpace(cfg.CommandApproverNode) != ""
 
-	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, validReviewer, ctx.now())
+	evaluation, err := evaluateCommandApproval(sessionDir, policy, resolvedThreadID, commandHash, approverConfigured, validReviewer, ctx.now())
 	if err != nil {
 		return err
 	}
-	if !evaluation.Allowed {
-		// Reached only when validReviewer is true: evaluateCommandApproval
-		// short-circuits to Allowed:true whenever no valid command_approver_node is
-		// configured, so commandApproverNode here is always the trusted,
-		// config-resolved node name (#626 B1) — never a requester-supplied
-		// value.
+	if !evaluation.Allowed && validReviewer {
+		// Only a config-resolved reviewer may receive a trusted approval request.
+		// A configured but unresolvable blocking reviewer remains locally blocked
+		// below, without recording or delivering a request that names the raw
+		// configuration value.
 		if err := recordCommandApprovalRequest(sessionDir, resolvedContextID, resolvedSessionName, resolvedThreadID, policy, commandApproverNode, commandHash, *reason, expiresAt, commandText, *storeCommandText, ctx.now()); err != nil {
 			return err
 		}
-		deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, commandApproverNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now())
+		if err := deliverCommandApprovalRequest(cfg, baseDir, resolvedContextID, resolvedSessionName, policy, commandApproverNode, resolvedThreadID, commandHash, *reason, *storeCommandText, ctx.now()); err != nil {
+			evaluation.Reason = err.Error()
+		}
 	}
 
 	decision := decisionForPolicy(policy.Mode, evaluation, *overrideApproval)
@@ -438,13 +440,15 @@ func validateCommandApprovalThreadID(threadID string) error {
 // mode. This must never be conflated with an actual recorded approval.
 const commandApprovalDecisionAutoApprovedNoReviewer = "auto_approved_no_reviewer"
 
-func evaluateCommandApproval(sessionDir string, policy resolvedCommandApprovalPolicy, threadID, commandHash string, validReviewer bool, now time.Time) (commandApprovalEvaluation, error) {
+func evaluateCommandApproval(sessionDir string, policy resolvedCommandApprovalPolicy, threadID, commandHash string, approverConfigured, validReviewer bool, now time.Time) (commandApprovalEvaluation, error) {
 	if !validReviewer {
-		// #626 decided requirement 1 (unified fail-open rule): unless a
-		// valid command_approver_node is configured, every command is treated as
-		// approved across all three modes, including blocking. This is
-		// evaluated before any projection lookup so a missing/unresolvable
-		// command_approver_node never depends on prior approval state.
+		if approverConfigured && policy.Mode == "blocking" {
+			return commandApprovalEvaluation{Decision: "unresolved_command_approver", Allowed: false, Reason: "configured command_approver_node is not resolvable; blocking approval fails closed"}, nil
+		}
+		// An unset approver, or a non-blocking policy with an unresolvable one,
+		// fails open. A configured unresolvable blocking approver returned above
+		// fails closed. This is evaluated before any projection lookup so an
+		// unresolved command_approver_node never depends on prior approval state.
 		return commandApprovalEvaluation{
 			Decision: commandApprovalDecisionAutoApprovedNoReviewer,
 			Allowed:  true,

--- a/internal/cli/execute_bash_test.go
+++ b/internal/cli/execute_bash_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 )
@@ -26,6 +27,7 @@ type executeBashFixture struct {
 	policies            []config.CommandApprovalPolicy
 	commandApproverNode string
 	nodes               map[string]config.NodeConfig
+	discoveredNodes     map[string]discovery.NodeInfo
 	stdout              bytes.Buffer
 	stderr              bytes.Buffer
 	runCount            int
@@ -40,7 +42,7 @@ func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolic
 	baseDir := t.TempDir()
 	contextID := "ctx-484"
 	sessionName := "test-session"
-	return &executeBashFixture{
+	fixture := &executeBashFixture{
 		baseDir:     baseDir,
 		contextID:   contextID,
 		sessionName: sessionName,
@@ -56,7 +58,19 @@ func newExecuteBashFixture(t *testing.T, policies ...config.CommandApprovalPolic
 		// itself override commandApproverNode/nodes before calling context().
 		commandApproverNode: "orchestrator",
 		nodes:               map[string]config.NodeConfig{"orchestrator": {}},
+		discoveredNodes: map[string]discovery.NodeInfo{
+			"test-session:orchestrator": {
+				SessionName: "test-session",
+				SessionDir:  filepath.Join(baseDir, contextID, "test-session"),
+			},
+		},
 	}
+	originalDiscover := discoverNodesForCommandApprovalDeliveryFn
+	discoverNodesForCommandApprovalDeliveryFn = func(baseDir, contextID, selfSession string) (map[string]discovery.NodeInfo, []discovery.CollisionReport, error) {
+		return fixture.discoveredNodes, nil, nil
+	}
+	t.Cleanup(func() { discoverNodesForCommandApprovalDeliveryFn = originalDiscover })
+	return fixture
 }
 
 func (f *executeBashFixture) context() commandContext {
@@ -594,11 +608,10 @@ func TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnconfigured(t *t
 	}
 }
 
-// TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnresolvable guards the
-// second case of #626's decided requirement 1: command_approver_node configured but
-// naming a node that doesn't exist must fail open exactly like an
-// unconfigured command_approver_node, not fail closed.
-func TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnresolvable(t *testing.T) {
+// TestRunExecuteBashBlockingFailsClosedWhenCommandApproverNodeUnresolvable
+// prevents a configured-but-unresolvable reviewer from silently executing a
+// blocking command (#680).
+func TestRunExecuteBashBlockingFailsClosedWhenCommandApproverNodeUnresolvable(t *testing.T) {
 	policyConfig := config.CommandApprovalPolicy{
 		Requester: "worker",
 		Reviewer:  "orchestrator",
@@ -609,21 +622,76 @@ func TestRunExecuteBashBlockingFailsOpenWhenCommandApproverNodeUnresolvable(t *t
 	fixture := newExecuteBashFixture(t, policyConfig)
 	fixture.commandApproverNode = "typo-reviewer"
 	fixture.nodes = map[string]config.NodeConfig{"orchestrator": {}}
+	// A colliding live pane can use the same bare name in the requester session.
+	// Static configuration must still prevent it receiving an approval request.
+	fixture.discoveredNodes = map[string]discovery.NodeInfo{
+		"test-session:typo-reviewer": {
+			PaneID:      "%9",
+			SessionName: "test-session",
+			SessionDir:  fixture.sessionDir,
+		},
+	}
 
 	err := runExecuteBashWithContext(fixture.context(), fixture.args(
 		"--label", "protected",
 		"--category", "release",
 		"--command", "printf unresolvable",
 	))
-	if err != nil {
-		t.Fatalf("runExecuteBashWithContext() error = %v, want nil (fail open)", err)
+	if err == nil {
+		t.Fatal("runExecuteBashWithContext() error = nil, want unresolved approver block")
 	}
-	if fixture.runCount != 1 {
-		t.Fatalf("runCount = %d, want 1", fixture.runCount)
+	if fixture.runCount != 0 {
+		t.Fatalf("runCount = %d, want 0", fixture.runCount)
 	}
 	decision := findExecutionDecisionPayload(t, fixture.sessionDir)
-	if decision.Decision != commandApprovalDecisionAutoApprovedNoReviewer {
-		t.Fatalf("decision = %q, want %q", decision.Decision, commandApprovalDecisionAutoApprovedNoReviewer)
+	if decision.Decision != "blocked" {
+		t.Fatalf("decision = %q, want blocked", decision.Decision)
+	}
+	if !strings.Contains(decision.Reason, "not resolvable") {
+		t.Fatalf("decision reason = %q, want unresolved approver diagnostic", decision.Reason)
+	}
+	for _, event := range replayCommandEvents(t, fixture.sessionDir) {
+		if event.Type == journal.CommandApprovalRequestedEventType {
+			t.Fatalf("unexpected trusted pending approval event: %#v", event)
+		}
+	}
+	postEntries, err := os.ReadDir(filepath.Join(fixture.sessionDir, "post"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadDir(post) error = %v", err)
+	}
+	if len(postEntries) != 0 {
+		t.Fatalf("post/ has %d entries, want no invalid-approver delivery", len(postEntries))
+	}
+}
+
+func TestRunExecuteBashBlockingFailsClosedWhenCommandApproverNodeNotDiscovered(t *testing.T) {
+	policyConfig := config.CommandApprovalPolicy{
+		Requester: "worker",
+		Reviewer:  "orchestrator",
+		Label:     "protected",
+		Category:  "release",
+		Mode:      "blocking",
+	}
+	fixture := newExecuteBashFixture(t, policyConfig)
+	fixture.discoveredNodes = map[string]discovery.NodeInfo{}
+
+	err := runExecuteBashWithContext(fixture.context(), fixture.args(
+		"--label", "protected",
+		"--category", "release",
+		"--command", "printf missing-discovery",
+	))
+	if err == nil {
+		t.Fatal("runExecuteBashWithContext() error = nil, want delivery failure block")
+	}
+	if !strings.Contains(err.Error(), `command_approver_node "orchestrator" not found among discovered nodes`) {
+		t.Fatalf("error = %v, want missing discovered approver reason", err)
+	}
+	if fixture.runCount != 0 {
+		t.Fatalf("runCount = %d, want 0", fixture.runCount)
+	}
+	decision := findExecutionDecisionPayload(t, fixture.sessionDir)
+	if decision.Decision != "blocked" {
+		t.Fatalf("decision = %q, want blocked", decision.Decision)
 	}
 }
 

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -246,9 +246,9 @@ func buildWorkspaceTreeStatus(cfg *config.Config, sessionName string) *status.Wo
 }
 
 // buildCommandApprovalStatus surfaces any configured-but-unresolvable
-// command_approver_node so get-status makes the fail-open condition visible
-// (#626/#629), mirroring config.ValidateConfig's warning rule without depending
-// on its message wording.
+// command_approver_node so get-status makes the blocking fail-closed condition
+// visible, mirroring config.ValidateConfig's warning rule without depending on
+// its message wording.
 func buildCommandApprovalStatus(cfg *config.Config) *status.CommandApprovalStatus {
 	if cfg == nil {
 		return nil
@@ -258,7 +258,7 @@ func buildCommandApprovalStatus(cfg *config.Config) *status.CommandApprovalStatu
 		unresolved = append(unresolved, status.CommandApprovalUnresolvedApprover{
 			Field:   "command_approver_node",
 			Value:   name,
-			Message: fmt.Sprintf("command_approver_node %q does not match any configured node; command approval is failing open", name),
+			Message: fmt.Sprintf("command_approver_node %q does not match any configured node; blocking command approval is failing closed", name),
 		})
 	}
 	deprecated := make([]status.CommandApprovalDeprecatedApprover, 0, len(cfg.DeprecatedCommandApproverNodes))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	EvidencePresenceGateAfter      string                          `toml:"evidence_presence_gate_after"`
 	WorkspaceTree                  []WorkspaceTreeNodeConfig       `toml:"workspace_tree"` // Optional explicit hierarchy for tree aliases
 	CommandApproval                []CommandApprovalPolicy         `toml:"command_approval"`
-	CommandApproverNode            string                          `toml:"-"` // Mermaid-sourced reviewer node for command approval; unset/unresolvable = fail-open
+	CommandApproverNode            string                          `toml:"-"` // Mermaid-sourced reviewer node; unset = fail-open, configured unresolved blocking approval = fail-closed
 	DeprecatedCommandApproverNodes []DeprecatedCommandApproverNode `toml:"-"` // Ignored legacy TOML approver keys surfaced in get-status
 	Herdr                          HerdrConfig                     `toml:"herdr"`
 
@@ -199,9 +199,9 @@ type WorkspaceTreeNodeConfig struct {
 // ResolveCommandApproverNode resolves the globally designated command_approver_node
 // (#626/#629). valid reports whether the resolved name matches a node known to
 // this config (the same set edges/workspace_tree validate against). An empty or
-// unresolvable name is never valid — callers MUST fail open in that case rather
-// than treat an invalid name as if it were configured, per the decided unified
-// fail-open rule.
+// unresolvable name is never valid. Callers must distinguish an absent approver
+// from a configured-but-unresolvable one: blocking approval fails closed for the
+// latter, while an absent approver retains the documented fail-open behavior.
 func (cfg *Config) ResolveCommandApproverNode() (name string, valid bool) {
 	if cfg == nil {
 		return "", false

--- a/internal/config/postman.default.toml
+++ b/internal/config/postman.default.toml
@@ -143,9 +143,10 @@ auto_enable_new_sessions = true    # Required default: auto-claim configured nod
 # Configure the execute-bash command approver in postman.md by marking exactly
 # one node in the Mermaid edges graph with:
 #   class orchestrator command_approver_node
-# Unset, or set to a node that doesn't resolve, means every command approval
-# mode fails open (runs, audited as auto_approved_no_reviewer) — including
-# blocking. The approver is global; per-policy approver routing is unsupported.
+# Unset means every command approval mode fails open (runs, audited as
+# auto_approved_no_reviewer). A configured node that does not resolve makes
+# blocking approval fail closed. The approver is global; per-policy routing is
+# unsupported.
 
 # Command approval policies for execute-bash (Issue #484/#625/#626/#629). Optional; no policies means every
 # execute-bash invocation uses the advisory default.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -154,15 +154,14 @@ func ValidateConfig(cfg *Config) []ValidationError {
 	}
 
 	// Rule 5: command_approver_node resolvability check (severity: warning, #626).
-	// An unresolvable command_approver_node is never a load error — the unified
-	// fail-open rule means command approval simply stays permissive in that
-	// case — but it MUST be loud (a typo here silently disables blocking
-	// mode otherwise) and auditable, per the decided requirements.
+	// An unresolvable command_approver_node is never a load error, but it MUST
+	// be loud and auditable: a configured unresolved approver makes blocking
+	// command approval fail closed at execution time.
 	if name := strings.TrimSpace(cfg.CommandApproverNode); name != "" {
 		if _, exists := cfg.Nodes[name]; !exists {
 			errors = append(errors, ValidationError{
 				Field:    "command_approver_node",
-				Message:  fmt.Sprintf("command_approver_node %q does not match any configured node; command approval will fail open until this is fixed", name),
+				Message:  fmt.Sprintf("command_approver_node %q does not match any configured node; blocking command approval will fail closed until this is fixed", name),
 				Severity: "warning",
 			})
 		}

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -210,8 +210,8 @@ type WorkspaceTreeStatus struct {
 }
 
 // CommandApprovalUnresolvedApprover surfaces a configured-but-unresolvable
-// command_approver_node so a typo that silently disables blocking mode (#626's fail
-// open rule) is loud and auditable rather than a silent no-op.
+// command_approver_node so a typo that causes blocking approval to fail closed
+// is loud and auditable rather than a silent configuration defect.
 type CommandApprovalUnresolvedApprover struct {
 	Field   string `json:"field"`
 	Value   string `json:"value"`


### PR DESCRIPTION
Fixes #695
Fixes #680

## Summary

Resolve a configured bare `command_approver_node` against the requester session before looking it up in the discovered-node map. Discovery keys are session-qualified, so this restores same-session command-approval delivery without allowing a bare name to cross sessions.

## Changes

- resolve the configured approver through requester-session discovery before delivery
- preserve fail-closed behavior for delivery errors
- avoid issuing an approval request when the configured blocking approver is not a valid discovered node
- add deterministic coverage for same-session resolution, cross-session rejection, unresolved approvers, and undiscovered approvers

## Verification

- `go test ./...`
- `nix flake check`
- `nix build`
- `git diff --check`

No daemon restart, configuration change, or live end-to-end approval trial was performed.