### PR TITLE
fix(status): classify pane-local freshness (#639)

### DIFF
--- a/docs/design/node-state-machine.md
+++ b/docs/design/node-state-machine.md
@@ -337,11 +337,11 @@ prints `compact_severity` instead. A `?` suffix marks inferred evidence, such as
 Default compact marks are therefore a projection of the separated layers, not a
 raw alias for `visible_state`:
 
-| Mark | Meaning                                                       |
-| ---- | ------------------------------------------------------------- |
-| `⚫`  | Initial, unavailable, unowned, or missing local state         |
-| `🟢`  | Ready with no worse contextual node severity                  |
-| `🔵`  | Ready but pane-local evidence indicates active work           |
-| `🟡`  | Waiting or expected wait                                      |
-| `🔷`  | Pending or needs action                                       |
-| `🔴`  | Stale, blocked, delivery failure, or other attention severity |
+| Mark | Meaning                                                                  |
+| ---- | ------------------------------------------------------------------------ |
+| `⚫`  | Initial, unavailable, unowned, missing, or malformed local evidence      |
+| `🟢`  | Ready with positive pane-local evidence and no worse contextual severity |
+| `🔵`  | Ready but pane-local evidence indicates active work                      |
+| `🟡`  | Waiting or expected wait                                                 |
+| `🔷`  | Pending or needs action                                                  |
+| `🔴`  | Stale, blocked, delivery failure, or other attention severity            |

--- a/docs/design/node-state-machine.md
+++ b/docs/design/node-state-machine.md
@@ -58,6 +58,9 @@ input-request identity belongs to daemon status and reply projection.
 | `nodes[*].pane_state`                     | empty, `active`, `idle`, `stale`                                 | Pane availability and activity fact                       |
 | `nodes[*].visible_state`                  | `initial`, `ready`, `waiting`, `pending`, `stale`                | Operator-facing node state                                |
 | `nodes[*].screen_progress.evidence_state` | `missing`, `stale`, `changed`, `unchanged`                       | Non-content pane progress evidence                        |
+| `nodes[*].node_local.state`               | `unknown`, `live`, `working`, `stale`, `conflict`                | Pane-local lifecycle before message-flow overlay          |
+| `nodes[*].node_local.freshness`           | `unknown`, `fresh`, `aging`, `stale`, `conflict`                 | Age class for pane-local progress evidence                |
+| `nodes[*].flow.state`                     | `idle`, `expected_wait`, `needs_action`, `blocked`, `conflict`   | Input-request and blocked-report lifecycle                |
 | session `visible_state`                   | `initial`, `ready`, `waiting`, `pending`, `stale`, `unavailable` | Worst node state, or unavailable canonical session status |
 | `severity`                                | See contextual severity table                                    | Additive triage severity for operators                    |
 | `compact_severity`                        | ASCII token                                                      | One-line severity summary for opt-in compact scans        |
@@ -73,7 +76,38 @@ enough to mark a node or session `ready`.
 
 `screen_progress` carries timestamps and an opaque fingerprint from pane
 capture state so operators can tell whether the pane is still changing without
-reading raw pane text. It does not affect visible-state ranking.
+reading raw pane text. `screen_progress.stale_duration_seconds` is the elapsed
+capture time since `last_screen_change_at` when both timestamps are known and
+the latest capture is after the latest change. The value feeds
+`node_local.freshness`; it does not directly affect legacy visible-state
+ranking.
+
+Pane-local freshness classes are intentionally coarse:
+
+| Freshness  | Meaning                                                                  |
+| ---------- | ------------------------------------------------------------------------ |
+| `unknown`  | Progress evidence is missing or cannot be timestamped                    |
+| `fresh`    | The last capture changed, or unchanged evidence is within 30 seconds     |
+| `aging`    | Unchanged evidence is older than 30 seconds but younger than 180 seconds |
+| `stale`    | Pane state is stale, progress is stale, or unchanged for at least 180s   |
+| `conflict` | Reserved for contradictory pane evidence                                 |
+
+`node_local.state` is derived before workflow facts:
+
+| State      | Required evidence                                                                  |
+| ---------- | ---------------------------------------------------------------------------------- |
+| `unknown`  | Missing pane activity evidence                                                     |
+| `live`     | Live pane with no current activity evidence                                        |
+| `working`  | Changed screen evidence, or active pane with missing progress evidence             |
+| `stale`    | Stale pane evidence, stale progress evidence, or stale unchanged progress evidence |
+| `conflict` | Reserved for contradictory pane evidence                                           |
+
+An `active` pane does not remain `working` solely because it is inside
+`node_active_seconds` when explicit `screen_progress.evidence_state:
+unchanged` exists. In that case the node stays pane-local `live` while
+freshness reports whether the unchanged screen is `fresh`, `aging`, or `stale`.
+This preserves backward-compatible `visible_state: ready` while preventing a
+stale or aging screen from being reported as definitive active work.
 
 `unavailable` is a session-level fallback, not a per-node state. It means this
 daemon cannot provide canonical status for that tmux session. It is displayed
@@ -235,7 +269,7 @@ recipient. A node that is waiting for an approval or other required reply is
 `expected_wait`, not blocked. It becomes `blocked` only when an open blocked
 report exists.
 
-`get-status` exposes the evidence as:
+`get-status` exposes the evidence as separated layers:
 
 | Field                 | Meaning                                         |
 | --------------------- | ----------------------------------------------- |
@@ -247,6 +281,23 @@ report exists.
 | `nodes[*].node_local` | Pane-local activity/staleness status            |
 | `nodes[*].flow`       | Input-request and blocked-report workflow state |
 | `nodes[*].queues`     | Node-local queue counts                         |
+
+Layer precedence is fixed for severity projection:
+
+| Rank | Layer      | Examples                                               |
+| ---- | ---------- | ------------------------------------------------------ |
+| 1    | Delivery   | Dead letters and stuck `post/` files                   |
+| 2    | Flow       | Blocked reports, inbound action, outbound wait         |
+| 3    | Node-local | Pane work, stale pane, stale screen progress           |
+| 4    | Visibility | Legacy `visible_state` and compact compatibility marks |
+
+The highest ranked severity wins. `flow.state` never rewrites
+`node_local.state`: a node can be `node_local.state: stale` and
+`flow.state: needs_action` at the same time, with severity selecting the worse
+operator triage signal. Filling an input request closes transport only; it does
+not claim task acceptance. Review approval and task acceptance projections are
+separate higher-level facts and must not be inferred from a reply-required
+message being filled.
 
 Open input-request details include `opened_event_id` and `read_event_id` when
 the corresponding journal events are known. These IDs are traceability
@@ -262,17 +313,19 @@ prints `compact_severity` instead. A `?` suffix marks inferred evidence, such as
 
 ## 9. Severity Examples
 
-| Scenario            | Primary evidence                           | Severity           |
-| ------------------- | ------------------------------------------ | ------------------ |
-| Idle                | Positive live pane, no open action or wait | `ok`               |
-| Active work         | Active pane or changed screen evidence     | `working`          |
-| Approval wait       | Outbound required reply still open         | `expected_wait`    |
-| Reply-required wait | Outbound required reply still open         | `expected_wait`    |
-| Required action     | Inbound required reply open                | `needs_action`     |
-| Blocked             | Structured blocked report or `BLOCKED:`    | `blocked`          |
-| Stale pane          | Stale pane evidence                        | `attention_stale`  |
-| Delivery stuck      | Oldest pending post is at least 180s old   | `delivery_stuck`   |
-| Dead letter         | One or more dead-letter files exist        | `delivery_failure` |
+| Scenario              | Primary evidence                                                                | Severity           |
+| --------------------- | ------------------------------------------------------------------------------- | ------------------ |
+| Idle                  | Positive live pane, no open action or wait                                      | `ok`               |
+| Active work           | Changed screen evidence, or active pane with missing progress evidence          | `working`          |
+| Aging unchanged pane  | Active pane with unchanged screen evidence older than 30s but younger than 180s | `ok`               |
+| Stale screen progress | Active pane with unchanged screen evidence at least 180s old                    | `attention_stale`  |
+| Approval wait         | Outbound required reply still open                                              | `expected_wait`    |
+| Reply-required wait   | Outbound required reply still open                                              | `expected_wait`    |
+| Required action       | Inbound required reply open                                                     | `needs_action`     |
+| Blocked               | Structured blocked report or `BLOCKED:`                                         | `blocked`          |
+| Stale pane            | Stale pane evidence                                                             | `attention_stale`  |
+| Delivery stuck        | Oldest pending post is at least 180s old                                        | `delivery_stuck`   |
+| Dead letter           | One or more dead-letter files exist                                             | `delivery_failure` |
 
 Default compact marks are therefore a projection of the separated layers, not a
 raw alias for `visible_state`:

--- a/docs/design/node-state-machine.md
+++ b/docs/design/node-state-machine.md
@@ -60,7 +60,7 @@ input-request identity belongs to daemon status and reply projection.
 | `nodes[*].screen_progress.evidence_state` | `missing`, `stale`, `changed`, `unchanged`                       | Non-content pane progress evidence                        |
 | `nodes[*].node_local.state`               | `unknown`, `live`, `working`, `stale`, `conflict`                | Pane-local lifecycle before message-flow overlay          |
 | `nodes[*].node_local.freshness`           | `unknown`, `fresh`, `aging`, `stale`, `conflict`                 | Age class for pane-local progress evidence                |
-| `nodes[*].flow.state`                     | `idle`, `expected_wait`, `needs_action`, `blocked`, `conflict`   | Input-request and blocked-report lifecycle                |
+| `nodes[*].flow.state`                     | `idle`, `expected_wait`, `needs_action`, `blocked`               | Input-request and blocked-report lifecycle                |
 | session `visible_state`                   | `initial`, `ready`, `waiting`, `pending`, `stale`, `unavailable` | Worst node state, or unavailable canonical session status |
 | `severity`                                | See contextual severity table                                    | Additive triage severity for operators                    |
 | `compact_severity`                        | ASCII token                                                      | One-line severity summary for opt-in compact scans        |
@@ -74,40 +74,45 @@ configured or expected AI panes before any positive response, activity, or other
 live evidence arrives. A configured edge, role name, or AI command alone is not
 enough to mark a node or session `ready`.
 
-`screen_progress` carries timestamps and an opaque fingerprint from pane
-capture state so operators can tell whether the pane is still changing without
-reading raw pane text. `screen_progress.stale_duration_seconds` is the elapsed
-capture time since `last_screen_change_at` when both timestamps are known and
-the latest capture is after the latest change. The value feeds
-`node_local.freshness`; it does not directly affect legacy visible-state
+`screen_progress` carries timestamps, a reason for missing or malformed
+evidence, and an opaque fingerprint from pane capture state so operators can
+tell whether the pane is still changing without reading raw pane text.
+`screen_progress.stale_duration_seconds` is the elapsed capture time since
+`last_screen_change_at` when both timestamps are known and the latest capture is
+after the latest change. `node_local.age_seconds` is separate: it is the
+observation age of `last_capture_at` relative to the status collection time.
+`node_local.unchanged_seconds` preserves the unchanged duration. These values
+feed `node_local.freshness`; they do not directly affect legacy visible-state
 ranking.
 
 Pane-local freshness classes are intentionally coarse:
 
-| Freshness  | Meaning                                                                  |
-| ---------- | ------------------------------------------------------------------------ |
-| `unknown`  | Progress evidence is missing or cannot be timestamped                    |
-| `fresh`    | The last capture changed, or unchanged evidence is within 30 seconds     |
-| `aging`    | Unchanged evidence is older than 30 seconds but younger than 180 seconds |
-| `stale`    | Pane state is stale, progress is stale, or unchanged for at least 180s   |
-| `conflict` | Reserved for contradictory pane evidence                                 |
+| Freshness  | Meaning                                                               |
+| ---------- | --------------------------------------------------------------------- |
+| `unknown`  | Progress evidence is missing or cannot be timestamped                 |
+| `fresh`    | The capture is within 30 seconds and shows a coherent latest change   |
+| `aging`    | Capture or unchanged evidence is older than 30s but younger than 180s |
+| `stale`    | Pane state is stale, capture is stale, or unchanged for at least 180s |
+| `conflict` | Reserved for contradictory pane evidence                              |
 
 `node_local.state` is derived before workflow facts:
 
 | State      | Required evidence                                                                  |
 | ---------- | ---------------------------------------------------------------------------------- |
-| `unknown`  | Missing pane activity evidence                                                     |
+| `unknown`  | Missing pane activity evidence, missing progress, or malformed progress            |
 | `live`     | Live pane with no current activity evidence                                        |
-| `working`  | Changed screen evidence, or active pane with missing progress evidence             |
+| `working`  | Fresh, coherent changed screen evidence                                            |
 | `stale`    | Stale pane evidence, stale progress evidence, or stale unchanged progress evidence |
-| `conflict` | Reserved for contradictory pane evidence                                           |
+| `conflict` | Future timestamps, impossible capture/change ordering, or contradictory signals    |
 
-An `active` pane does not remain `working` solely because it is inside
-`node_active_seconds` when explicit `screen_progress.evidence_state:
-unchanged` exists. In that case the node stays pane-local `live` while
-freshness reports whether the unchanged screen is `fresh`, `aging`, or `stale`.
-This preserves backward-compatible `visible_state: ready` while preventing a
-stale or aging screen from being reported as definitive active work.
+An `active` pane does not remain `working` solely because the tmux pane is
+active or because it is inside `node_active_seconds`. If progress evidence is
+missing or malformed, pane-local state is `unknown`. If explicit
+`screen_progress.evidence_state: unchanged` exists, the node stays pane-local
+`live` while freshness reports whether the unchanged screen is `fresh`,
+`aging`, or `stale`. This preserves backward-compatible `visible_state: ready`
+while preventing stale, lagged, missing, or incoherent screen evidence from
+being reported as definitive active work.
 
 `unavailable` is a session-level fallback, not a per-node state. It means this
 daemon cannot provide canonical status for that tmux session. It is displayed
@@ -316,9 +321,11 @@ prints `compact_severity` instead. A `?` suffix marks inferred evidence, such as
 | Scenario              | Primary evidence                                                                | Severity           |
 | --------------------- | ------------------------------------------------------------------------------- | ------------------ |
 | Idle                  | Positive live pane, no open action or wait                                      | `ok`               |
-| Active work           | Changed screen evidence, or active pane with missing progress evidence          | `working`          |
+| Active work           | Fresh, coherent changed screen evidence                                         | `working`          |
+| Aging capture         | Changed screen evidence from a capture older than 30s but younger than 180s     | `ok`               |
 | Aging unchanged pane  | Active pane with unchanged screen evidence older than 30s but younger than 180s | `ok`               |
-| Stale screen progress | Active pane with unchanged screen evidence at least 180s old                    | `attention_stale`  |
+| Stale screen progress | Capture or unchanged screen evidence at least 180s old                          | `attention_stale`  |
+| Conflicting progress  | Future timestamp, impossible ordering, or contradictory pane evidence           | `attention_stale`  |
 | Approval wait         | Outbound required reply still open                                              | `expected_wait`    |
 | Reply-required wait   | Outbound required reply still open                                              | `expected_wait`    |
 | Required action       | Inbound required reply open                                                     | `needs_action`     |

--- a/docs/design/notification.md
+++ b/docs/design/notification.md
@@ -44,13 +44,13 @@ input-request identifiers parsed from the message metadata.
 get-status, get-status-oneline, and the default TUI are three views over the
 same canonical contract.
 
-| State     | Meaning                                       | Compact mark     |
-| --------- | --------------------------------------------- | ---------------- |
-| `initial` | No positive live evidence has arrived yet     | `⚫` black circle |
-| `ready`   | Pane is live with no open action or wait      | `🟢` green mark   |
-| `waiting` | Node is waiting for a reply-required response | `🟡` yellow mark  |
-| `pending` | Node has inbound reply-required action        | `🔷` blue diamond |
-| `stale`   | Previously known pane/session is stale        | `🔴` red mark     |
+| State     | Meaning                                                    | Compact mark     |
+| --------- | ---------------------------------------------------------- | ---------------- |
+| `initial` | No positive live evidence has arrived yet                  | `⚫` black circle |
+| `ready`   | Pane has positive live evidence and no open action or wait | `🟢` green mark   |
+| `waiting` | Node is waiting for a reply-required response              | `🟡` yellow mark  |
+| `pending` | Node has inbound reply-required action                     | `🔷` blue diamond |
+| `stale`   | Previously known pane/session is stale                     | `🔴` red mark     |
 
 A live pane that simply has not changed for a long time is internally `idle`
 and remains `ready` in the visible status model.
@@ -58,7 +58,8 @@ and remains `ready` in the visible status model.
 `initial` is neutral. Non-AI panes, unreachable or unclassified sessions, and
 configured or expected AI panes with no positive response or activity remain
 `initial` until evidence moves them to `ready`, `waiting`, `pending`, or
-`stale`.
+`stale`. Missing or malformed pane-local progress evidence remains neutral and
+does not render as ready green.
 
 Session fallback may report `unavailable` when this daemon cannot provide
 canonical status for a tmux session. It is displayed with the neutral `⚫`
@@ -95,11 +96,11 @@ See [Schema and Event Terminology](schema-event-terminology.md).
 
 `get-status-oneline` keeps compact operator marks by default. Pending, waiting,
 stale, and initial visible states keep their legacy marks; ready nodes also
-consult contextual node severity so active local work renders as `🔵` and
-blocked or stale attention renders as `🔴` instead of plain green. Use the
-`--severity` flag when the operator needs an ASCII severity token. Tokens with
-`?` are inferred, for example a `BLOCKED:` first line without structured
-blocked-report metadata.
+consult contextual node severity and pane-local evidence, so active local work
+renders as `🔵`, unknown evidence remains neutral `⚫`, and blocked or stale
+attention renders as `🔴` instead of plain green. Use the `--severity` flag when
+the operator needs an ASCII severity token. Tokens with `?` are inferred, for
+example a `BLOCKED:` first line without structured blocked-report metadata.
 
 ## 4. Configuration
 

--- a/internal/cli/helptext/get-status-oneline.txt
+++ b/internal/cli/helptext/get-status-oneline.txt
@@ -20,7 +20,8 @@ Marks:
   🔴 stale     previously known pane/session is stale
   🔷 pending   action-required inbound message is open
   🟡 waiting   outbound reply-required message is open
-  🟢 ready     pane is live with no open action or wait
+  🟢 ready     pane has positive live evidence with no open action or wait
 
 Screen progress fingerprints stay out of this compact view; use get-status
-for nodes[*].screen_progress JSON evidence.
+for nodes[*].screen_progress JSON evidence. Missing or malformed pane-local
+evidence remains neutral instead of green.

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -61,7 +61,7 @@ func compactNodeStatusMark(node status.NodeStatus) string {
 		return compactStatusMark(node.VisibleState)
 	}
 
-	if node.NodeLocal != nil && node.NodeLocal.State == "unknown" {
+	if node.NodeLocal != nil && node.NodeLocal.State == "unknown" && status.SeverityRank(node.Severity) == status.SeverityRank("ok") {
 		return "⚫"
 	}
 

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -61,6 +61,10 @@ func compactNodeStatusMark(node status.NodeStatus) string {
 		return compactStatusMark(node.VisibleState)
 	}
 
+	if node.NodeLocal != nil && node.NodeLocal.State == "unknown" {
+		return "⚫"
+	}
+
 	switch node.Severity {
 	case "working":
 		return "🔵"
@@ -207,8 +211,8 @@ func buildSessionStatusSnapshot(inputs sessionStatusInputs) status.SessionStatus
 	result.Windows = buildSessionWindows(result.LayoutGroups)
 	result.WorkspaceTree = buildWorkspaceTreeStatus(inputs.cfg, inputs.sessionName)
 	result.CommandApproval = buildCommandApprovalStatus(inputs.cfg)
-	result.Compact = buildSessionCompact(result, inputs.panes)
 	applySessionStatusEnrichment(&result, inputs.delivery, inputs.blockedByNode, inputs.now)
+	result.Compact = buildSessionCompact(result, inputs.panes)
 	return result
 }
 
@@ -695,7 +699,7 @@ func buildSessionCompact(health status.SessionStatus, panes []sessionPane) strin
 	for _, windowIndex := range windowOrder {
 		var marks strings.Builder
 		for _, node := range windowNodes[windowIndex] {
-			if isShellCommand(node.CurrentCommand) {
+			if shouldSkipCompactNode(node) {
 				continue
 			}
 			marks.WriteString(compactNodeStatusMark(node))
@@ -711,6 +715,16 @@ func buildSessionCompact(health status.SessionStatus, panes []sessionPane) strin
 	}
 
 	return strings.Join(windowMarks, ":")
+}
+
+func shouldSkipCompactNode(node status.NodeStatus) bool {
+	if !isShellCommand(node.CurrentCommand) {
+		return false
+	}
+	if node.Severity != "ok" {
+		return false
+	}
+	return node.NodeLocal == nil || node.NodeLocal.State != "unknown"
 }
 
 func buildSessionLayoutGroups(nodes []status.NodeStatus, panes []sessionPane) []status.LayoutGroup {

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -528,6 +528,9 @@ func screenProgressEvidence(paneState, lastChangeAt, lastCaptureAt, screenFinger
 	if hasLastCapture {
 		progress.LastCaptureAt = lastCaptureText
 	}
+	if hasLastChange && hasLastCapture && lastCaptureTime.After(lastChangeTime) {
+		progress.StaleDurationSeconds = int(lastCaptureTime.Sub(lastChangeTime).Seconds())
+	}
 	if fingerprint := normalizeScreenFingerprint(screenFingerprint); fingerprint != "" {
 		progress.ScreenFingerprint = fingerprint
 	}

--- a/internal/cli/session_status_contract.go
+++ b/internal/cli/session_status_contract.go
@@ -208,7 +208,7 @@ func buildSessionStatusSnapshot(inputs sessionStatusInputs) status.SessionStatus
 	result.WorkspaceTree = buildWorkspaceTreeStatus(inputs.cfg, inputs.sessionName)
 	result.CommandApproval = buildCommandApprovalStatus(inputs.cfg)
 	result.Compact = buildSessionCompact(result, inputs.panes)
-	applySessionStatusEnrichment(&result, inputs.delivery, inputs.blockedByNode)
+	applySessionStatusEnrichment(&result, inputs.delivery, inputs.blockedByNode, inputs.now)
 	return result
 }
 
@@ -520,8 +520,8 @@ func missingScreenProgressEvidence() *status.ScreenProgressEvidence {
 func screenProgressEvidence(paneState, lastChangeAt, lastCaptureAt, screenFingerprint string) *status.ScreenProgressEvidence {
 	progress := missingScreenProgressEvidence()
 
-	lastChangeText, lastChangeTime, hasLastChange := normalizeProgressTimestamp(lastChangeAt)
-	lastCaptureText, lastCaptureTime, hasLastCapture := normalizeProgressTimestamp(lastCaptureAt)
+	lastChangeText, lastChangeTime, hasLastChange, invalidLastChange := normalizeProgressTimestamp(lastChangeAt)
+	lastCaptureText, lastCaptureTime, hasLastCapture, invalidLastCapture := normalizeProgressTimestamp(lastCaptureAt)
 	if hasLastChange {
 		progress.LastScreenChangeAt = lastChangeText
 	}
@@ -538,29 +538,39 @@ func screenProgressEvidence(paneState, lastChangeAt, lastCaptureAt, screenFinger
 	switch {
 	case paneState == "stale":
 		progress.EvidenceState = "stale"
+	case invalidLastChange || invalidLastCapture:
+		progress.EvidenceState = "missing"
+		progress.Reason = "screen progress timestamp is malformed"
 	case !hasLastCapture || progress.ScreenFingerprint == "":
 		progress.EvidenceState = "missing"
+		if !hasLastCapture {
+			progress.Reason = "screen progress capture timestamp is missing"
+		} else {
+			progress.Reason = "screen progress fingerprint is missing"
+		}
 	case hasLastChange && !lastCaptureTime.After(lastChangeTime):
 		progress.EvidenceState = "changed"
 	case hasLastChange:
 		progress.EvidenceState = "unchanged"
 	default:
 		progress.EvidenceState = "missing"
+		progress.Reason = "screen progress change timestamp is missing"
 	}
 
 	return progress
 }
 
-func normalizeProgressTimestamp(value string) (string, time.Time, bool) {
+func normalizeProgressTimestamp(value string) (string, time.Time, bool, bool) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", time.Time{}, false
+		return "", time.Time{}, false, false
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil || parsed.IsZero() {
-		return "", time.Time{}, false
+		return "", time.Time{}, false, true
 	}
-	return parsed.UTC().Format(time.RFC3339Nano), parsed, true
+	parsed = parsed.UTC()
+	return parsed.Format(time.RFC3339Nano), parsed, true, false
 }
 
 func normalizeScreenFingerprint(value string) string {

--- a/internal/cli/session_status_oneline_test.go
+++ b/internal/cli/session_status_oneline_test.go
@@ -140,6 +140,19 @@ func TestCompactNodeStatusMarkUsesContextualNodeSeverityWhenVisibleReady(t *test
 			want: "🔴",
 		},
 		{
+			name: "unknown pane-local evidence is neutral not green",
+			node: status.NodeStatus{
+				VisibleState: "ready",
+				Severity:     "ok",
+				NodeLocal: &status.NodeLocalStatus{
+					State:         "unknown",
+					Severity:      "ok",
+					EvidenceLevel: "unknown",
+				},
+			},
+			want: "⚫",
+		},
+		{
 			name: "pending obligation keeps pending mark",
 			node: status.NodeStatus{
 				VisibleState: "pending",
@@ -158,6 +171,59 @@ func TestCompactNodeStatusMarkUsesContextualNodeSeverityWhenVisibleReady(t *test
 		t.Run(tt.name, func(t *testing.T) {
 			if got := compactNodeStatusMark(tt.node); got != tt.want {
 				t.Fatalf("compactNodeStatusMark(...) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldSkipCompactNodeKeepsClassifiedShellEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		node status.NodeStatus
+		want bool
+	}{
+		{
+			name: "plain shell pane is skipped",
+			node: status.NodeStatus{
+				CurrentCommand: "bash",
+				Severity:       "ok",
+				NodeLocal: &status.NodeLocalStatus{
+					State:    "live",
+					Severity: "ok",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "shell pane with unknown evidence is retained as neutral",
+			node: status.NodeStatus{
+				CurrentCommand: "bash",
+				Severity:       "ok",
+				NodeLocal: &status.NodeLocalStatus{
+					State:    "unknown",
+					Severity: "ok",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "shell pane with conflict evidence is retained",
+			node: status.NodeStatus{
+				CurrentCommand: "bash",
+				Severity:       "attention_stale",
+				NodeLocal: &status.NodeLocalStatus{
+					State:    "conflict",
+					Severity: "attention_stale",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipCompactNode(tt.node); got != tt.want {
+				t.Fatalf("shouldSkipCompactNode(...) = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -324,7 +390,7 @@ func TestRunGetSessionStatusOneline_UsesSessionIDOrder(t *testing.T) {
 		t.Fatalf("RunGetSessionStatusOneline: %v", err)
 	}
 
-	if stdout.String() != "[0]🔷🟢:🟢 [1]🟢🔷\n" {
+	if stdout.String() != "[0]🔷⚫:⚫ [1]⚫🔷\n" {
 		t.Fatalf("stdout = %q, want compact status line", stdout.String())
 	}
 
@@ -427,7 +493,7 @@ func TestRunGetSessionStatusOneline_PreservesSessionIDIndicesAcrossSessionsWitho
 		t.Fatalf("RunGetSessionStatusOneline: %v", err)
 	}
 
-	if stdout.String() != "[0]🟢🟢 [1]⚫\n" {
+	if stdout.String() != "[0]⚫⚫ [1]⚫\n" {
 		t.Fatalf("stdout = %q, want compact status line", stdout.String())
 	}
 }

--- a/internal/cli/session_status_oneline_test.go
+++ b/internal/cli/session_status_oneline_test.go
@@ -140,6 +140,24 @@ func TestCompactNodeStatusMarkUsesContextualNodeSeverityWhenVisibleReady(t *test
 			want: "🔴",
 		},
 		{
+			name: "blocked flow is not hidden behind unknown pane-local evidence",
+			node: status.NodeStatus{
+				VisibleState: "ready",
+				Severity:     "blocked",
+				NodeLocal: &status.NodeLocalStatus{
+					State:         "unknown",
+					Severity:      "ok",
+					EvidenceLevel: "unknown",
+				},
+				Flow: &status.NodeFlowStatus{
+					State:         "blocked",
+					Severity:      "blocked",
+					EvidenceLevel: "proven",
+				},
+			},
+			want: "🔴",
+		},
+		{
 			name: "unknown pane-local evidence is neutral not green",
 			node: status.NodeStatus{
 				VisibleState: "ready",

--- a/internal/cli/session_status_projection_test.go
+++ b/internal/cli/session_status_projection_test.go
@@ -303,6 +303,9 @@ func TestSessionStatusExposesChangedAndUnchangedScreenProgressEvidence(t *testin
 	if worker.ScreenFingerprint != "00000011" {
 		t.Fatalf("worker screen_fingerprint = %q, want 00000011", worker.ScreenFingerprint)
 	}
+	if worker.StaleDurationSeconds != 5 {
+		t.Fatalf("worker stale_duration_seconds = %d, want 5", worker.StaleDurationSeconds)
+	}
 
 	critic := nodeByName["critic"].ScreenProgress
 	if critic == nil {
@@ -320,6 +323,90 @@ func TestSessionStatusExposesChangedAndUnchangedScreenProgressEvidence(t *testin
 	}
 	if critic.ScreenFingerprint != "00000012" {
 		t.Fatalf("critic screen_fingerprint = %q, want 00000012", critic.ScreenFingerprint)
+	}
+}
+
+func TestSessionStatusClassifiesNodeLocalFreshnessFromScreenProgress(t *testing.T) {
+	fixture := writeSessionStatusProjectionFixture(
+		t,
+		map[string]string{"worker": "active", "critic": "active"},
+		nil,
+		nil,
+	)
+	writeSessionStatusPaneActivity(t, fixture, `{
+  "%11": {"status":"active","lastChangeAt":"2026-04-14T00:00:00Z","lastCaptureAt":"2026-04-14T00:04:00Z","screenFingerprint":"00000011"},
+  "%12": {"status":"active","lastChangeAt":"2026-04-14T00:01:00Z","lastCaptureAt":"2026-04-14T00:01:00Z","screenFingerprint":"00000012"}
+}`)
+
+	health, err := collectLiveSessionStatus(fixture.baseDir, fixture.contextID, fixture.sessionName, fixture.cfg)
+	if err != nil {
+		t.Fatalf("collectLiveSessionStatus() error = %v", err)
+	}
+
+	nodeByName := map[string]status.NodeStatus{}
+	for _, node := range health.Nodes {
+		nodeByName[node.Name] = node
+	}
+
+	worker := nodeByName["worker"]
+	if worker.NodeLocal == nil {
+		t.Fatal("worker node_local is nil")
+	}
+	if worker.NodeLocal.State != "stale" || worker.NodeLocal.Severity != "attention_stale" {
+		t.Fatalf("worker node_local = %#v, want stale attention from unchanged old screen progress", worker.NodeLocal)
+	}
+	if worker.NodeLocal.Freshness != "stale" || worker.NodeLocal.AgeSeconds != 240 {
+		t.Fatalf("worker node_local freshness/age = %q/%d, want stale/240", worker.NodeLocal.Freshness, worker.NodeLocal.AgeSeconds)
+	}
+	if worker.NodeLocal.EvidenceLevel != "observed" {
+		t.Fatalf("worker node_local evidence = %q, want observed", worker.NodeLocal.EvidenceLevel)
+	}
+	if health.CompactSeverity != "attention_stale:node=worker" {
+		t.Fatalf("CompactSeverity = %q, want attention_stale for stale pane-local evidence", health.CompactSeverity)
+	}
+
+	critic := nodeByName["critic"]
+	if critic.NodeLocal == nil {
+		t.Fatal("critic node_local is nil")
+	}
+	if critic.NodeLocal.State != "working" || critic.NodeLocal.Freshness != "fresh" {
+		t.Fatalf("critic node_local = %#v, want fresh working from changed screen progress", critic.NodeLocal)
+	}
+}
+
+func TestSessionStatusKeepsAgingUnchangedPaneLiveNotWorking(t *testing.T) {
+	fixture := writeSessionStatusProjectionFixture(
+		t,
+		map[string]string{"worker": "active", "critic": "active"},
+		nil,
+		nil,
+	)
+	writeSessionStatusPaneActivity(t, fixture, `{
+  "%11": {"status":"active","lastChangeAt":"2026-04-14T00:00:00Z","lastCaptureAt":"2026-04-14T00:01:00Z","screenFingerprint":"00000011"},
+  "%12": {"status":"active","lastChangeAt":"2026-04-14T00:02:00Z","lastCaptureAt":"2026-04-14T00:02:00Z","screenFingerprint":"00000012"}
+}`)
+
+	health, err := collectLiveSessionStatus(fixture.baseDir, fixture.contextID, fixture.sessionName, fixture.cfg)
+	if err != nil {
+		t.Fatalf("collectLiveSessionStatus() error = %v", err)
+	}
+
+	nodeByName := map[string]status.NodeStatus{}
+	for _, node := range health.Nodes {
+		nodeByName[node.Name] = node
+	}
+	worker := nodeByName["worker"]
+	if worker.NodeLocal == nil {
+		t.Fatal("worker node_local is nil")
+	}
+	if worker.NodeLocal.State != "live" || worker.NodeLocal.Severity != "ok" {
+		t.Fatalf("worker node_local = %#v, want live ok from aging unchanged screen progress", worker.NodeLocal)
+	}
+	if worker.NodeLocal.Freshness != "aging" || worker.NodeLocal.AgeSeconds != 60 {
+		t.Fatalf("worker node_local freshness/age = %q/%d, want aging/60", worker.NodeLocal.Freshness, worker.NodeLocal.AgeSeconds)
+	}
+	if health.CompactSeverity != "working:node=critic" {
+		t.Fatalf("CompactSeverity = %q, want only changed critic to report working", health.CompactSeverity)
 	}
 }
 

--- a/internal/cli/session_status_projection_test.go
+++ b/internal/cli/session_status_projection_test.go
@@ -326,87 +326,161 @@ func TestSessionStatusExposesChangedAndUnchangedScreenProgressEvidence(t *testin
 	}
 }
 
-func TestSessionStatusClassifiesNodeLocalFreshnessFromScreenProgress(t *testing.T) {
-	fixture := writeSessionStatusProjectionFixture(
-		t,
-		map[string]string{"worker": "active", "critic": "active"},
-		nil,
-		nil,
-	)
-	writeSessionStatusPaneActivity(t, fixture, `{
-  "%11": {"status":"active","lastChangeAt":"2026-04-14T00:00:00Z","lastCaptureAt":"2026-04-14T00:04:00Z","screenFingerprint":"00000011"},
-  "%12": {"status":"active","lastChangeAt":"2026-04-14T00:01:00Z","lastCaptureAt":"2026-04-14T00:01:00Z","screenFingerprint":"00000012"}
-}`)
-
-	health, err := collectLiveSessionStatus(fixture.baseDir, fixture.contextID, fixture.sessionName, fixture.cfg)
-	if err != nil {
-		t.Fatalf("collectLiveSessionStatus() error = %v", err)
+func TestSessionStatusClassifiesNodeLocalFreshnessMatrix(t *testing.T) {
+	now := time.Date(2026, time.April, 14, 0, 10, 0, 0, time.UTC)
+	progress := func(state string, changeDelta, captureDelta time.Duration) *status.ScreenProgressEvidence {
+		captureAt := now.Add(captureDelta)
+		changeAt := now.Add(changeDelta)
+		result := &status.ScreenProgressEvidence{
+			EvidenceState:        state,
+			LastCaptureAt:        captureAt.Format(time.RFC3339Nano),
+			LastScreenChangeAt:   changeAt.Format(time.RFC3339Nano),
+			ScreenFingerprint:    "00000011",
+			StaleDurationSeconds: int(captureAt.Sub(changeAt).Seconds()),
+		}
+		if result.StaleDurationSeconds < 0 {
+			result.StaleDurationSeconds = 0
+		}
+		return result
 	}
 
-	nodeByName := map[string]status.NodeStatus{}
-	for _, node := range health.Nodes {
-		nodeByName[node.Name] = node
+	tests := []struct {
+		name             string
+		node             status.NodeStatus
+		wantState        string
+		wantSeverity     string
+		wantEvidence     string
+		wantFreshness    string
+		wantAge          int
+		wantUnchanged    int
+		wantReasonSubstr string
+	}{
+		{
+			name:          "fresh changed becomes working",
+			node:          status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", -5*time.Second, -5*time.Second)},
+			wantState:     "working",
+			wantSeverity:  "working",
+			wantEvidence:  "observed",
+			wantFreshness: "fresh",
+			wantAge:       5,
+		},
+		{
+			name:          "fresh unchanged remains live",
+			node:          status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("unchanged", -20*time.Second, -5*time.Second)},
+			wantState:     "live",
+			wantSeverity:  "ok",
+			wantEvidence:  "observed",
+			wantFreshness: "fresh",
+			wantAge:       5,
+			wantUnchanged: 15,
+		},
+		{
+			name:          "aging unchanged remains live",
+			node:          status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("unchanged", -70*time.Second, -5*time.Second)},
+			wantState:     "live",
+			wantSeverity:  "ok",
+			wantEvidence:  "observed",
+			wantFreshness: "aging",
+			wantAge:       5,
+			wantUnchanged: 65,
+		},
+		{
+			name:             "old but changed is stale",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", -4*time.Minute, -4*time.Minute)},
+			wantState:        "stale",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "stale",
+			wantAge:          240,
+			wantReasonSubstr: "capture is stale",
+		},
+		{
+			name:             "runtime lagged changed is aging live",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", -45*time.Second, -45*time.Second)},
+			wantState:        "live",
+			wantSeverity:     "ok",
+			wantEvidence:     "observed",
+			wantFreshness:    "aging",
+			wantAge:          45,
+			wantReasonSubstr: "capture is aging",
+		},
+		{
+			name:             "explicit stale is stale",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: &status.ScreenProgressEvidence{EvidenceState: "stale", StaleDurationSeconds: 181}},
+			wantState:        "stale",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "stale",
+			wantUnchanged:    181,
+			wantReasonSubstr: "evidence is stale",
+		},
+		{
+			name:             "active missing is unknown not working",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: missingScreenProgressEvidence()},
+			wantState:        "unknown",
+			wantSeverity:     "ok",
+			wantEvidence:     "unknown",
+			wantFreshness:    "unknown",
+			wantReasonSubstr: "missing",
+		},
+		{
+			name:             "malformed progress is unknown not working",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: screenProgressEvidence("active", "bad", now.Format(time.RFC3339Nano), "00000011")},
+			wantState:        "unknown",
+			wantSeverity:     "ok",
+			wantEvidence:     "unknown",
+			wantFreshness:    "unknown",
+			wantReasonSubstr: "malformed",
+		},
+		{
+			name:             "future capture is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", time.Second, time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          -1,
+			wantReasonSubstr: "future",
+		},
+		{
+			name:             "change after capture is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("unchanged", -5*time.Second, -10*time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          10,
+			wantReasonSubstr: "after the capture",
+		},
+		{
+			name:             "contradictory changed state is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", -20*time.Second, -5*time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          5,
+			wantUnchanged:    15,
+			wantReasonSubstr: "contradicts",
+		},
 	}
 
-	worker := nodeByName["worker"]
-	if worker.NodeLocal == nil {
-		t.Fatal("worker node_local is nil")
-	}
-	if worker.NodeLocal.State != "stale" || worker.NodeLocal.Severity != "attention_stale" {
-		t.Fatalf("worker node_local = %#v, want stale attention from unchanged old screen progress", worker.NodeLocal)
-	}
-	if worker.NodeLocal.Freshness != "stale" || worker.NodeLocal.AgeSeconds != 240 {
-		t.Fatalf("worker node_local freshness/age = %q/%d, want stale/240", worker.NodeLocal.Freshness, worker.NodeLocal.AgeSeconds)
-	}
-	if worker.NodeLocal.EvidenceLevel != "observed" {
-		t.Fatalf("worker node_local evidence = %q, want observed", worker.NodeLocal.EvidenceLevel)
-	}
-	if health.CompactSeverity != "attention_stale:node=worker" {
-		t.Fatalf("CompactSeverity = %q, want attention_stale for stale pane-local evidence", health.CompactSeverity)
-	}
-
-	critic := nodeByName["critic"]
-	if critic.NodeLocal == nil {
-		t.Fatal("critic node_local is nil")
-	}
-	if critic.NodeLocal.State != "working" || critic.NodeLocal.Freshness != "fresh" {
-		t.Fatalf("critic node_local = %#v, want fresh working from changed screen progress", critic.NodeLocal)
-	}
-}
-
-func TestSessionStatusKeepsAgingUnchangedPaneLiveNotWorking(t *testing.T) {
-	fixture := writeSessionStatusProjectionFixture(
-		t,
-		map[string]string{"worker": "active", "critic": "active"},
-		nil,
-		nil,
-	)
-	writeSessionStatusPaneActivity(t, fixture, `{
-  "%11": {"status":"active","lastChangeAt":"2026-04-14T00:00:00Z","lastCaptureAt":"2026-04-14T00:01:00Z","screenFingerprint":"00000011"},
-  "%12": {"status":"active","lastChangeAt":"2026-04-14T00:02:00Z","lastCaptureAt":"2026-04-14T00:02:00Z","screenFingerprint":"00000012"}
-}`)
-
-	health, err := collectLiveSessionStatus(fixture.baseDir, fixture.contextID, fixture.sessionName, fixture.cfg)
-	if err != nil {
-		t.Fatalf("collectLiveSessionStatus() error = %v", err)
-	}
-
-	nodeByName := map[string]status.NodeStatus{}
-	for _, node := range health.Nodes {
-		nodeByName[node.Name] = node
-	}
-	worker := nodeByName["worker"]
-	if worker.NodeLocal == nil {
-		t.Fatal("worker node_local is nil")
-	}
-	if worker.NodeLocal.State != "live" || worker.NodeLocal.Severity != "ok" {
-		t.Fatalf("worker node_local = %#v, want live ok from aging unchanged screen progress", worker.NodeLocal)
-	}
-	if worker.NodeLocal.Freshness != "aging" || worker.NodeLocal.AgeSeconds != 60 {
-		t.Fatalf("worker node_local freshness/age = %q/%d, want aging/60", worker.NodeLocal.Freshness, worker.NodeLocal.AgeSeconds)
-	}
-	if health.CompactSeverity != "working:node=critic" {
-		t.Fatalf("CompactSeverity = %q, want only changed critic to report working", health.CompactSeverity)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveNodeLocalStatusAt(tt.node, now)
+			if got.State != tt.wantState || got.Severity != tt.wantSeverity || got.EvidenceLevel != tt.wantEvidence || got.Freshness != tt.wantFreshness {
+				t.Fatalf("node_local = %#v, want state/severity/evidence/freshness %q/%q/%q/%q", got, tt.wantState, tt.wantSeverity, tt.wantEvidence, tt.wantFreshness)
+			}
+			if got.AgeSeconds != tt.wantAge {
+				t.Fatalf("AgeSeconds = %d, want %d (%#v)", got.AgeSeconds, tt.wantAge, got)
+			}
+			if got.UnchangedSeconds != tt.wantUnchanged {
+				t.Fatalf("UnchangedSeconds = %d, want %d (%#v)", got.UnchangedSeconds, tt.wantUnchanged, got)
+			}
+			if tt.wantReasonSubstr != "" && !strings.Contains(got.Reason, tt.wantReasonSubstr) {
+				t.Fatalf("Reason = %q, want substring %q", got.Reason, tt.wantReasonSubstr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/session_status_projection_test.go
+++ b/internal/cli/session_status_projection_test.go
@@ -550,6 +550,10 @@ func TestSessionStatusBuildsDefaultCompactAfterNodeLocalEnrichment(t *testing.T)
 		wantCompact      string
 		wantNodeLocal    string
 		wantSeverity     string
+		wantNodeSeverity string
+		blockedReports   []projection.BlockedReport
+		wantFlowState    string
+		wantCompactSev   string
 		wantOneline      string
 		wantReasonSubstr string
 	}{
@@ -629,10 +633,38 @@ func TestSessionStatusBuildsDefaultCompactAfterNodeLocalEnrichment(t *testing.T)
 			wantOneline:      "🔴",
 			wantReasonSubstr: "pane state is idle",
 		},
+		{
+			name:           "blocked flow beats unknown local evidence",
+			paneState:      "active",
+			currentCommand: "claude",
+			screenProgress: missingScreenProgressEvidence(),
+			blockedReports: []projection.BlockedReport{
+				{
+					Node:            "worker",
+					MessageID:       "blocked-message",
+					BlockedReportID: "blocked-report-001",
+					EvidenceLevel:   "proven",
+					EvidenceSource:  "blocked_report_file",
+					Reason:          "waiting on owner",
+				},
+			},
+			wantCompact:      "🔴",
+			wantNodeLocal:    "unknown",
+			wantSeverity:     "ok",
+			wantNodeSeverity: "blocked",
+			wantFlowState:    "blocked",
+			wantCompactSev:   "blocked:node=worker:blocked_report=blocked-report-001",
+			wantOneline:      "🔴",
+			wantReasonSubstr: "missing",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			blockedByNode := map[string][]projection.BlockedReport{}
+			if len(tt.blockedReports) > 0 {
+				blockedByNode["worker"] = tt.blockedReports
+			}
 			health := buildSessionStatusSnapshot(sessionStatusInputs{
 				contextID:        "ctx",
 				sessionName:      "review",
@@ -663,7 +695,7 @@ func TestSessionStatusBuildsDefaultCompactAfterNodeLocalEnrichment(t *testing.T)
 				},
 				inboxCounts:   map[string]int{},
 				delivery:      &status.DeliveryStatus{State: "ok", Severity: "ok", EvidenceLevel: "proven"},
-				blockedByNode: map[string][]projection.BlockedReport{},
+				blockedByNode: blockedByNode,
 				now:           now,
 			})
 
@@ -679,6 +711,22 @@ func TestSessionStatusBuildsDefaultCompactAfterNodeLocalEnrichment(t *testing.T)
 			local := health.Nodes[0].NodeLocal
 			if local.State != tt.wantNodeLocal || local.Severity != tt.wantSeverity {
 				t.Fatalf("node_local = %#v, want state/severity %q/%q", local, tt.wantNodeLocal, tt.wantSeverity)
+			}
+			node := health.Nodes[0]
+			wantNodeSeverity := tt.wantNodeSeverity
+			if wantNodeSeverity == "" {
+				wantNodeSeverity = tt.wantSeverity
+			}
+			if node.Severity != wantNodeSeverity {
+				t.Fatalf("node severity = %q, want %q; node=%#v", node.Severity, wantNodeSeverity, node)
+			}
+			if tt.wantFlowState != "" {
+				if node.Flow == nil || node.Flow.State != tt.wantFlowState {
+					t.Fatalf("flow = %#v, want state %q", node.Flow, tt.wantFlowState)
+				}
+			}
+			if tt.wantCompactSev != "" && health.CompactSeverity != tt.wantCompactSev {
+				t.Fatalf("CompactSeverity = %q, want %q", health.CompactSeverity, tt.wantCompactSev)
 			}
 			if tt.wantReasonSubstr != "" && !strings.Contains(local.Reason, tt.wantReasonSubstr) {
 				t.Fatalf("Reason = %q, want substring %q", local.Reason, tt.wantReasonSubstr)

--- a/internal/cli/session_status_projection_test.go
+++ b/internal/cli/session_status_projection_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/i9wa4/tmux-a2a-postman/internal/config"
+	"github.com/i9wa4/tmux-a2a-postman/internal/discovery"
 	"github.com/i9wa4/tmux-a2a-postman/internal/journal"
 	"github.com/i9wa4/tmux-a2a-postman/internal/projection"
 	"github.com/i9wa4/tmux-a2a-postman/internal/status"
@@ -141,7 +142,7 @@ func TestSessionStatusLayoutGroupsProjectTmuxWindowsCompatibility(t *testing.T) 
 		t.Fatalf("collectLiveSessionStatus() error = %v", err)
 	}
 
-	if got, want := health.Compact, "🟢🟢"; got != want {
+	if got, want := health.Compact, "⚫⚫"; got != want {
 		t.Fatalf("Compact = %q, want %q", got, want)
 	}
 	if len(health.Windows) != 1 || health.Windows[0].Index != "0" {
@@ -256,7 +257,7 @@ func TestSessionStatusUsesLiveArtifactsWithoutSnapshot(t *testing.T) {
 	if projected.SessionName != fixture.sessionName {
 		t.Fatalf("SessionName = %q, want %q", projected.SessionName, fixture.sessionName)
 	}
-	if projected.VisibleState != "pending" || projected.Compact != "🔷🟢" || projected.NodeCount != 2 {
+	if projected.VisibleState != "pending" || projected.Compact != "🔷⚫" || projected.NodeCount != 2 {
 		t.Fatalf("unexpected live health payload: %#v", projected)
 	}
 	if len(projected.Nodes) != 2 || len(projected.Windows) != 1 {
@@ -443,6 +444,15 @@ func TestSessionStatusClassifiesNodeLocalFreshnessMatrix(t *testing.T) {
 			wantReasonSubstr: "future",
 		},
 		{
+			name:             "sub-second future capture is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("changed", 500*time.Millisecond, 500*time.Millisecond)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantReasonSubstr: "future",
+		},
+		{
 			name:             "change after capture is conflict",
 			node:             status.NodeStatus{Name: "worker", PaneState: "active", ScreenProgress: progress("unchanged", -5*time.Second, -10*time.Second)},
 			wantState:        "conflict",
@@ -463,6 +473,36 @@ func TestSessionStatusClassifiesNodeLocalFreshnessMatrix(t *testing.T) {
 			wantUnchanged:    15,
 			wantReasonSubstr: "contradicts",
 		},
+		{
+			name:             "changed screen with shell command is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "active", CurrentCommand: "bash", ScreenProgress: progress("changed", -5*time.Second, -5*time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          5,
+			wantReasonSubstr: "current command is a shell",
+		},
+		{
+			name:             "changed screen with idle pane is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "idle", CurrentCommand: "claude", ScreenProgress: progress("changed", -5*time.Second, -5*time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          5,
+			wantReasonSubstr: "pane state is idle",
+		},
+		{
+			name:             "changed screen with stale pane is conflict",
+			node:             status.NodeStatus{Name: "worker", PaneState: "stale", CurrentCommand: "claude", ScreenProgress: progress("changed", -5*time.Second, -5*time.Second)},
+			wantState:        "conflict",
+			wantSeverity:     "attention_stale",
+			wantEvidence:     "observed",
+			wantFreshness:    "conflict",
+			wantAge:          5,
+			wantReasonSubstr: "pane state is stale",
+		},
 	}
 
 	for _, tt := range tests {
@@ -479,6 +519,169 @@ func TestSessionStatusClassifiesNodeLocalFreshnessMatrix(t *testing.T) {
 			}
 			if tt.wantReasonSubstr != "" && !strings.Contains(got.Reason, tt.wantReasonSubstr) {
 				t.Fatalf("Reason = %q, want substring %q", got.Reason, tt.wantReasonSubstr)
+			}
+		})
+	}
+}
+
+func TestSessionStatusBuildsDefaultCompactAfterNodeLocalEnrichment(t *testing.T) {
+	now := time.Date(2026, time.April, 14, 0, 10, 0, 0, time.UTC)
+	progress := func(state string, changeDelta, captureDelta time.Duration) *status.ScreenProgressEvidence {
+		captureAt := now.Add(captureDelta)
+		changeAt := now.Add(changeDelta)
+		result := &status.ScreenProgressEvidence{
+			EvidenceState:        state,
+			LastCaptureAt:        captureAt.Format(time.RFC3339Nano),
+			LastScreenChangeAt:   changeAt.Format(time.RFC3339Nano),
+			ScreenFingerprint:    "00000011",
+			StaleDurationSeconds: int(captureAt.Sub(changeAt).Seconds()),
+		}
+		if result.StaleDurationSeconds < 0 {
+			result.StaleDurationSeconds = 0
+		}
+		return result
+	}
+
+	tests := []struct {
+		name             string
+		paneState        string
+		currentCommand   string
+		screenProgress   *status.ScreenProgressEvidence
+		wantCompact      string
+		wantNodeLocal    string
+		wantSeverity     string
+		wantOneline      string
+		wantReasonSubstr string
+	}{
+		{
+			name:           "fresh work is blue not legacy green",
+			paneState:      "active",
+			currentCommand: "claude",
+			screenProgress: progress("changed", -5*time.Second, -5*time.Second),
+			wantCompact:    "🔵",
+			wantNodeLocal:  "working",
+			wantSeverity:   "working",
+			wantOneline:    "🔵",
+		},
+		{
+			name:             "missing progress is neutral not green",
+			paneState:        "active",
+			currentCommand:   "claude",
+			screenProgress:   missingScreenProgressEvidence(),
+			wantCompact:      "⚫",
+			wantNodeLocal:    "unknown",
+			wantSeverity:     "ok",
+			wantOneline:      "⚫",
+			wantReasonSubstr: "missing",
+		},
+		{
+			name:             "malformed progress is neutral not green",
+			paneState:        "active",
+			currentCommand:   "claude",
+			screenProgress:   screenProgressEvidence("active", "bad", now.Format(time.RFC3339Nano), "00000011"),
+			wantCompact:      "⚫",
+			wantNodeLocal:    "unknown",
+			wantSeverity:     "ok",
+			wantOneline:      "⚫",
+			wantReasonSubstr: "malformed",
+		},
+		{
+			name:             "stale capture is red",
+			paneState:        "active",
+			currentCommand:   "claude",
+			screenProgress:   progress("changed", -4*time.Minute, -4*time.Minute),
+			wantCompact:      "🔴",
+			wantNodeLocal:    "stale",
+			wantSeverity:     "attention_stale",
+			wantOneline:      "🔴",
+			wantReasonSubstr: "capture is stale",
+		},
+		{
+			name:             "sub-second future is red conflict",
+			paneState:        "active",
+			currentCommand:   "claude",
+			screenProgress:   progress("changed", 500*time.Millisecond, 500*time.Millisecond),
+			wantCompact:      "🔴",
+			wantNodeLocal:    "conflict",
+			wantSeverity:     "attention_stale",
+			wantOneline:      "🔴",
+			wantReasonSubstr: "future",
+		},
+		{
+			name:             "shell command contradiction is red not skipped green",
+			paneState:        "active",
+			currentCommand:   "bash",
+			screenProgress:   progress("changed", -5*time.Second, -5*time.Second),
+			wantCompact:      "🔴",
+			wantNodeLocal:    "conflict",
+			wantSeverity:     "attention_stale",
+			wantOneline:      "🔴",
+			wantReasonSubstr: "current command is a shell",
+		},
+		{
+			name:             "idle pane with changed screen is red conflict",
+			paneState:        "idle",
+			currentCommand:   "claude",
+			screenProgress:   progress("changed", -5*time.Second, -5*time.Second),
+			wantCompact:      "🔴",
+			wantNodeLocal:    "conflict",
+			wantSeverity:     "attention_stale",
+			wantOneline:      "🔴",
+			wantReasonSubstr: "pane state is idle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			health := buildSessionStatusSnapshot(sessionStatusInputs{
+				contextID:        "ctx",
+				sessionName:      "review",
+				cfg:              config.DefaultConfig(),
+				orderedEdgeNodes: []string{"worker"},
+				edgeNodeRank:     map[string]int{"worker": 0},
+				nodes: map[string]discovery.NodeInfo{
+					"worker": {
+						PaneID:      "%11",
+						SessionName: "review",
+					},
+				},
+				paneActivity: map[string]paneActivityEvidence{
+					"%11": {
+						Status:         tt.paneState,
+						ScreenProgress: tt.screenProgress,
+					},
+				},
+				panes: []sessionPane{
+					{
+						windowIndex:    "0",
+						windowOrder:    0,
+						paneOrder:      0,
+						paneID:         "%11",
+						title:          "worker",
+						currentCommand: tt.currentCommand,
+					},
+				},
+				inboxCounts:   map[string]int{},
+				delivery:      &status.DeliveryStatus{State: "ok", Severity: "ok", EvidenceLevel: "proven"},
+				blockedByNode: map[string][]projection.BlockedReport{},
+				now:           now,
+			})
+
+			if health.Compact != tt.wantCompact {
+				t.Fatalf("Compact = %q, want %q; health=%#v", health.Compact, tt.wantCompact, health)
+			}
+			if got := formatSessionStatusOneline(health); got != tt.wantOneline {
+				t.Fatalf("formatSessionStatusOneline(...) = %q, want %q", got, tt.wantOneline)
+			}
+			if len(health.Nodes) != 1 || health.Nodes[0].NodeLocal == nil {
+				t.Fatalf("node_local missing in health: %#v", health.Nodes)
+			}
+			local := health.Nodes[0].NodeLocal
+			if local.State != tt.wantNodeLocal || local.Severity != tt.wantSeverity {
+				t.Fatalf("node_local = %#v, want state/severity %q/%q", local, tt.wantNodeLocal, tt.wantSeverity)
+			}
+			if tt.wantReasonSubstr != "" && !strings.Contains(local.Reason, tt.wantReasonSubstr) {
+				t.Fatalf("Reason = %q, want substring %q", local.Reason, tt.wantReasonSubstr)
 			}
 		})
 	}

--- a/internal/cli/session_status_severity.go
+++ b/internal/cli/session_status_severity.go
@@ -187,12 +187,15 @@ func collectDeadLetterItems(sessionDir string) []status.StatusItem {
 }
 
 func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
+	freshness, ageSeconds := nodeLocalFreshness(node.ScreenProgress)
 	local := &status.NodeLocalStatus{
-		State:          "quiet",
+		State:          "live",
 		Severity:       "ok",
-		EvidenceLevel:  "proven",
+		EvidenceLevel:  "observed",
 		EvidenceSource: "pane_activity",
-		Reason:         "pane is live without recent activity evidence",
+		Freshness:      freshness,
+		AgeSeconds:     ageSeconds,
+		Reason:         "pane is live without current activity evidence",
 		PaneState:      node.PaneState,
 		CurrentCommand: node.CurrentCommand,
 		ScreenProgress: node.ScreenProgress,
@@ -200,6 +203,8 @@ func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
 	if status.NormalizePaneState(node.PaneState) == "stale" {
 		local.State = "stale"
 		local.Severity = "attention_stale"
+		local.EvidenceLevel = "observed"
+		local.Freshness = "stale"
 		local.Reason = "pane state is stale"
 		return local
 	}
@@ -207,19 +212,69 @@ func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
 		local.State = "unknown"
 		local.Severity = "ok"
 		local.EvidenceLevel = "unknown"
+		local.Freshness = "unknown"
 		local.Reason = "pane activity evidence is missing"
 		return local
 	}
-	if node.PaneState == "active" || (node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "changed") {
+	if node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "stale" {
+		local.State = "stale"
+		local.Severity = "attention_stale"
+		local.EvidenceLevel = "observed"
+		local.Freshness = "stale"
+		local.Reason = "screen progress evidence is stale"
+		return local
+	}
+	if local.Freshness == "stale" {
+		local.State = "stale"
+		local.Severity = "attention_stale"
+		local.EvidenceLevel = "observed"
+		local.Reason = "screen progress has not changed within the pane-local freshness window"
+		return local
+	}
+	if node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "changed" {
+		local.State = "working"
+		local.Severity = "working"
+		local.EvidenceLevel = "observed"
+		local.Freshness = "fresh"
+		local.Reason = "screen progress changed in the latest capture"
+		return local
+	}
+	if node.PaneState == "active" && (node.ScreenProgress == nil || node.ScreenProgress.EvidenceState == "missing") {
 		local.State = "working"
 		local.Severity = "working"
 		local.EvidenceLevel = "inferred"
-		local.Reason = "pane activity suggests current work"
+		local.Freshness = "unknown"
+		local.Reason = "pane activity suggests current work but screen progress evidence is missing"
 		return local
 	}
-	local.State = "live"
 	local.Reason = "pane is live"
 	return local
+}
+
+func nodeLocalFreshness(progress *status.ScreenProgressEvidence) (string, int) {
+	if progress == nil {
+		return "unknown", 0
+	}
+	switch progress.EvidenceState {
+	case "missing":
+		return "unknown", 0
+	case "stale":
+		return "stale", progress.StaleDurationSeconds
+	case "changed":
+		return "fresh", 0
+	case "unchanged":
+		ageSeconds := progress.StaleDurationSeconds
+		switch {
+		case ageSeconds >= status.NodeLocalStaleAfterSeconds:
+			return "stale", ageSeconds
+		case ageSeconds > status.NodeLocalFreshAfterSeconds:
+			return "aging", ageSeconds
+		default:
+			return "fresh", ageSeconds
+		}
+	default:
+		return "unknown", progress.StaleDurationSeconds
+	}
 }
 
 func deriveNodeFlowStatus(node status.NodeStatus, blockedReports []projection.BlockedReport) *status.NodeFlowStatus {

--- a/internal/cli/session_status_severity.go
+++ b/internal/cli/session_status_severity.go
@@ -12,13 +12,13 @@ import (
 	"github.com/i9wa4/tmux-a2a-postman/internal/status"
 )
 
-func applySessionStatusEnrichment(health *status.SessionStatus, delivery *status.DeliveryStatus, blockedByNode map[string][]projection.BlockedReport) {
+func applySessionStatusEnrichment(health *status.SessionStatus, delivery *status.DeliveryStatus, blockedByNode map[string][]projection.BlockedReport, now time.Time) {
 	health.SchemaVersion = status.SchemaVersion
 	health.Delivery = delivery
 	for idx := range health.Nodes {
 		node := &health.Nodes[idx]
 		node.Queues = &status.NodeQueues{InboxCount: node.InboxCount}
-		node.NodeLocal = deriveNodeLocalStatus(*node)
+		node.NodeLocal = deriveNodeLocalStatusAt(*node, now)
 		node.Flow = deriveNodeFlowStatus(*node, blockedByNode[node.Name])
 		applyNodeSeverity(node)
 	}
@@ -37,7 +37,7 @@ func enrichSessionStatus(health *status.SessionStatus, sessionDir string, now ti
 		}
 	}
 	delivery := collectSessionDelivery(sessionDir, health.Queues, now)
-	applySessionStatusEnrichment(health, delivery, blockedByNode)
+	applySessionStatusEnrichment(health, delivery, blockedByNode, now)
 	for idx := range health.Nodes {
 		if convention, ok := conventionByNode[health.Nodes[idx].Name]; ok {
 			health.Nodes[idx].ConventionMeter = statusConventionMeter(convention)
@@ -187,18 +187,27 @@ func collectDeadLetterItems(sessionDir string) []status.StatusItem {
 }
 
 func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
-	freshness, ageSeconds := nodeLocalFreshness(node.ScreenProgress)
+	return deriveNodeLocalStatusAt(node, time.Now())
+}
+
+func deriveNodeLocalStatusAt(node status.NodeStatus, now time.Time) *status.NodeLocalStatus {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	evidence := evaluateNodeLocalProgress(node.ScreenProgress, now)
 	local := &status.NodeLocalStatus{
-		State:          "live",
-		Severity:       "ok",
-		EvidenceLevel:  "observed",
-		EvidenceSource: "pane_activity",
-		Freshness:      freshness,
-		AgeSeconds:     ageSeconds,
-		Reason:         "pane is live without current activity evidence",
-		PaneState:      node.PaneState,
-		CurrentCommand: node.CurrentCommand,
-		ScreenProgress: node.ScreenProgress,
+		State:            "live",
+		Severity:         "ok",
+		EvidenceLevel:    "observed",
+		EvidenceSource:   "pane_activity",
+		Freshness:        evidence.freshness,
+		AgeSeconds:       evidence.observationAgeSeconds,
+		ObservedAt:       evidence.observedAt,
+		UnchangedSeconds: evidence.unchangedSeconds,
+		Reason:           "pane is live without current activity evidence",
+		PaneState:        node.PaneState,
+		CurrentCommand:   node.CurrentCommand,
+		ScreenProgress:   node.ScreenProgress,
 	}
 	if status.NormalizePaneState(node.PaneState) == "stale" {
 		local.State = "stale"
@@ -216,6 +225,23 @@ func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
 		local.Reason = "pane activity evidence is missing"
 		return local
 	}
+
+	if evidence.state == nodeLocalProgressConflict {
+		local.State = "conflict"
+		local.Severity = "attention_stale"
+		local.EvidenceLevel = "observed"
+		local.Freshness = "conflict"
+		local.Reason = evidence.reason
+		return local
+	}
+	if evidence.state == nodeLocalProgressMissing {
+		local.State = "unknown"
+		local.Severity = "ok"
+		local.EvidenceLevel = "unknown"
+		local.Freshness = "unknown"
+		local.Reason = evidence.reason
+		return local
+	}
 	if node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "stale" {
 		local.State = "stale"
 		local.Severity = "attention_stale"
@@ -224,14 +250,14 @@ func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
 		local.Reason = "screen progress evidence is stale"
 		return local
 	}
-	if local.Freshness == "stale" {
+	if evidence.freshness == "stale" {
 		local.State = "stale"
 		local.Severity = "attention_stale"
 		local.EvidenceLevel = "observed"
-		local.Reason = "screen progress has not changed within the pane-local freshness window"
+		local.Reason = evidence.reason
 		return local
 	}
-	if node.ScreenProgress != nil && node.ScreenProgress.EvidenceState == "changed" {
+	if evidence.state == nodeLocalProgressChanged && evidence.freshness == "fresh" {
 		local.State = "working"
 		local.Severity = "working"
 		local.EvidenceLevel = "observed"
@@ -239,42 +265,142 @@ func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
 		local.Reason = "screen progress changed in the latest capture"
 		return local
 	}
-	if node.PaneState == "active" && (node.ScreenProgress == nil || node.ScreenProgress.EvidenceState == "missing") {
-		local.State = "working"
-		local.Severity = "working"
-		local.EvidenceLevel = "inferred"
-		local.Freshness = "unknown"
-		local.Reason = "pane activity suggests current work but screen progress evidence is missing"
+	if evidence.state == nodeLocalProgressChanged {
+		local.State = "live"
+		local.Severity = "ok"
+		local.EvidenceLevel = "observed"
+		local.Reason = evidence.reason
 		return local
 	}
 	local.Reason = "pane is live"
 	return local
 }
 
-func nodeLocalFreshness(progress *status.ScreenProgressEvidence) (string, int) {
+type nodeLocalProgressState string
+
+const (
+	nodeLocalProgressMissing   nodeLocalProgressState = "missing"
+	nodeLocalProgressChanged   nodeLocalProgressState = "changed"
+	nodeLocalProgressUnchanged nodeLocalProgressState = "unchanged"
+	nodeLocalProgressStale     nodeLocalProgressState = "stale"
+	nodeLocalProgressConflict  nodeLocalProgressState = "conflict"
+)
+
+type nodeLocalProgressEvaluation struct {
+	state                 nodeLocalProgressState
+	freshness             string
+	reason                string
+	observedAt            string
+	observationAgeSeconds int
+	unchangedSeconds      int
+}
+
+func evaluateNodeLocalProgress(progress *status.ScreenProgressEvidence, now time.Time) nodeLocalProgressEvaluation {
+	result := nodeLocalProgressEvaluation{
+		state:     nodeLocalProgressMissing,
+		freshness: "unknown",
+		reason:    "screen progress evidence is missing",
+	}
 	if progress == nil {
-		return "unknown", 0
+		return result
+	}
+	if progress.Reason != "" && progress.EvidenceState == "missing" {
+		result.reason = progress.Reason
+		return result
 	}
 	switch progress.EvidenceState {
 	case "missing":
-		return "unknown", 0
-	case "stale":
-		return "stale", progress.StaleDurationSeconds
-	case "changed":
-		return "fresh", 0
-	case "unchanged":
-		ageSeconds := progress.StaleDurationSeconds
-		switch {
-		case ageSeconds >= status.NodeLocalStaleAfterSeconds:
-			return "stale", ageSeconds
-		case ageSeconds > status.NodeLocalFreshAfterSeconds:
-			return "aging", ageSeconds
-		default:
-			return "fresh", ageSeconds
+		if progress.Reason != "" {
+			result.reason = progress.Reason
 		}
+		return result
+	case "stale":
+		result.state = nodeLocalProgressStale
+		result.freshness = "stale"
+		result.unchangedSeconds = progress.StaleDurationSeconds
+		result.reason = "screen progress evidence is stale"
+		return result
+	case "changed", "unchanged":
 	default:
-		return "unknown", progress.StaleDurationSeconds
+		result.reason = "screen progress evidence state is unknown"
+		return result
 	}
+
+	captureAt, hasCapture := parseNodeLocalTimestamp(progress.LastCaptureAt)
+	changeAt, hasChange := parseNodeLocalTimestamp(progress.LastScreenChangeAt)
+	if !hasCapture {
+		result.reason = "screen progress capture timestamp is missing or malformed"
+		return result
+	}
+	if !hasChange {
+		result.reason = "screen progress change timestamp is missing or malformed"
+		return result
+	}
+
+	result.observedAt = captureAt.Format(time.RFC3339Nano)
+	result.observationAgeSeconds = int(now.Sub(captureAt).Seconds())
+	if result.observationAgeSeconds < 0 || changeAt.After(now) {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen progress timestamp is in the future"
+		return result
+	}
+	if changeAt.After(captureAt) {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen change timestamp is after the capture timestamp"
+		return result
+	}
+	result.unchangedSeconds = int(captureAt.Sub(changeAt).Seconds())
+
+	if progress.EvidenceState == "changed" && result.unchangedSeconds > 0 {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen progress state contradicts capture/change timestamps"
+		return result
+	}
+	if progress.EvidenceState == "unchanged" && result.unchangedSeconds == 0 {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "unchanged screen progress has no elapsed unchanged duration"
+		return result
+	}
+
+	if result.observationAgeSeconds >= status.NodeLocalStaleAfterSeconds {
+		result.state = nodeLocalProgressStale
+		result.freshness = "stale"
+		result.reason = "screen progress capture is stale"
+		return result
+	}
+
+	result.state = nodeLocalProgressState(progress.EvidenceState)
+	switch {
+	case result.unchangedSeconds >= status.NodeLocalStaleAfterSeconds:
+		result.freshness = "stale"
+		result.reason = "screen has not changed within the pane-local freshness window"
+	case result.observationAgeSeconds > status.NodeLocalFreshAfterSeconds:
+		result.freshness = "aging"
+		result.reason = "screen progress capture is aging"
+	case result.unchangedSeconds > status.NodeLocalFreshAfterSeconds:
+		result.freshness = "aging"
+		result.reason = "screen has not changed within the fresh pane-local window"
+	default:
+		result.freshness = "fresh"
+		result.reason = "screen progress evidence is fresh"
+	}
+	return result
+}
+
+func parseNodeLocalTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil || parsed.IsZero() {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
 }
 
 func deriveNodeFlowStatus(node status.NodeStatus, blockedReports []projection.BlockedReport) *status.NodeFlowStatus {

--- a/internal/cli/session_status_severity.go
+++ b/internal/cli/session_status_severity.go
@@ -186,15 +186,11 @@ func collectDeadLetterItems(sessionDir string) []status.StatusItem {
 	return items
 }
 
-func deriveNodeLocalStatus(node status.NodeStatus) *status.NodeLocalStatus {
-	return deriveNodeLocalStatusAt(node, time.Now())
-}
-
 func deriveNodeLocalStatusAt(node status.NodeStatus, now time.Time) *status.NodeLocalStatus {
 	if now.IsZero() {
 		now = time.Now()
 	}
-	evidence := evaluateNodeLocalProgress(node.ScreenProgress, now)
+	evidence := evaluateNodeLocalProgress(node, now)
 	local := &status.NodeLocalStatus{
 		State:            "live",
 		Severity:         "ok",
@@ -210,6 +206,14 @@ func deriveNodeLocalStatusAt(node status.NodeStatus, now time.Time) *status.Node
 		ScreenProgress:   node.ScreenProgress,
 	}
 	if status.NormalizePaneState(node.PaneState) == "stale" {
+		if evidence.state == nodeLocalProgressConflict {
+			local.State = "conflict"
+			local.Severity = "attention_stale"
+			local.EvidenceLevel = "observed"
+			local.Freshness = "conflict"
+			local.Reason = evidence.reason
+			return local
+		}
 		local.State = "stale"
 		local.Severity = "attention_stale"
 		local.EvidenceLevel = "observed"
@@ -295,7 +299,8 @@ type nodeLocalProgressEvaluation struct {
 	unchangedSeconds      int
 }
 
-func evaluateNodeLocalProgress(progress *status.ScreenProgressEvidence, now time.Time) nodeLocalProgressEvaluation {
+func evaluateNodeLocalProgress(node status.NodeStatus, now time.Time) nodeLocalProgressEvaluation {
+	progress := node.ScreenProgress
 	result := nodeLocalProgressEvaluation{
 		state:     nodeLocalProgressMissing,
 		freshness: "unknown",
@@ -339,7 +344,7 @@ func evaluateNodeLocalProgress(progress *status.ScreenProgressEvidence, now time
 
 	result.observedAt = captureAt.Format(time.RFC3339Nano)
 	result.observationAgeSeconds = int(now.Sub(captureAt).Seconds())
-	if result.observationAgeSeconds < 0 || changeAt.After(now) {
+	if captureAt.After(now) || changeAt.After(now) {
 		result.state = nodeLocalProgressConflict
 		result.freshness = "conflict"
 		result.reason = "screen progress timestamp is in the future"
@@ -363,6 +368,24 @@ func evaluateNodeLocalProgress(progress *status.ScreenProgressEvidence, now time
 		result.state = nodeLocalProgressConflict
 		result.freshness = "conflict"
 		result.reason = "unchanged screen progress has no elapsed unchanged duration"
+		return result
+	}
+	if progress.EvidenceState == "changed" && isShellCommand(node.CurrentCommand) {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen progress changed while current command is a shell"
+		return result
+	}
+	if progress.EvidenceState == "changed" && node.PaneState == "idle" {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen progress changed while pane state is idle"
+		return result
+	}
+	if node.PaneState == "stale" && progress.EvidenceState == "changed" {
+		result.state = nodeLocalProgressConflict
+		result.freshness = "conflict"
+		result.reason = "screen progress changed while pane state is stale"
 		return result
 	}
 

--- a/internal/cli/session_status_test.go
+++ b/internal/cli/session_status_test.go
@@ -329,8 +329,8 @@ func TestRunGetSessionStatus_IncludesVisibleStateAndTopology(t *testing.T) {
 	if got := payload["visible_state"]; got != "pending" {
 		t.Fatalf("visible_state = %#v, want %q", got, "pending")
 	}
-	if got := payload["compact"]; got != "🔷🟢" {
-		t.Fatalf("compact = %#v, want %q", got, "🔷🟢")
+	if got := payload["compact"]; got != "🔷⚫" {
+		t.Fatalf("compact = %#v, want %q", got, "🔷⚫")
 	}
 	if _, ok := payload["runtime_diagnostics"]; ok {
 		t.Fatalf("runtime_diagnostics present without --debug: %#v", payload["runtime_diagnostics"])
@@ -794,8 +794,8 @@ func TestRunGetSessionStatus_UsesConfigEdgeOrderForNodesAndTMUXOrderForWindows(t
 	if payload.Nodes[0].Name != "worker" || payload.Nodes[1].Name != "critic" {
 		t.Fatalf("nodes order = %#v, want worker then critic", payload.Nodes)
 	}
-	if payload.Compact != "🟢:🟢" {
-		t.Fatalf("compact = %q, want %q", payload.Compact, "🟢:🟢")
+	if payload.Compact != "⚫:⚫" {
+		t.Fatalf("compact = %q, want %q", payload.Compact, "⚫:⚫")
 	}
 
 	if len(payload.Windows) != 2 {
@@ -928,11 +928,11 @@ func TestCollectAllSessionStatus_ReturnsAggregateCanonicalPayloadInSessionIDOrde
 	if payload.Sessions[0].SessionName != "main" || payload.Sessions[1].SessionName != "review" {
 		t.Fatalf("session order = %#v, want main then review to match numeric tmux session_id order", payload.Sessions)
 	}
-	if payload.Sessions[0].Compact != "🔷🟢:🟢" {
-		t.Fatalf("main compact = %q, want %q", payload.Sessions[0].Compact, "🔷🟢:🟢")
+	if payload.Sessions[0].Compact != "🔷⚫:⚫" {
+		t.Fatalf("main compact = %q, want %q", payload.Sessions[0].Compact, "🔷⚫:⚫")
 	}
-	if payload.Sessions[1].Compact != "🟢🔷" {
-		t.Fatalf("review compact = %q, want %q", payload.Sessions[1].Compact, "🟢🔷")
+	if payload.Sessions[1].Compact != "⚫🔷" {
+		t.Fatalf("review compact = %q, want %q", payload.Sessions[1].Compact, "⚫🔷")
 	}
 }
 
@@ -1025,8 +1025,8 @@ func TestCollectAllSessionStatus_IncludesSessionsWithoutCanonicalPanesInSessionI
 	if payload.Sessions[0].SessionName != "main" || payload.Sessions[1].SessionName != "ghost" {
 		t.Fatalf("session order = %#v, want main then ghost", payload.Sessions)
 	}
-	if payload.Sessions[0].Compact != "🟢🟢" {
-		t.Fatalf("main compact = %q, want %q", payload.Sessions[0].Compact, "🟢🟢")
+	if payload.Sessions[0].Compact != "⚫⚫" {
+		t.Fatalf("main compact = %q, want %q", payload.Sessions[0].Compact, "⚫⚫")
 	}
 	if payload.Sessions[1].VisibleState != "initial" {
 		t.Fatalf("ghost visible_state = %q, want %q", payload.Sessions[1].VisibleState, "initial")

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -44,6 +44,7 @@ type ConventionMeterStatus struct {
 
 type ScreenProgressEvidence struct {
 	EvidenceState        string `json:"evidence_state"`
+	Reason               string `json:"reason,omitempty"`
 	LastCaptureAt        string `json:"last_capture_at,omitempty"`
 	LastScreenChangeAt   string `json:"last_screen_change_at,omitempty"`
 	StaleDurationSeconds int    `json:"stale_duration_seconds,omitempty"`
@@ -126,16 +127,18 @@ type NodeFlowStatus struct {
 }
 
 type NodeLocalStatus struct {
-	State          string                  `json:"state"`
-	Severity       string                  `json:"severity"`
-	EvidenceLevel  string                  `json:"evidence_level"`
-	EvidenceSource string                  `json:"evidence_source,omitempty"`
-	Freshness      string                  `json:"freshness,omitempty"`
-	AgeSeconds     int                     `json:"age_seconds,omitempty"`
-	Reason         string                  `json:"reason,omitempty"`
-	PaneState      string                  `json:"pane_state,omitempty"`
-	CurrentCommand string                  `json:"current_command,omitempty"`
-	ScreenProgress *ScreenProgressEvidence `json:"screen_progress,omitempty"`
+	State            string                  `json:"state"`
+	Severity         string                  `json:"severity"`
+	EvidenceLevel    string                  `json:"evidence_level"`
+	EvidenceSource   string                  `json:"evidence_source,omitempty"`
+	Freshness        string                  `json:"freshness,omitempty"`
+	AgeSeconds       int                     `json:"age_seconds,omitempty"`
+	ObservedAt       string                  `json:"observed_at,omitempty"`
+	UnchangedSeconds int                     `json:"unchanged_seconds,omitempty"`
+	Reason           string                  `json:"reason,omitempty"`
+	PaneState        string                  `json:"pane_state,omitempty"`
+	CurrentCommand   string                  `json:"current_command,omitempty"`
+	ScreenProgress   *ScreenProgressEvidence `json:"screen_progress,omitempty"`
 }
 
 type DeliveryStatus struct {

--- a/internal/status/contract.go
+++ b/internal/status/contract.go
@@ -2,7 +2,11 @@ package status
 
 const SchemaVersion = 5
 
-const DeliveryStuckAfterSeconds = 180
+const (
+	DeliveryStuckAfterSeconds  = 180
+	NodeLocalFreshAfterSeconds = 30
+	NodeLocalStaleAfterSeconds = 180
+)
 
 type NodeStatus struct {
 	Name                string                      `json:"name"`
@@ -126,6 +130,8 @@ type NodeLocalStatus struct {
 	Severity       string                  `json:"severity"`
 	EvidenceLevel  string                  `json:"evidence_level"`
 	EvidenceSource string                  `json:"evidence_source,omitempty"`
+	Freshness      string                  `json:"freshness,omitempty"`
+	AgeSeconds     int                     `json:"age_seconds,omitempty"`
 	Reason         string                  `json:"reason,omitempty"`
 	PaneState      string                  `json:"pane_state,omitempty"`
 	CurrentCommand string                  `json:"current_command,omitempty"`

--- a/skills/postman-config-auditor/SKILL.md
+++ b/skills/postman-config-auditor/SKILL.md
@@ -19,8 +19,8 @@ Audit tmux-a2a-postman configuration with implementation-level accuracy.
 
 - Audit or fix `postman.toml`, `postman.md`, or `nodes/*` config.
 - Check Mermaid edges, `ui_node`, role templates, and skill catalogs.
-- Diagnose `get-status` evidence for dead-letter, missing route, quiet node, or
-  unread backlog symptoms.
+- Diagnose `get-status` evidence for dead-letter, missing route, live-but-idle
+  node, or unread backlog symptoms.
 
 ## 2. Procedure
 


### PR DESCRIPTION
Fixes #639.

Summary:
- classify pane-local freshness and age in get-status JSON
- fail closed for stale screen progress instead of reporting stale panes as active work
- document pane-local and flow lifecycle layers

Verification:
- go test ./...
- nix flake check
- nix build
